### PR TITLE
fix(sidebar): fix background-color when displaying all dropdowns on small screens

### DIFF
--- a/src/app/shared/components/layout/layout.component.scss
+++ b/src/app/shared/components/layout/layout.component.scss
@@ -103,7 +103,7 @@
   color: ut.get-color('neutral', 100);
   display: flex;
   flex-direction: column;
-  height: calc(100% - 56px);
+  min-height: calc(100% - 56px);
 }
 
 .custom-sidenav-content p {


### PR DESCRIPTION
## Description
 When displaying sidebar's dropdown, background color should stay the same
![{FB2D4EBD-7C6D-4596-BCF0-88FAE8522A79}](https://github.com/user-attachments/assets/0b200037-ab33-4dab-863a-ec38c56b83cc)


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Related Issues


