### PR TITLE
Hotfix/eras fe 171/heatmap cells

### DIFF
--- a/src/app/core/constants/riskLevel.ts
+++ b/src/app/core/constants/riskLevel.ts
@@ -20,13 +20,14 @@ export const RISK_TEXT_COLORS: Record<number | 'default', string> = {
   default: '#FFFFFF',
 };
 
-export const RISK_LABELS: Record<number, RiskLevel> = {
+export const RISK_LABELS: Record<number | 'default', RiskLevel> = {
   0: 'No Answer',
   1: 'Low Risk',
   2: 'Low-Medium Risk',
   3: 'Medium Risk',
   4: 'Medium-High Risk',
   5: 'High Risk',
+  default: 'High Risk',
 };
 
 export type RiskColorType = keyof typeof RISK_COLORS;

--- a/src/app/features/cohort/util/heat-map-config.ts
+++ b/src/app/features/cohort/util/heat-map-config.ts
@@ -16,6 +16,9 @@ export function GetChartOptions(
   const options: ApexOptions = {
     series: series,
     chart: {
+      zoom: {
+        enabled: false,
+      },
       type: 'heatmap',
       toolbar: {
         show: false,

--- a/src/app/features/reports/constants/heat-map.ts
+++ b/src/app/features/reports/constants/heat-map.ts
@@ -1,6 +1,7 @@
 import { ApexOptions } from 'ng-apexcharts';
 import {
   RISK_COLORS,
+  RISK_LABELS,
   RISK_TEXT_COLORS,
 } from '../../../core/constants/riskLevel';
 
@@ -39,42 +40,42 @@ export const ChartOptionsColorsCount: ApexOptions = {
             to: 0,
             color: RISK_COLORS[0],
             foreColor: RISK_TEXT_COLORS[0],
-            name: 'No answer',
+            name: RISK_LABELS[0],
           },
           {
             from: 0,
             to: 2,
             color: RISK_COLORS[1],
             foreColor: RISK_TEXT_COLORS[1],
-            name: 'Low Risk',
+            name: RISK_LABELS[1],
           },
           {
             from: 2,
             to: 4,
             color: RISK_COLORS[2],
             foreColor: RISK_TEXT_COLORS[2],
-            name: 'Low-Medium Risk',
+            name: RISK_LABELS[2],
           },
           {
             from: 4,
             to: 6,
             color: RISK_COLORS[3],
             foreColor: RISK_TEXT_COLORS[3],
-            name: 'Medium Risk',
+            name: RISK_LABELS[3],
           },
           {
             from: 6,
             to: 8,
             color: RISK_COLORS[4],
             foreColor: RISK_TEXT_COLORS[4],
-            name: 'Medium-High Risk',
+            name: RISK_LABELS[4],
           },
           {
             from: 8,
             to: 100,
             color: RISK_COLORS['default'],
             foreColor: RISK_TEXT_COLORS['default'],
-            name: 'High Risk',
+            name: RISK_LABELS['default'],
           },
         ],
       },

--- a/src/app/shared/components/charts/bar-chart/bar-chart.component.ts
+++ b/src/app/shared/components/charts/bar-chart/bar-chart.component.ts
@@ -13,7 +13,7 @@ export class BarChartComponent extends ChartBase implements OnInit {
   public chartOptions: ApexOptions = {};
   seriesY = input([1]);
   colors = input(Object.values(RISK_COLORS));
-  categoriesX = input(Object.values(RISK_LABELS as string[]));
+  categoriesX = input(Object.values(RISK_LABELS).map(rl => rl.toString()));
   constructor() {
     super();
   }

--- a/src/app/shared/components/charts/pie-chart/pie-chart.component.ts
+++ b/src/app/shared/components/charts/pie-chart/pie-chart.component.ts
@@ -13,7 +13,9 @@ export class PieChartComponent extends ChartBase implements OnInit {
   public chartOptions: ApexOptions = {};
   seriesY = input([12, 5, 3, 2, 12, 6]);
   colors = input(Object.values(RISK_COLORS));
-  categoriesX = input(Object.values(RISK_LABELS as string[]));
+  categoriesX = input(
+    Object.values(Object.values(RISK_LABELS).map(rl => rl.toString()))
+  );
 
   constructor() {
     super();


### PR DESCRIPTION
## Description
There is a glitch. When hovering on cells and they're tooltip provoques an x-overflow and user scrolls vertically, the cells with blanks spaces around them are reordered.

This PR should solve it. Please try to reproduce it with the following steps:
1. Go to the heatmap on /reports/dynamic-heatmap
2. Click on any blank space on the chart
3. Scroll up and down *with the wheel* while the chart is focused


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Related Issues


