### PR TITLE
Fix/eras fe 210/multiple be calls

### DIFF
--- a/src/app/features/student-detail/student-detail.component.spec.ts
+++ b/src/app/features/student-detail/student-detail.component.spec.ts
@@ -46,10 +46,4 @@ describe('StudentDetailComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should call getStudentDetails on init', () => {
-    const spy = spyOn(component, 'getStudentDetails');
-    component.ngOnInit();
-    expect(spy).toHaveBeenCalled();
-  });
 });

--- a/src/app/features/student-detail/student-detail.component.ts
+++ b/src/app/features/student-detail/student-detail.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   Input,
   OnDestroy,
-  OnInit,
   ViewChild,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -52,7 +51,7 @@ interface SwiperEventTarget extends EventTarget {
   styleUrl: './student-detail.component.scss',
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class StudentDetailComponent implements OnInit, OnDestroy {
+export class StudentDetailComponent implements OnDestroy {
   @ViewChild('mainContainer', { static: false }) mainContainer!: ElementRef;
   private readonly exportPrintService = inject(PdfService);
   studentDetails: StudentResponse = {
@@ -135,10 +134,6 @@ export class StudentDetailComponent implements OnInit, OnDestroy {
   };
 
   private destroy$ = new Subject<void>();
-
-  ngOnInit(): void {
-    this.getStudentDetails(this.studentId);
-  }
 
   ngOnDestroy(): void {
     this.destroy$.next();


### PR DESCRIPTION
## Description
Now, when calling to actions on /reports/polls-answered, BE is only called once.
![Uploading {0CA4DD0E-CD00-431E-8788-D029D17EBDF9}.png…]()

![{EC70767E-B256-4A04-A031-6106D7A5EA40}](https://github.com/user-attachments/assets/c8571be2-de64-4b14-a408-ac03c84979a5)


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


