### PR TITLE
fix(poll-filters): update subscription call to use new values

### DIFF
--- a/src/app/core/models/summary.model.ts
+++ b/src/app/core/models/summary.model.ts
@@ -2,6 +2,7 @@ import { UUID } from 'crypto';
 import { PollModel } from './poll.model';
 import { PollInstanceModel } from './poll-instance.model';
 import { BaseModel } from './common/base.model';
+import { ComponentValueType } from '../../features/heat-map/types/risk-students-detail.type';
 
 export const ENTITY_NAMES = [
   'Students',
@@ -46,7 +47,7 @@ export interface PollAvgReport {
 }
 
 export interface PollAvgComponent {
-  description: string;
+  description: ComponentValueType;
   averageRisk: number;
   questions: PollAvgQuestion[];
 }

--- a/src/app/core/models/summary.model.ts
+++ b/src/app/core/models/summary.model.ts
@@ -106,7 +106,8 @@ export interface PollCountReport {
 }
 
 export interface PollCountComponent {
-  description: string;
+  description: ComponentValueType;
+  text: string;
   questions: PollCountQuestion[];
 }
 

--- a/src/app/core/services/api/report.service.ts
+++ b/src/app/core/services/api/report.service.ts
@@ -16,6 +16,7 @@ import { Serie } from '../../models/heatmap-data.model';
 import { RISK_COLORS, RISK_LEVEL } from '../../constants/riskLevel';
 import { Pagination } from '../interfaces/server.type';
 import { PagedResult } from '../interfaces/page.type';
+import { ComponentValueType } from '../../../features/heat-map/types/risk-students-detail.type';
 
 @Injectable({
   providedIn: 'root',
@@ -78,6 +79,7 @@ export class ReportService extends BaseApiService {
   getHMSeriesFromAvgReport(body: PollAvgReport) {
     const series = body.components.map(component => {
       return {
+        text: `${component.description}\n RISK AVG: ${component.averageRisk.toFixed(2)}`,
         description: component.description,
         data: component.questions.map(question => {
           return {
@@ -160,7 +162,8 @@ export class ReportService extends BaseApiService {
 
   regroupByColor(
     serie: {
-      description: string;
+      description: ComponentValueType;
+      text: string;
       data: Serie[];
     }[]
   ) {
@@ -178,7 +181,8 @@ export class ReportService extends BaseApiService {
       }
 
       return {
-        name: row.description,
+        description: row.description,
+        text: row.text,
         colorGroups,
       };
     });
@@ -210,7 +214,8 @@ export class ReportService extends BaseApiService {
         newData.push(...items, ...fillers);
       }
       return {
-        name: row.name,
+        description: row.description,
+        text: row.text,
         data: newData,
       };
     });

--- a/src/app/core/services/api/report.service.ts
+++ b/src/app/core/services/api/report.service.ts
@@ -78,7 +78,7 @@ export class ReportService extends BaseApiService {
   getHMSeriesFromAvgReport(body: PollAvgReport) {
     const series = body.components.map(component => {
       return {
-        name: `${component.description}\n RISK AVG: ${component.averageRisk.toFixed(2)}`,
+        description: component.description,
         data: component.questions.map(question => {
           return {
             x: question.question,
@@ -160,7 +160,7 @@ export class ReportService extends BaseApiService {
 
   regroupByColor(
     serie: {
-      name: string;
+      description: string;
       data: Serie[];
     }[]
   ) {
@@ -178,7 +178,7 @@ export class ReportService extends BaseApiService {
       }
 
       return {
-        name: row.name,
+        name: row.description,
         colorGroups,
       };
     });

--- a/src/app/features/heat-map/modal-question-details/modal-question-details.component.html
+++ b/src/app/features/heat-map/modal-question-details/modal-question-details.component.html
@@ -2,7 +2,7 @@
   <div class="modal-header">
     <div class="modal-header-title">
       <h2 class="title-modal">Question Details</h2>
-      <h3>{{ inputQuestion.componentName }}</h3>
+      <h3>{{ inputQuestion.text }}</h3>
       <h4>{{ inputQuestion.question.question }}</h4>
       @if (isPollAvgQuestion(inputQuestion.question)) {
         <p>Most answered option: {{ inputQuestion.question.averageAnswer }}</p>

--- a/src/app/features/heat-map/modal-question-details/modal-question-details.component.spec.ts
+++ b/src/app/features/heat-map/modal-question-details/modal-question-details.component.spec.ts
@@ -11,6 +11,7 @@ import { PollAvgQuestion } from '../../../core/models/summary.model';
 import { ReportService } from '../../../core/services/api/report.service';
 import { PollService } from '../../../core/services/api/poll.service';
 import { ActivatedRoute } from '@angular/router';
+import { ComponentValueType } from '../types/risk-students-detail.type';
 
 describe('ModalQuestionDetailsComponent', () => {
   let component: ModalQuestionDetailsComponent;
@@ -42,7 +43,8 @@ describe('ModalQuestionDetailsComponent', () => {
   const mockDialogData: SelectedHMData = {
     cohortId: 'cohort-1',
     pollUuid: 'test-uuid',
-    componentName: 'Test Component',
+    componentName: 'FAMILIAR' as ComponentValueType,
+    text: 'Test Component',
     question: mockQuestion,
   };
 

--- a/src/app/features/heat-map/modal-question-details/modal-question-details.component.ts
+++ b/src/app/features/heat-map/modal-question-details/modal-question-details.component.ts
@@ -33,11 +33,13 @@ import { EventAction, EventLoad } from '../../../shared/events/load';
 import { ListComponent } from '../../../shared/components/list/list.component';
 import { BadgeRiskComponent } from '../../../shared/components/badge-risk-level/badge-risk-level.component';
 import { Pagination } from '../../../core/services/interfaces/server.type';
+import { ComponentValueType } from '../types/risk-students-detail.type';
 
 export interface SelectedHMData {
   cohortId: string;
   pollUuid: string;
-  componentName: string;
+  componentName: ComponentValueType;
+  text?: string;
   question: PollAvgQuestion | PollCountQuestion;
 }
 

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -67,17 +67,23 @@ export class PollFiltersComponent implements OnInit {
       next: res => (this.polls = res),
       error: () => (this.polls = null),
     });
-    this.filterForm.controls.selectedPoll.valueChanges.subscribe(() => {
-      this.cohortsService
-        .getCohorts(this.filterForm.value.selectedPoll?.uuid)
-        .subscribe(res => {
-          this.cohorts = res.body;
-          this.filterForm.controls.cohortIds.setValue(
-            this.cohorts.map(c => c.id)
-          );
-          this.handleCohortSelect(false);
-        });
-    });
+    this.filterForm.controls.selectedPoll.valueChanges.subscribe(
+      newSelectedPoll => {
+        if (newSelectedPoll) {
+          this.cohortsService
+            .getCohorts(newSelectedPoll.uuid)
+            .subscribe(res => {
+              this.cohorts = res.body;
+              this.filterForm.controls.cohortIds.setValue(
+                this.cohorts.map(c => c.id)
+              );
+              this.handleCohortSelect(false);
+            });
+        } else {
+          console.warn('selectedPoll is null');
+        }
+      }
+    );
   }
 
   handleCohortSelect(isOpen: boolean) {

--- a/src/app/modules/reports/views/dynamic-heatmap/dynamic-heatmap.component.ts
+++ b/src/app/modules/reports/views/dynamic-heatmap/dynamic-heatmap.component.ts
@@ -21,6 +21,7 @@ import { Filter } from '../../components/poll-filters/types/filters';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ChangeDetectorRef } from '@angular/core';
+import { ComponentValueType } from '../../../../features/heat-map/types/risk-students-detail.type';
 
 @Component({
   selector: 'app-dynamic-heatmap',
@@ -87,7 +88,8 @@ export class DynamicHeatmapComponent {
             this.uuid!,
             1,
             report.components[index].questions[y],
-            report.components[index].description
+            report.components[index].description,
+            report.components[index].text
           );
         },
         undefined,
@@ -132,12 +134,14 @@ export class DynamicHeatmapComponent {
     pollUuid: string,
     cohortId: number,
     question: PollCountQuestion,
-    componentName: string
+    componentName: ComponentValueType,
+    text?: string
   ): void {
     const data: SelectedHMData = {
       cohortId: cohortId.toString(),
       pollUuid,
       componentName,
+      text,
       question,
     };
     this.dialog.open(ModalQuestionDetailsComponent, {

--- a/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.spec.ts
+++ b/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.spec.ts
@@ -135,7 +135,11 @@ describe('SummaryHeatmapComponent', () => {
     const question = { question: 'Q', averageRisk: 1 } as PollAvgQuestion;
     component.pollUuid = 'poll-uuid';
     component.selectedCohort = { id: 1, name: 'Cohort' } as CohortModel;
-    component.openDetailsModal(question, 'Component');
+    component.openDetailsModal(
+      question,
+      'FAMILIAR' as ComponentValueType,
+      'Component test'
+    );
     expect(matDialogSpy.open).toHaveBeenCalled();
   });
 

--- a/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.spec.ts
+++ b/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.spec.ts
@@ -21,6 +21,7 @@ import { PollFiltersComponent } from '../../components/poll-filters/poll-filters
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { PdfHelper } from '../../exportReport.util';
 import { PagedResult } from '../../../../core/services/interfaces/page.type';
+import { ComponentValueType } from '../../../../features/heat-map/types/risk-students-detail.type';
 
 describe('SummaryHeatmapComponent', () => {
   let component: SummaryHeatmapComponent;
@@ -108,7 +109,13 @@ describe('SummaryHeatmapComponent', () => {
       body: { components: [], pollCount: 0 },
       status: 'success',
     };
-    const mockSeries = [{ name: 'Comp', data: [] }];
+    const mockSeries = [
+      {
+        description: 'FAMILIAR' as ComponentValueType,
+        text: 'Familiar description',
+        data: [],
+      },
+    ];
     reportServiceSpy.getAvgPoolReport.and.returnValue(of(mockReport));
     reportServiceSpy.getHMSeriesFromAvgReport.and.returnValue(mockSeries);
     reportServiceSpy.regroupByColor.and.returnValue(mockSeries);

--- a/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.ts
+++ b/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.ts
@@ -31,6 +31,7 @@ import { PdfHelper } from '../../exportReport.util';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { EventLoad } from '../../../../shared/events/load';
 import { EmptyDataComponent } from '../../../../shared/components/empty-data/empty-data.component';
+import { ComponentValueType } from '../../../../features/heat-map/types/risk-students-detail.type';
 
 @Component({
   selector: 'app-students-risk',
@@ -122,20 +123,25 @@ export class SummaryHeatmapComponent {
         const reportSeries = this.reportService.getHMSeriesFromAvgReport(
           res.body
         );
+        console.log(reportSeries);
         const series = this.reportService.regroupByColor(reportSeries);
         this.chartOptions = GetChartOptions(`${this.title}`, series, (x, y) => {
           const component = series[y];
           const serieQuestion = series[y].data[x];
           const pollAvgQuestion = this.getPollAvgQuestionFromSeries(
             res.body,
-            component.name,
+            component.description,
             serieQuestion
           );
 
           if (!pollAvgQuestion) {
             console.error('Error getting question from report.');
           } else {
-            this.openDetailsModal(pollAvgQuestion, component.name);
+            this.openDetailsModal(
+              pollAvgQuestion,
+              component.description,
+              component.text
+            );
           }
         });
       });
@@ -170,12 +176,17 @@ export class SummaryHeatmapComponent {
     this.isGeneratingPDF = false;
   }
 
-  openDetailsModal(question: PollAvgQuestion, componentName: string): void {
+  openDetailsModal(
+    question: PollAvgQuestion,
+    componentName: ComponentValueType,
+    text?: string
+  ): void {
     if (!this.pollUuid) return;
     const data: SelectedHMData = {
       cohortId: this.selectedCohort?.id.toString() || '0',
       pollUuid: this.pollUuid,
       componentName,
+      text: text ?? componentName,
       question,
     };
     this.dialog.open(ModalQuestionDetailsComponent, { data });

--- a/src/app/shared/components/risk-students-table/risk-students-table.component.ts
+++ b/src/app/shared/components/risk-students-table/risk-students-table.component.ts
@@ -148,7 +148,6 @@ export class RiskStudentsTableComponent {
     this.studentNames = [];
     this.risks = [];
     this.studentRisks = [];
-    console.log(this.studentDataResponse);
     this.studentDataResponse.forEach(student => {
       const name = student.studentName;
       const risk = Math.round(student.pollinstancesAverage);
@@ -161,7 +160,6 @@ export class RiskStudentsTableComponent {
       this.risks.push(risk);
       this.studentRisks.push(studentRisk);
     });
-    console.log(this.studentRisks);
   }
 
   private updateChartData(): void {


### PR DESCRIPTION
## Description
Now 
Fixed bug on /reports/dynamic-heatmap. Now heatmaps shall be displayed no matter in which order cohorts are called.
Took the time to also fix bug in /reports/summary-heatmap. Now tabular data should be displayed on modal.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


