### PR TITLE
fix(cohort.service): add lastversion to getCohorts function

### DIFF
--- a/src/app/core/services/api/cohort.service.ts
+++ b/src/app/core/services/api/cohort.service.ts
@@ -12,8 +12,11 @@ import { Pagination } from '../interfaces/server.type';
 export class CohortService extends BaseApiService {
   protected resource = 'cohorts';
 
-  getCohorts(pollUuid: string | null = null) {
-    const params = new HttpParams().set('pollUuid', pollUuid || '');
+  getCohorts(pollUuid: string | null = null, lastVersion = true) {
+    const params = new HttpParams()
+      .set('pollUuid', pollUuid || '')
+      .set('lastVersion', lastVersion);
+
     return this.get<ApiResponse<CohortModel[]>>('', params);
   }
 

--- a/src/app/features/heat-map/modal-question-details/modal-question-details.component.ts
+++ b/src/app/features/heat-map/modal-question-details/modal-question-details.component.ts
@@ -120,8 +120,8 @@ export class ModalQuestionDetailsComponent implements AfterViewInit {
       pollInstanceUUID,
       [this.inputQuestion.componentName.toLowerCase()],
       true
-    ).subscribe(res => {
-      const variable = res.find(
+    ).subscribe(response => {
+      const variable = response.find(
         variable => variable.name == this.inputQuestion.question.question
       );
       if (!variable) return;

--- a/src/app/features/heat-map/modal-risk-students-cohort/modal-risk-students-cohort.component.ts
+++ b/src/app/features/heat-map/modal-risk-students-cohort/modal-risk-students-cohort.component.ts
@@ -71,7 +71,7 @@ export class ModalRiskStudentsCohortComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.cohortService.getCohorts(null, true).subscribe({
+    this.cohortService.getCohorts().subscribe({
       next: data => (this.cohorts = data.body),
       error: error => console.error('Error fetching cohorts', error),
     });

--- a/src/app/features/heat-map/modal-risk-students-cohort/modal-risk-students-cohort.component.ts
+++ b/src/app/features/heat-map/modal-risk-students-cohort/modal-risk-students-cohort.component.ts
@@ -71,7 +71,7 @@ export class ModalRiskStudentsCohortComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.cohortService.getCohorts().subscribe({
+    this.cohortService.getCohorts(null, true).subscribe({
       next: data => (this.cohorts = data.body),
       error: error => console.error('Error fetching cohorts', error),
     });

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -89,7 +89,7 @@ export class HomeComponent implements OnInit {
   loadCount() {
     this.reportService
       .getCountSummary()
-      .subscribe(res => (this.count = res.body));
+      .subscribe(response => (this.count = response.body));
   }
 
   loadEvaluations() {
@@ -107,8 +107,8 @@ export class HomeComponent implements OnInit {
   }
 
   loadEvalDetails(evalId: number) {
-    this.evalService.getEvalProcDetails(evalId).subscribe(res => {
-      this.selEval = res.body;
+    this.evalService.getEvalProcDetails(evalId).subscribe(response => {
+      this.selEval = response.body;
       if (this.selEval?.polls && this.selEval?.polls.length > 0) {
         this.selPoll = this.selEval.polls[0];
         this.loadPollDetails(this.selPoll.uuid);
@@ -127,8 +127,8 @@ export class HomeComponent implements OnInit {
         })
       )
       .subscribe({
-        next: res => {
-          const body = res.body;
+        next: response => {
+          const body = response.body;
           this.riskLevelAvg = body.averageRisk.toFixed(2);
           this.riskLevels =
             this.reportService.getBMSeriesFromSummaryReport(body);

--- a/src/app/features/reports/summary-heatmap/summary-heatmap.component.ts
+++ b/src/app/features/reports/summary-heatmap/summary-heatmap.component.ts
@@ -47,10 +47,10 @@ export class SummaryHeatmapComponent implements OnInit {
 
     this.reportService
       .getAvgPoolReport(this.pollUuid, this.cohortId, true)
-      .subscribe(res => {
+      .subscribe(response => {
         this.isLoading = false;
         const reportSeries = this.reportService.getHMSeriesFromAvgReport(
-          res.body
+          response.body
         );
         const serie = this.reportService.regroupSummaryByColor(reportSeries);
         this.chartOptions = GetChartOptions(

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -10,7 +10,11 @@
     @if (polls !== null && polls.length > 0) {
       <mat-form-field appearance="fill">
         <mat-label for="sl-poll">Poll</mat-label>
-        <mat-select id="sl-poll" formControlName="selectedPoll">
+        <mat-select
+          id="sl-poll"
+          formControlName="selectedPoll"
+          (openedChange)="handlePollSelect($event)"
+        >
           @for (poll of polls; track $index) {
             <mat-option class="versioned-option" [value]="poll">
               <p>{{ poll.name }}</p>
@@ -27,7 +31,7 @@
         <mat-label for="sl-version">Version</mat-label>
         <mat-select
           formControlName="lastVersion"
-          (openedChange)="handleVersionSelect($event)"
+          (openedChange)="handlePollSelect($event)"
         >
           <mat-option [value]="false">Older Versions</mat-option>
           <mat-option [value]="true">
@@ -39,26 +43,28 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field appearance="fill">
-        <mat-label for="sl-cohort">Cohort</mat-label>
-        <mat-select
-          required
-          id="sl-cohort"
-          multiple
-          formControlName="cohortIds"
-          (openedChange)="handleCohortSelect($event)"
-        >
-          <mat-option appSelectAll [allValues]="cohorts">Select all</mat-option>
-          @for (cohort of cohorts; track $index) {
-            <mat-option [value]="cohort.id">
-              {{ cohort.name }}
-            </mat-option>
-          }
-        </mat-select>
-        @if (filterForm.get('cohortId')?.errors) {
-          <mat-error>This field is required</mat-error>
-        }
-      </mat-form-field>
+      @if ((filterForm.value.cohortIds || []).length > 0) {
+        <mat-form-field appearance="fill">
+          <mat-label for="sl-cohort">Cohort</mat-label>
+          <mat-select
+            id="sl-cohort"
+            multiple
+            formControlName="cohortIds"
+            (openedChange)="handleCohortSelect($event)"
+          >
+            @if (cohorts.length > 0) {
+              <mat-option appSelectAll [allValues]="cohorts"
+                >Select all</mat-option
+              >
+            }
+            @for (cohort of cohorts; track $index) {
+              <mat-option [value]="cohort.id">
+                {{ cohort.name }}
+              </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      }
     }
     @if (
       filterForm.value.cohortIds &&

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -64,7 +64,7 @@ export class PollFiltersComponent implements OnInit {
 
   ngOnInit(): void {
     this.pollsService.getAllPolls().subscribe({
-      next: res => (this.polls = res),
+      next: response => (this.polls = response),
       error: () => (this.polls = null),
     });
   }
@@ -76,10 +76,10 @@ export class PollFiltersComponent implements OnInit {
     if (newSelectedPoll) {
       this.cohortsService
         .getCohorts(newSelectedPoll.uuid, !!this.filterForm.value.lastVersion)
-        .subscribe(res => {
-          this.cohorts = res.body;
+        .subscribe(response => {
+          this.cohorts = response.body;
           this.filterForm.controls.cohortIds.setValue(
-            this.cohorts.map(c => c.id)
+            this.cohorts.map(cohort => cohort.id)
           );
           this.handleCohortSelect(false);
         });

--- a/src/app/modules/reports/views/polls-answered/polls-answered.component.ts
+++ b/src/app/modules/reports/views/polls-answered/polls-answered.component.ts
@@ -124,21 +124,23 @@ export class PollsAnsweredComponent implements OnInit {
   }
 
   loadCohortsList(): void {
-    this.cohortService.getCohorts(this.selectedPollUuid).subscribe(data => {
-      const defaultOpt: CohortModel = {
-        name: 'All Cohorts',
-        courseCode: '',
-        audit: {
-          createdBy: '',
-          modifiedBy: '',
-          createdAt: new Date(),
-          modifiedAt: new Date(),
-        },
-        id: 0,
-      };
-      this.cohortsData = data.body;
-      this.cohortsData.push(defaultOpt);
-    });
+    this.cohortService
+      .getCohorts(this.selectedPollUuid, this.lastVersion)
+      .subscribe(data => {
+        const defaultOpt: CohortModel = {
+          name: 'All Cohorts',
+          courseCode: '',
+          audit: {
+            createdBy: '',
+            modifiedBy: '',
+            createdAt: new Date(),
+            modifiedAt: new Date(),
+          },
+          id: 0,
+        };
+        this.cohortsData = data.body;
+        this.cohortsData.push(defaultOpt);
+      });
   }
 
   getPollsByCohortId(id: number) {

--- a/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.ts
+++ b/src/app/modules/reports/views/summary-heatmap/summary-heatmap.component.ts
@@ -106,9 +106,9 @@ export class SummaryHeatmapComponent {
           pollUuid: this.pollUuid,
           lastVersion: this.lastVersion,
         })
-        .subscribe(res => {
-          this.students = res.items;
-          this.totalStudents = res.count;
+        .subscribe(response => {
+          this.students = response.items;
+          this.totalStudents = response.count;
           this.isLoading = false;
         });
     }
@@ -119,16 +119,16 @@ export class SummaryHeatmapComponent {
 
     this.reportService
       .getAvgPoolReport(this.pollUuid, this.cohortIds, this.lastVersion)
-      .subscribe(res => {
+      .subscribe(response => {
         const reportSeries = this.reportService.getHMSeriesFromAvgReport(
-          res.body
+          response.body
         );
         const series = this.reportService.regroupSummaryByColor(reportSeries);
         this.chartOptions = GetChartOptions(`${this.title}`, series, (x, y) => {
           const component = series[y];
           const serieQuestion = series[y].data[x];
           const pollAvgQuestion = this.getPollAvgQuestionFromSeries(
-            res.body,
+            response.body,
             component.description,
             serieQuestion
           );


### PR DESCRIPTION
## Description
Now, Cohorts selection on /reports should hide whenever there are no cohorts on any given Poll and Version


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


