### PR TITLE
fix(poll-filters): update select-all to use most recent variableIds v…

### DIFF
--- a/src/app/core/services/api/report.service.ts
+++ b/src/app/core/services/api/report.service.ts
@@ -20,6 +20,7 @@ import {
   DynamicReport,
   SummaryReport,
 } from '../../models/reports/reports-data.model';
+import { Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -65,7 +66,9 @@ export class ReportService extends BaseApiService {
     cohortIds: number[] | null,
     variableIds: number[],
     lastVersion: boolean
-  ) {
+  ): Observable<GetQueryResponse<PollCountReport> | null> {
+    if (!variableIds || !variableIds.length) return of(null);
+
     let params = new HttpParams().set(
       'variableIds',
       this.arrayAsStringParams(variableIds)

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -78,7 +78,7 @@
           required
           id="sl-components"
           multiple
-          (openedChange)="handleUpdateComponents($event)"
+          (openedChange)="handleComponentsSelect($event)"
           formControlName="componentNames"
         >
           <mat-select-trigger>
@@ -116,8 +116,8 @@
           <mat-select-trigger>
             {{ getVariablesDisplay() }}
           </mat-select-trigger>
-          @if (!!variableGroups.length) {
-            <mat-option appSelectAll [allValues]="variables"
+          @if (!!variables.length) {
+            <mat-option appSelectAll [allValues]="getAllVariableIds()"
               >Select all</mat-option
             >
           }

--- a/src/app/modules/reports/views/dynamic-heatmap/dynamic-heatmap.component.ts
+++ b/src/app/modules/reports/views/dynamic-heatmap/dynamic-heatmap.component.ts
@@ -68,9 +68,13 @@ export class DynamicHeatmapComponent {
     this.reportService
       .getCountPoolReport(this.uuid, cohortIds, variablesIds, lastVersion)
       .subscribe(data => {
-        this.generateSeries(data.body);
-        this.isGeneratingPDF = false;
-        this.isLoading = false;
+        if (data) {
+          this.generateSeries(data.body);
+          this.isGeneratingPDF = false;
+          this.isLoading = false;
+        } else {
+          this.chartsOptions = [];
+        }
       });
   }
 


### PR DESCRIPTION
## Description
This PR should fix the issues pointed by QA:
* Select all is a precise representation of user's selection
* Elements in multiple option dropdowns can be reselected
* VariableIds now is updated with the newest value
* Empty reports will appear only when no variables or components or cohorts are selected

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


