### PR TITLE
feat(ERAS-372): create generic modal forms

### DIFF
--- a/src/app/shared/components/modals/eras-modal/eras-modal.component.html
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.component.html
@@ -1,0 +1,19 @@
+@if (data.closeButton) {
+  <div class="modal-header">
+    <button class="close" mat-dialog-close>
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+}
+
+<mat-dialog-content>
+  <ng-template #erasModalContainer></ng-template>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  @for (action of data.actions; track $index) {
+    <button mat-button (click)="onAction(action)">
+      {{ action.label }}
+    </button>
+  }
+</mat-dialog-actions>

--- a/src/app/shared/components/modals/eras-modal/eras-modal.component.scss
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.component.scss
@@ -1,0 +1,24 @@
+@use 'index.scss' as main-styles;
+
+::ng-deep .eras-modal-component {
+  border-radius: 15px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: end;
+}
+
+.modal-header button.close {
+  display: flex;
+  justify-content: end;
+
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  opacity: 0.4;
+  padding: 15px 15px 0px 0px;
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/src/app/shared/components/modals/eras-modal/eras-modal.component.spec.ts
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErasModalComponent } from './eras-modal.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { EnvironmentInjector } from '@angular/core';
+
+describe('ErasModalComponent', () => {
+  let component: ErasModalComponent;
+  let fixture: ComponentFixture<ErasModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ErasModalComponent],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: EnvironmentInjector, useValue: {} },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ErasModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/modals/eras-modal/eras-modal.component.ts
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.component.ts
@@ -1,0 +1,71 @@
+import {
+  AfterViewInit,
+  Component,
+  EnvironmentInjector,
+  EventEmitter,
+  inject,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
+
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogModule,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+import { FormGroup } from '@angular/forms';
+
+import { ErasModalAction, ErasModalData } from './eras-modal.interface';
+
+@Component({
+  selector: 'app-eras-modal',
+  imports: [MatDialogModule, MatIconModule, MatButtonModule],
+  templateUrl: './eras-modal.component.html',
+  styleUrl: './eras-modal.component.scss',
+})
+export class ErasModalComponent implements AfterViewInit {
+  @ViewChild('erasModalContainer', { read: ViewContainerRef })
+  erasModalContainer!: ViewContainerRef;
+
+  data = inject<ErasModalData>(MAT_DIALOG_DATA);
+  dialogRef = inject(MatDialogRef<ErasModalComponent>);
+  envInjector = inject(EnvironmentInjector);
+
+  ngAfterViewInit() {
+    if (!this.data.component) return;
+
+    this.erasModalContainer.clear();
+
+    // Creates dinamically the inner component.
+    const componentReference = this.erasModalContainer.createComponent(
+      this.data.component!,
+      { environmentInjector: this.envInjector }
+    );
+
+    // Link the FormGroup if the inner component has a form.
+    const instComp = componentReference.instance;
+    if (!this.data.form && instComp?.form instanceof FormGroup) {
+      this.data.form = instComp.form;
+    }
+    if (instComp.formReady instanceof EventEmitter) {
+      instComp.formReady.subscribe(
+        (formGroup: FormGroup) => (this.data.form = formGroup)
+      );
+    }
+  }
+
+  onAction(action: ErasModalAction) {
+    if (action.value === 'save' && this.data.form) {
+      if (this.data.form.invalid) {
+        this.data.form.markAllAsTouched();
+        return;
+      }
+      this.dialogRef.close({ type: 'save', data: this.data.form.value });
+      return;
+    }
+    this.dialogRef.close(action.value);
+  }
+}

--- a/src/app/shared/components/modals/eras-modal/eras-modal.interface.ts
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.interface.ts
@@ -1,0 +1,20 @@
+import { EventEmitter, Type } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+export interface ErasModalData<T extends InnerComponent = InnerComponent> {
+  component?: Type<T>;
+  form?: FormGroup;
+  actions?: ErasModalAction[];
+  closeButton?: boolean;
+}
+
+export interface ErasModalAction {
+  label: string;
+  value?: string;
+  close?: boolean;
+}
+
+export interface InnerComponent {
+  form?: FormGroup;
+  formReady?: EventEmitter<FormGroup>;
+}

--- a/src/app/shared/components/modals/eras-modal/eras-modal.service.ts
+++ b/src/app/shared/components/modals/eras-modal/eras-modal.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, Type } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ErasModalAction } from './eras-modal.interface';
+import { ErasModalComponent } from './eras-modal.component';
+
+@Injectable({ providedIn: 'root' })
+export class ErasModalService<T> {
+  constructor(private dialog: MatDialog) {}
+
+  openComponent(
+    component: Type<T>,
+    actions: ErasModalAction[] = [],
+    closeButton = true
+  ) {
+    return this.dialog.open(ErasModalComponent, {
+      data: { component, actions, closeButton },
+      panelClass: 'eras-modal-component',
+    });
+  }
+}


### PR DESCRIPTION
## Description
-Added generic component for modals to keep just a single form design for all pop-pups.
-We can create modals-forms, modals-confirmations, and sent every custom content.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [x] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [x] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [x] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


