### PR TITLE
fix(ERAS-568): configuration name cannot be repeated

### DIFF
--- a/src/app/features/cosmic-latte/configuration-card/configuration-card.component.ts
+++ b/src/app/features/cosmic-latte/configuration-card/configuration-card.component.ts
@@ -43,6 +43,7 @@ import { MODAL_DEFAULT_CONF } from '../../../core/constants/modal';
 })
 export class ConfigurationCardComponent implements OnInit {
   @Input() configuration!: ConfigurationsModel;
+  @Input() configurations!: ConfigurationsModel[];
   @Input() serviceProviders: ServiceProviderModel[] = [];
   @Output() updateList = new EventEmitter<boolean>();
   isLoading = false;
@@ -81,7 +82,10 @@ export class ConfigurationCardComponent implements OnInit {
     const dialogRef = this.dialog.open(NewConfigurationModalComponent, {
       width: '400px',
       disableClose: true,
-      data: { existingConfiguration: configuration },
+      data: {
+        existingConfiguration: configuration,
+        configurations: this.configurations,
+      },
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {

--- a/src/app/features/cosmic-latte/cosmic-latte.component.html
+++ b/src/app/features/cosmic-latte/cosmic-latte.component.html
@@ -29,6 +29,7 @@
     <app-configuration-card
       *ngFor="let configuration of configurations"
       [configuration]="configuration"
+      [configurations]="configurations"
       [serviceProviders]="serviceProviders"
       (updateList)="onConfigurationUpdate($event)"
     ></app-configuration-card>

--- a/src/app/features/cosmic-latte/cosmic-latte.component.ts
+++ b/src/app/features/cosmic-latte/cosmic-latte.component.ts
@@ -48,7 +48,7 @@ export class CosmicLatteComponent implements OnInit {
     const dialogRef = this.dialog.open(NewConfigurationModalComponent, {
       width: '400px',
       disableClose: true,
-      data: {},
+      data: { configurations: this.configurations },
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {

--- a/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.html
+++ b/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.html
@@ -44,6 +44,14 @@
       >
         This field cannot contain only spaces.
       </mat-error>
+      <mat-error
+        *ngIf="
+          configurationForm.get('configurationName')?.hasError('duplicate') &&
+          configurationForm.get('configurationName')?.touched
+        "
+      >
+        Configuration name must be unique.
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="fill">

--- a/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.ts
+++ b/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.ts
@@ -22,6 +22,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { ConfigurationsModel } from '../../../core/models/configurations.model';
 import { forbiddenCharsValidator } from '../../../shared/validators/forbiden-chars.validator';
 import { noWhitespaceValidator } from '../../../shared/validators/no-whitespace.validator';
+import { duplicatePropertyValidator } from '../../../shared/validators/duplicateProperty.validator';
 
 @Component({
   selector: 'app-new-configuration-modal',
@@ -49,7 +50,10 @@ export class NewConfigurationModalComponent implements OnInit {
     private serviceProvidersService: ServiceProvidersService,
     public dialogRef: MatDialogRef<NewConfigurationModalComponent>,
     @Inject(MAT_DIALOG_DATA)
-    public data: { existingConfiguration?: ConfigurationsModel }
+    public data: {
+      existingConfiguration?: ConfigurationsModel;
+      configurations?: ConfigurationsModel[];
+    }
   ) {}
 
   ngOnInit(): void {
@@ -58,7 +62,15 @@ export class NewConfigurationModalComponent implements OnInit {
     this.configurationForm = this.fb.group({
       configurationName: [
         '',
-        [Validators.required, forbiddenCharsValidator, noWhitespaceValidator],
+        [
+          Validators.required,
+          forbiddenCharsValidator,
+          noWhitespaceValidator,
+          duplicatePropertyValidator(
+            this.data?.configurations ?? [],
+            'configurationName'
+          ),
+        ],
       ],
       baseURL: ['', [Validators.required, noWhitespaceValidator]],
       apiKey: [

--- a/src/app/shared/validators/duplicateProperty.validator.ts
+++ b/src/app/shared/validators/duplicateProperty.validator.ts
@@ -1,0 +1,18 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function duplicatePropertyValidator<T>(
+  list: T[],
+  property: keyof T
+): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value || !list) return null;
+
+    const exist = list.some(
+      item =>
+        String(item[property]).toLowerCase().trim() ===
+        String(control.value).toLowerCase().trim()
+    );
+
+    return exist ? { duplicate: true } : null;
+  };
+}


### PR DESCRIPTION
## Description
Created a generic validator for repeated attribute names.
Validated that user should not put a duplicated name


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [x] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [x] Are form validations implemented and working correctly?
- [x] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


