### PR TITLE
fix(ERAS#569): edit configuration name should not be triggered if no …

### DIFF
--- a/src/app/features/cosmic-latte/configuration-card/configuration-card.component.ts
+++ b/src/app/features/cosmic-latte/configuration-card/configuration-card.component.ts
@@ -84,7 +84,11 @@ export class ConfigurationCardComponent implements OnInit {
       disableClose: true,
       data: {
         existingConfiguration: configuration,
-        configurations: this.configurations,
+        configurations: this.configurations.filter(
+          config =>
+            config.configurationName !== this.configuration.configurationName
+        ),
+        action: 'edit',
       },
     });
     dialogRef.afterClosed().subscribe(result => {

--- a/src/app/features/cosmic-latte/cosmic-latte.component.ts
+++ b/src/app/features/cosmic-latte/cosmic-latte.component.ts
@@ -48,7 +48,7 @@ export class CosmicLatteComponent implements OnInit {
     const dialogRef = this.dialog.open(NewConfigurationModalComponent, {
       width: '400px',
       disableClose: true,
-      data: { configurations: this.configurations },
+      data: { configurations: this.configurations, action: 'create' },
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {

--- a/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.html
+++ b/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>Create new configuration</h2>
+<h2 mat-dialog-title>{{ data.action | titlecase }} configuration</h2>
 <form [formGroup]="configurationForm">
   <mat-dialog-content>
     <mat-form-field appearance="fill">

--- a/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.ts
+++ b/src/app/features/cosmic-latte/new-configuration-modal/new-configuration-modal.component.ts
@@ -53,6 +53,7 @@ export class NewConfigurationModalComponent implements OnInit {
     public data: {
       existingConfiguration?: ConfigurationsModel;
       configurations?: ConfigurationsModel[];
+      action: string;
     }
   ) {}
 
@@ -60,9 +61,8 @@ export class NewConfigurationModalComponent implements OnInit {
     this.existingConfiguration = this.data?.existingConfiguration;
 
     this.configurationForm = this.fb.group({
-      configurationName: [
-        '',
-        [
+      configurationName: this.fb.control('', {
+        validators: [
           Validators.required,
           forbiddenCharsValidator,
           noWhitespaceValidator,
@@ -71,7 +71,8 @@ export class NewConfigurationModalComponent implements OnInit {
             'configurationName'
           ),
         ],
-      ],
+        updateOn: 'blur',
+      }),
       baseURL: ['', [Validators.required, noWhitespaceValidator]],
       apiKey: [
         '',


### PR DESCRIPTION
## Description
-Added Luis observations, about edit configurationName
-Changed edit name of form to no longer display Create, instead of now it displays "Edit configurations"

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


