### PR TITLE
fix(ERAS-353): dynamic heatmap: some of the highest values are not in…

### DIFF
--- a/src/app/core/services/api/report.service.ts
+++ b/src/app/core/services/api/report.service.ts
@@ -257,7 +257,7 @@ export class ReportService extends BaseApiService {
 
     for (const color of colorList) {
       maxByColor[color] = Math.max(
-        ...groupedByRow.map(row => row.colorGroups[color]?.length || 0)
+        ...groupedByRow.map(row => row.colorGroups[color]?.length || 1)
       );
     }
 


### PR DESCRIPTION
## Description
-Getting the max number of items by color, we usually set a value 0 to drow the rows without a risk to math the other sections, it was changed to 1, to avoid the empty fills.


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [ ] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


