### PR TITLE
Update RW-test-package-FE-Runner.yml

### DIFF
--- a/.github/workflows/RW-test-package-FE-Runner.yml
+++ b/.github/workflows/RW-test-package-FE-Runner.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Save FE tag as JSON
         run: |
-          TAG="${{ env.LAST_TAG }}-${{ env.SHORT_SHA }}-${{ inputs.environment_tag }}"
+          TAG="${{ env.SHORT_SHA }}-${{ inputs.environment_tag }}"
           echo "{\"ERAS-FE\": \"$TAG\"}" > fe_tag.json
 
       - name: Build project


### PR DESCRIPTION
The sh file in ERAS project has hardcoded this first part, to avoid conflicts is required to remove the first part of the tag.

## Description
I recovered from the Docker hub tags the following information "ERAS-FE": "0.1.0-86094a5-testing", "ERAS-BE": "0.1.0-b06c2b0-testing" but the sh file setVersion.sh has already hardcoded the "0.1.0-" so I need to recover only the part EX "86094a5"


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


