### PR TITLE
fix(ERAS-599): evaluation process the configuration is not filling up…

### DIFF
--- a/src/app/core/utilities/helpers/is-empty.spec.ts
+++ b/src/app/core/utilities/helpers/is-empty.spec.ts
@@ -1,0 +1,48 @@
+import { isEmpty } from './is-empty';
+
+describe('isEmpty', () => {
+  it('should return true, whether the value is null', () => {
+    const isNullEmpty = isEmpty(null);
+    expect(isNullEmpty).toBeTrue();
+  });
+
+  it('should return true, whether the value is undefined', () => {
+    const isUndefinedEmpty = isEmpty(undefined);
+    expect(isUndefinedEmpty).toBeTrue();
+  });
+
+  it('should return true, whether the value is an empty string', () => {
+    const isStringEmpty = isEmpty(' ');
+    expect(isStringEmpty).toBeTrue();
+  });
+
+  it('should return true, whether the value is an array without values', () => {
+    const isArrayEmpty = isEmpty([]);
+    expect(isArrayEmpty).toBeTrue();
+  });
+
+  it('should return true, whether the value is an object empty', () => {
+    const isObjectEmpty = isEmpty({});
+    expect(isObjectEmpty).toBeTrue();
+  });
+
+  it('should return false, whether the value is a number', () => {
+    const isNumberEmpty = isEmpty(1);
+    expect(isNumberEmpty).toBeFalse();
+  });
+
+  it('should return false, whether the value is a non empty string', () => {
+    const isStringEmpty = isEmpty('test');
+    expect(isStringEmpty).toBeFalse();
+  });
+
+  it('should return false, whether the value is a non empty array', () => {
+    const isArrayEmpty = isEmpty([1]);
+    expect(isArrayEmpty).toBeFalse();
+  });
+
+  it('should return false, whether the value is an object with any data', () => {
+    const isObjectEmpty = isEmpty({ data: 1 });
+    expect(isObjectEmpty).toBeFalse();
+  });
+});

--- a/src/app/core/utilities/helpers/is-empty.ts
+++ b/src/app/core/utilities/helpers/is-empty.ts
@@ -1,0 +1,23 @@
+export function isEmpty<T>(value: T): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string' && value.trim().length === 0) {
+    return true;
+  }
+
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.keys(value).length === 0
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Description
Bug: List Evaluation process: The configuration on the evaluation process is not transferred to the import menu when the import button of the evaluation is triggered.

**Additional:**
+ I added a new helper **isEmpty**, it evaluates as empty if it receives 
null, undefined, an string empty(' '), array empty ([]) or an object empty ({}).
+ Also was added their corresponding unit test for those scenarios.


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


