### PR TITLE
feat(FE560): the selected elements are displayed on the menu but the …

### DIFF
--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -52,7 +52,9 @@
           (openedChange)="handleCohortSelect($event)"
         >
           <mat-select-trigger>
-            {{ getCohortsDisplay() }}
+            <app-selected-items
+              [items]="getCohortsDisplay()"
+            ></app-selected-items>
           </mat-select-trigger>
           @if (cohorts.length > 0) {
             <mat-option appSelectAll [allValues]="cohorts"
@@ -82,7 +84,9 @@
           formControlName="componentNames"
         >
           <mat-select-trigger>
-            {{ getComponentsDisplay() }}
+            <app-selected-items
+              [items]="getComponentsDisplay()"
+            ></app-selected-items>
           </mat-select-trigger>
           @if (!!componentNames.length) {
             <mat-option appSelectAll [allValues]="componentNames"
@@ -114,7 +118,9 @@
           formControlName="variables"
         >
           <mat-select-trigger>
-            {{ getVariablesDisplay() }}
+            <app-selected-items
+              [items]="getVariablesDisplay()"
+            ></app-selected-items>
           </mat-select-trigger>
           @if (!!variables.length) {
             <mat-option appSelectAll [allValues]="getAllVariableIds()"

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -23,6 +23,7 @@ import { VariableModel } from '@core/models/variable.model';
 import { CommonModule } from '@angular/common';
 import { SelectAllDirective } from '@shared/directives/select-all.directive';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { SelectedItemsComponent } from './selected-items/selected-items.component';
 
 @Component({
   selector: 'app-poll-filters',
@@ -34,6 +35,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
     CommonModule,
     SelectAllDirective,
     MatProgressSpinner,
+    SelectedItemsComponent,
   ],
   templateUrl: './poll-filters.component.html',
   styleUrl: './poll-filters.component.scss',
@@ -195,13 +197,10 @@ export class PollFiltersComponent implements OnInit {
     );
 
     return cohortIds?.length === this.cohorts.length
-      ? 'Select all'
-      : cohortIds
-          ?.map(
-            cohortId =>
-              this.cohorts.find(cohort => cohort.id === cohortId)?.name
-          )
-          ?.join(', ');
+      ? ['Select all']
+      : cohortIds?.map(
+          cohortId => this.cohorts.find(cohort => cohort.id === cohortId)?.name
+        );
   }
 
   getComponentsDisplay() {
@@ -210,12 +209,10 @@ export class PollFiltersComponent implements OnInit {
     );
 
     return componentNames?.length === this.componentNames.length
-      ? 'Select all'
-      : componentNames
-          ?.map(componentName =>
-            this.componentNames.find(cN => cN === componentName)
-          )
-          ?.join(', ');
+      ? ['Select all']
+      : componentNames?.map(componentName =>
+          this.componentNames.find(cN => cN === componentName)
+        );
   }
 
   getVariablesDisplay() {
@@ -224,10 +221,10 @@ export class PollFiltersComponent implements OnInit {
     );
 
     return variables?.length === this.variables.length
-      ? 'Select all'
-      : variables
-          ?.map(id => this.variables.find(v => v.pollVariableId === id)?.name)
-          ?.join(', ');
+      ? ['Select all']
+      : variables?.map(
+          id => this.variables.find(v => v.pollVariableId === id)?.name
+        );
   }
 
   getAllVariableIds() {

--- a/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.html
+++ b/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.html
@@ -1,0 +1,6 @@
+<div class="selected-items">
+  <span class="si-texts">{{ items() }}</span>
+  @if ((items()?.length || 0) > 1) {
+    <span class="si-selection">({{ items()?.length || 0 }} selected)</span>
+  }
+</div>

--- a/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.scss
+++ b/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.scss
@@ -1,0 +1,16 @@
+.selected-items {
+  display: flex;
+}
+
+.si-texts {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.si-selection {
+  opacity: 0.75;
+  font-size: 0.75em;
+  margin: 0 0.5rem 0 0.5rem;
+}

--- a/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.spec.ts
+++ b/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectedItemsComponent } from './selected-items.component';
+
+describe('SelectedItemsComponent', () => {
+  let component: SelectedItemsComponent;
+  let fixture: ComponentFixture<SelectedItemsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectedItemsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectedItemsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.ts
+++ b/src/app/modules/reports/components/poll-filters/selected-items/selected-items.component.ts
@@ -1,0 +1,10 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-selected-items',
+  templateUrl: './selected-items.component.html',
+  styleUrl: './selected-items.component.scss',
+})
+export class SelectedItemsComponent {
+  items = input<(string | undefined)[]>();
+}


### PR DESCRIPTION
## Description
- Added selection number to the right of the dropdown in order to have the user now how manu items does he/she selected. Note, it only be displayed from the second item selected a head.
- Added support for mobile mode as well.


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


