### PR TITLE
fix(FE640): select all on the filters is out of sync

### DIFF
--- a/src/app/core/utils/helpers/are-arrays-equal.spec.ts
+++ b/src/app/core/utils/helpers/are-arrays-equal.spec.ts
@@ -1,0 +1,29 @@
+import { areArraysEqual } from './are-arrays-equal';
+
+describe('areArraysEqual', () => {
+  it('should return false, whether the arrays have different sizes.', () => {
+    const areEquals = areArraysEqual([1], [1, 2]);
+    expect(areEquals).toBeFalse();
+  });
+
+  it('should return false, whether the arrays have different values', () => {
+    const firstArray = [1, 'a'];
+    const secondArray = ['b', 1];
+    const areEquals = areArraysEqual(firstArray, secondArray);
+    expect(areEquals).toBeFalse();
+  });
+
+  it('should return false, whether the arrays have different values', () => {
+    const firstArray = [1, 'a'];
+    const secondArray = ['b', 1];
+    const areEquals = areArraysEqual(firstArray, secondArray);
+    expect(areEquals).toBeFalse();
+  });
+
+  it('should return true, whether the arrays are equals', () => {
+    const firstArray = [1, 'a'];
+    const secondArray = [1, 'a'];
+    const areEquals = areArraysEqual(firstArray, secondArray);
+    expect(areEquals).toBeTrue();
+  });
+});

--- a/src/app/core/utils/helpers/are-arrays-equal.ts
+++ b/src/app/core/utils/helpers/are-arrays-equal.ts
@@ -1,0 +1,4 @@
+export function areArraysEqual<T>(firstArray: T[], secondArray: T[]): boolean {
+  if (firstArray.length !== secondArray.length) return false;
+  return firstArray.every((element, idx) => element === secondArray[idx]);
+}

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -13,7 +13,7 @@
         <mat-select
           id="sl-poll"
           formControlName="selectedPoll"
-          (openedChange)="handlePollSelect($event)"
+          (selectionChange)="handlePollSelect($event)"
         >
           @for (poll of polls; track $index) {
             <mat-option class="versioned-option" [value]="poll">
@@ -31,7 +31,7 @@
         <mat-label for="sl-version">Version</mat-label>
         <mat-select
           formControlName="lastVersion"
-          (openedChange)="handlePollSelect($event)"
+          (selectionChange)="handleVersionSelect($event)"
         >
           <mat-option [value]="false">Older Versions</mat-option>
           <mat-option [value]="true">
@@ -53,7 +53,7 @@
         >
           <mat-select-trigger>
             <app-selected-items
-              [items]="getCohortsDisplay()"
+              [items]="getCohortsSelection()"
             ></app-selected-items>
           </mat-select-trigger>
           @if (cohorts.length > 0) {
@@ -85,7 +85,7 @@
         >
           <mat-select-trigger>
             <app-selected-items
-              [items]="getComponentsDisplay()"
+              [items]="getComponentsSelection()"
             ></app-selected-items>
           </mat-select-trigger>
           @if (!!componentNames.length) {
@@ -119,7 +119,7 @@
         >
           <mat-select-trigger>
             <app-selected-items
-              [items]="getVariablesDisplay()"
+              [items]="getVariablesSelection()"
             ></app-selected-items>
           </mat-select-trigger>
           @if (!!variables.length) {

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.scss
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.scss
@@ -8,6 +8,7 @@
 .form-container > *:nth-child(n + 3) {
   grid-column: 1 / -1; /* Span both columns */
 }
+
 .versioned-option span {
   display: flex;
   align-items: center;
@@ -15,10 +16,6 @@
   gap: 0.5rem;
 }
 
-.version {
-  font-weight: 600;
-  font-size: small;
-}
 mat-spinner {
   display: block;
   margin: 2rem auto;


### PR DESCRIPTION
## Description
Dynamic Heatmap: The Select all on the filters of variables and Components can be out of Sync when a filter in a higher level is modified


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


