### PR TITLE
fix(FE636): when there is no polls infinite spinner is displayed

### DIFF
--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -1,7 +1,5 @@
 <form [formGroup]="filterForm">
-  @if (polls?.length === 0) {
-    <mat-spinner></mat-spinner>
-  } @else if (polls === null) {
+  @if (polls === null) {
     <p class="error-message">
       There was an error looking for polls. Please contact support
     </p>

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -15,7 +15,6 @@ import {
 } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 
 import { CohortModel } from '@core/models/cohort.model';
@@ -39,7 +38,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     MatIconModule,
     CommonModule,
     SelectAllDirective,
-    MatProgressSpinner,
     SelectedItemsComponent,
   ],
   templateUrl: './poll-filters.component.html',


### PR DESCRIPTION
## Description
FE - When there is no polls Dynamic, Summary and Polls answered screen got block and infinite spinner is displayed


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [ ] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


