### PR TITLE
fix(FE-696): created access service to control keycloak init and mana…

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,22 +1,28 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  inject,
+  provideAppInitializer,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideKeycloak } from 'keycloak-angular';
 import { routes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { environment } from '../environments/environment';
 import { keycloakHttpInterceptor } from '@core/interceptors/keycloak-interceptor';
+import { AuthService } from '@core/services/access/access.service';
+import Keycloak from 'keycloak-js';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideKeycloak({
-      config: environment.keycloak,
-      initOptions: {
-        onLoad: 'login-required',
-        redirectUri: environment.production ? window.location.origin + '/' : '',
-        checkLoginIframe: false,
-      },
+    {
+      provide: Keycloak,
+      useFactory: () => new Keycloak(environment.keycloak),
+    },
+    provideAppInitializer(async () => {
+      const authService = inject(AuthService);
+      return await authService.init();
     }),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -79,7 +79,6 @@ export const routes: Routes = [
       {
         path: 'risk-students',
         component: RiskStudentsComponent,
-        canActivate: [authGuard],
         data: { breadcrumb: 'Risk Students' },
       },
 

--- a/src/app/core/auth/guards/auth.guard.ts
+++ b/src/app/core/auth/guards/auth.guard.ts
@@ -1,8 +1,13 @@
 import { inject } from '@angular/core';
 import { CanActivateChildFn } from '@angular/router';
-import Keycloak from 'keycloak-js';
+import { AuthService } from '@core/services/access/access.service';
 
-export const authGuard: CanActivateChildFn = () => {
-  const keycloak = inject(Keycloak);
-  return !!keycloak.authenticated; // Replace with actual logic to check if user is logged in
+export const authGuard: CanActivateChildFn = async () => {
+  const authService = inject(AuthService);
+
+  if (!authService.isAuthenticated()) {
+    await authService.login();
+  }
+
+  return authService.isAuthenticated();
 };

--- a/src/app/core/components/layout/user-menu/user-menu.component.ts
+++ b/src/app/core/components/layout/user-menu/user-menu.component.ts
@@ -4,8 +4,8 @@ import { MatIcon } from '@angular/material/icon';
 import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
 import { MatToolbar } from '@angular/material/toolbar';
 
-import Keycloak from 'keycloak-js';
 import { UserDataService } from '@core/services/access/user-data.service';
+import { AuthService } from '@core/services/access/access.service';
 
 @Component({
   selector: 'app-user-menu',
@@ -15,12 +15,12 @@ import { UserDataService } from '@core/services/access/user-data.service';
 })
 export class UserMenuComponent {
   timedOutCloser: ReturnType<typeof setTimeout> | null = null;
-  private readonly keycloak = inject(Keycloak);
+  private readonly authService = inject(AuthService);
   private readonly userData = inject(UserDataService);
 
   logout() {
     this.userData.clear();
-    this.keycloak.logout();
+    this.authService.logout();
   }
 
   mouseEnter(trigger: MatMenuTrigger) {

--- a/src/app/core/services/access/access.service.ts
+++ b/src/app/core/services/access/access.service.ts
@@ -1,0 +1,152 @@
+import { HttpHandlerFn, HttpRequest } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+
+import Keycloak from 'keycloak-js';
+
+import { environment } from 'src/environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private keycloak = inject(Keycloak);
+  private isInitialized = false;
+  private TOKEN_KEY = 'keycloak_token';
+  // TODO: save tokens on a more secure place, e.g. httpOnly cookies
+  private REFRESH_TOKEN_KEY = 'keycloak_refreshToken';
+  private UPDATE_TOKEN_TIME = 15;
+
+  private REDIRECT_URI = environment.production
+    ? window.location.origin + '/'
+    : '';
+
+  async init() {
+    if (this.isInitialized) return;
+
+    this.keycloak.onAuthLogout = this.onAuthLogout;
+    this.keycloak.onTokenExpired = this.onTokenExpired;
+    this.keycloak.onAuthRefreshError = this.onAuthRefreshError;
+
+    try {
+      const authenticated = await this.keycloak.init({
+        onLoad: undefined,
+        token: sessionStorage.getItem(this.TOKEN_KEY) || undefined,
+        refreshToken:
+          sessionStorage.getItem(this.REFRESH_TOKEN_KEY) || undefined,
+        redirectUri: this.REDIRECT_URI,
+        checkLoginIframe: false,
+      });
+
+      if (authenticated) {
+        sessionStorage.setItem(this.TOKEN_KEY, this.keycloak.token!);
+        sessionStorage.setItem(
+          this.REFRESH_TOKEN_KEY,
+          this.keycloak.refreshToken!
+        );
+      }
+
+      this.isInitialized = true;
+    } catch (error) {
+      console.error('Error initializing Keycloak', error);
+    }
+  }
+
+  async login() {
+    if (!this.keycloak.token) {
+      this.keycloak.login({
+        redirectUri: this.REDIRECT_URI,
+      });
+    }
+  }
+
+  logout() {
+    this.clearTokens();
+    this.keycloak.logout();
+  }
+
+  updateToken() {
+    try {
+      this.keycloak.updateToken(this.UPDATE_TOKEN_TIME).then(refreshed => {
+        if (refreshed) {
+          this.storeTokens();
+        } else {
+          this.clearTokens();
+        }
+
+        return refreshed;
+      });
+
+      return false;
+    } catch (error) {
+      console.error(
+        'An error has ocured while refreshing the access token',
+        error
+      );
+      this.logout();
+      this.clearTokens();
+
+      return false;
+    }
+  }
+
+  getAccessToken() {
+    return this.keycloak.token;
+  }
+
+  getRefreshToken() {
+    return this.keycloak.refreshToken;
+  }
+
+  handleRefresh(req: HttpRequest<unknown>, next: HttpHandlerFn) {
+    const isRefreshed = this.updateToken();
+
+    if (isRefreshed) {
+      const accessToken = this.getAccessToken();
+      const retryReq = req.clone({
+        setHeaders: { Authorization: `Bearer ${accessToken}` },
+      });
+      return next(retryReq);
+    }
+
+    this.logout();
+    this.clearTokens();
+
+    return next(req);
+  }
+
+  isAuthenticated() {
+    return !!this.keycloak.authenticated;
+  }
+
+  storeTokens() {
+    const keycloakToken = this.keycloak.token;
+    const keycloakRefreshToken = this.keycloak.refreshToken;
+
+    if (keycloakToken) {
+      sessionStorage.setItem(this.TOKEN_KEY, keycloakToken);
+    } else {
+      console.error('No keycloak token to store');
+    }
+    if (keycloakRefreshToken) {
+      sessionStorage.setItem(this.REFRESH_TOKEN_KEY, keycloakRefreshToken);
+    } else {
+      console.error('No keycloak refresh token to store');
+    }
+  }
+
+  clearTokens() {
+    sessionStorage.removeItem(this.TOKEN_KEY);
+    sessionStorage.removeItem(this.REFRESH_TOKEN_KEY);
+  }
+
+  private onAuthLogout = () => {
+    this.clearTokens();
+  };
+
+  private onTokenExpired = () => {
+    this.updateToken();
+  };
+
+  private onAuthRefreshError = () => {
+    this.clearTokens();
+    this.logout();
+  };
+}


### PR DESCRIPTION
## Description
Updated authentication adding a new auth.service.
This should solve the following issues:
1. When refreshing the page, the user should stay on the same route instead of being redirected to home
2. When refreshing the page, the "auth" query **should no longer appear** on the network tab on developer console.
<img width="1917" height="252" alt="image" src="https://github.com/user-attachments/assets/9079894a-0b7e-4194-9103-ecea645d7911" />

NOTE: For now, keycloak tokens are stored on sessionStorage. We need to consider saving them on a more secure place (httpOnly cookies, for example)

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


