### PR TITLE
fix(FE653): updated based on QA's comments

### DIFF
--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -8,6 +8,7 @@ import {
   DialogData,
   DialogType,
 } from '@shared/components/modals/modal-dialog/types/dialog';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -19,7 +20,7 @@ export class DialogService {
     descriptionMessage: string,
     type: DialogType,
     extraMessage?: string
-  ): void {
+  ): Observable<MatDialog> {
     const buttonElement = document.activeElement as HTMLElement;
     const dialogData: DialogData = {
       type,
@@ -28,9 +29,12 @@ export class DialogService {
       details: [descriptionMessage],
     };
     buttonElement.blur(); // Remove focus from the button - avoid console warning
-    this.dialog.open(ModalComponent, {
-      ...MODAL_DEFAULT_CONF,
-      data: dialogData,
-    });
+
+    return this.dialog
+      .open(ModalComponent, {
+        ...MODAL_DEFAULT_CONF,
+        data: dialogData,
+      })
+      .afterClosed();
   }
 }

--- a/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
@@ -78,6 +78,7 @@ export class ImportAnswersPreviewComponent implements OnChanges {
   clService = inject(CosmicLatteService);
 
   @Input() importedPollData: PollInstance[] = [];
+  @Input({ required: true }) evaluationId!: number;
 
   @Output() saveCompleted = new EventEmitter<{
     state: string;
@@ -144,7 +145,7 @@ export class ImportAnswersPreviewComponent implements OnChanges {
     this.clService
       .savePollsCosmicLattePreview(
         pollsToSave as unknown as PollInstance[],
-        history.state.evaluationId
+        this.evaluationId
       )
       .subscribe({
         next: data => {

--- a/src/app/modules/imports/components/import-preview/import-preview.component.html
+++ b/src/app/modules/imports/components/import-preview/import-preview.component.html
@@ -1,8 +1,11 @@
 <h2 class="page-title">Import Polls</h2>
-<app-import-answers-preview
-  [importedPollData]="importedPollData"
-  (saveCompleted)="handleSavePollState($event)"
-></app-import-answers-preview>
+@if (evaluationId) {
+  <app-import-answers-preview
+    [evaluationId]="evaluationId"
+    [importedPollData]="importedPollData"
+    (saveCompleted)="handleSavePollState($event)"
+  />
+}
 <div *ngIf="isLoading$ | async" class="spinner-container">
   <mat-spinner></mat-spinner>
 </div>

--- a/src/app/modules/imports/components/import-preview/import-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-preview.component.ts
@@ -42,6 +42,7 @@ export class ImportPreviewComponent implements OnInit {
   private router: Router = inject(Router);
   private route: ActivatedRoute = inject(ActivatedRoute);
 
+  evaluationId: number | null = null;
   selectedConfiguration: ConfigurationsModel | null = null;
   loadingSubject = new BehaviorSubject<boolean>(true);
   isLoading$ = this.loadingSubject.asObservable();
@@ -59,8 +60,10 @@ export class ImportPreviewComponent implements OnInit {
       this.router.navigate(['../'], { relativeTo: this.route });
       return;
     }
-    const { pollName, startDate, endDate, configuration } = routeData;
+    const { evaluationId, pollName, startDate, endDate, configuration } =
+      routeData;
 
+    this.evaluationId = evaluationId;
     this.selectedConfiguration = configuration;
     this.checkScreenSize();
     this.loadingSubject.next(true);
@@ -104,7 +107,11 @@ export class ImportPreviewComponent implements OnInit {
     } else if (event.state == 'true') {
       this.loadingSubject.next(false);
       this.importedPollData = [];
-      this.dialogService.openDialog('Polls saved successfully!', 'success');
+      this.dialogService
+        .openDialog('Polls saved successfully!', 'success')
+        .subscribe(() => {
+          this.router.navigate(['evaluation-process']);
+        });
     } else {
       this.loadingSubject.next(false);
       this.dialogService.openDialog(

--- a/src/app/modules/imports/models/preselected-poll.ts
+++ b/src/app/modules/imports/models/preselected-poll.ts
@@ -1,6 +1,7 @@
 import { ConfigurationsModel } from '@core/models/configurations.model';
 
 export interface PreselectedPoll {
+  evaluationId: number;
   configuration: ConfigurationsModel;
   pollName: string;
   startDate: string;

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -31,6 +31,7 @@ import { ModalComponent } from '@shared/components/modals/modal-dialog/modal-dia
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouteDataService } from '@core/services/route-data.service';
 import { ModalImportAnswersFormComponent } from '@modules/lists/components/modal-import-answers-form/modal-import-answers-form.component';
+import { PreselectedPoll } from '@modules/imports/models/preselected-poll';
 
 @Component({
   selector: 'app-evaluation-process-list',
@@ -142,6 +143,7 @@ export class EvaluationProcessListComponent implements OnInit {
   getClassName(value: string): string {
     return value ? value.replace(/\s+/g, '_') : '';
   }
+
   deleteEvaluationConfirmation(id: number) {
     if (id) {
       this.openAlertDialog(
@@ -153,6 +155,7 @@ export class EvaluationProcessListComponent implements OnInit {
       console.warn("id wasn't provided");
     }
   }
+
   deleteEvaluation(id: number) {
     this.evaluationProcessService
       .deleteEvaluationProcess(id.toString())
@@ -205,6 +208,7 @@ export class EvaluationProcessListComponent implements OnInit {
         },
       });
   }
+
   openModalNewEvaluationProcess(): void {
     const buttonElement = document.activeElement as HTMLElement;
     buttonElement.blur(); // Remove focus from the button - avoid console warning
@@ -223,14 +227,16 @@ export class EvaluationProcessListComponent implements OnInit {
         ...MODAL_DEFAULT_CONF,
         panelClass: 'border-modalbox-dialog',
         data: {
+          evaluationId: data.id,
           pollName: data.pollName,
           endDate: data.endDate,
           startDate: data.startDate,
         },
       })
       .afterClosed()
-      .subscribe(result => {
+      .subscribe((result: PreselectedPoll) => {
         this.routeDataService.updateRouteData({
+          evaluationId: data.id,
           configuration: result.configuration,
           pollName: result.pollName,
           startDate: result.startDate,
@@ -287,10 +293,12 @@ export class EvaluationProcessListComponent implements OnInit {
       data,
     });
   }
+
   normalizeData(data: EvaluationModel[]): EvaluationModel[] {
     const statusTransformed = this.transformStatus(data);
     return this.adaptDataToColumNames(statusTransformed);
   }
+
   adaptDataToColumNames(data: EvaluationModel[]): EvaluationModel[] {
     data.forEach((evaluation: EvaluationModel) => {
       evaluation.country = evaluation.country.toUpperCase();
@@ -298,6 +306,7 @@ export class EvaluationProcessListComponent implements OnInit {
     });
     return data;
   }
+
   transformStatus(data: EvaluationModel[]): EvaluationModel[] {
     data.forEach((evaluation: EvaluationModel) => {
       evaluation.status = getStatusForEvaluationProcess(evaluation);

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -192,7 +192,9 @@ export class PollFiltersComponent implements OnInit {
       .getAllPolls()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: polls => (this.polls = polls),
+        next: polls => {
+          this.polls = polls;
+        },
         error: () => (this.polls = null),
       });
   }


### PR DESCRIPTION
## Description
Updated based on QA's comments.

Now, Configuration and pollName are retrieved from the evaluation-process table and these options are disabled on the form
<img width="522" height="478" alt="import-polls" src="https://github.com/user-attachments/assets/084b2732-a912-4794-a975-d9df8c35688a" />


Also, the undefined error when saving polls is fixed.

A redirection to /evaluation-process was also added since import-polls page is left blank after saving polls shown on the preview.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


