### PR TITLE
fix(FE653): updated based on QA's comments

### DIFF
--- a/src/app/core/models/configurations.model.ts
+++ b/src/app/core/models/configurations.model.ts
@@ -1,7 +1,7 @@
 import { AuditModel } from './common/audit.model';
+import { BaseModel } from './common/base.model';
 
-export interface ConfigurationsModel {
-  id: number;
+export interface ConfigurationsModel extends BaseModel {
   userId: string;
   configurationName: string;
   baseURL: string;

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -231,20 +231,24 @@ export class EvaluationProcessListComponent implements OnInit {
           pollName: data.pollName,
           endDate: data.endDate,
           startDate: data.startDate,
+          configurationId: data.configurationId,
         },
       })
       .afterClosed()
       .subscribe((result: PreselectedPoll) => {
-        this.routeDataService.updateRouteData({
-          evaluationId: data.id,
-          configuration: result.configuration,
-          pollName: result.pollName,
-          startDate: result.startDate,
-          endDate: result.endDate,
-        });
-        this.router.navigate(['import-preview'], {
-          relativeTo: this.route,
-        });
+        if (result) {
+          this.routeDataService.updateRouteData({
+            evaluationId: data.id,
+            configuration: result.configuration,
+            pollName: result.pollName,
+            startDate: result.startDate,
+            endDate: result.endDate,
+          });
+
+          this.router.navigate(['import-preview'], {
+            relativeTo: this.route,
+          });
+        }
       });
   }
 
@@ -264,6 +268,7 @@ export class EvaluationProcessListComponent implements OnInit {
       },
     });
   }
+
   openAlertDialog(
     descriptionMessage: string,
     type: DialogType,

--- a/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.html
+++ b/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.html
@@ -1,65 +1,76 @@
-<div class="form-container">
-  <h2 class="page-title">Import Polls</h2>
-  <div class="container-form-answer">
-    <form [formGroup]="form" (ngSubmit)="onSubmit()">
-      <div class="row">
-        <mat-form-field class="input" appearance="outline">
-          <mat-label>Select a configuration to start</mat-label>
-          <mat-select
-            formControlName="configuration"
-            (selectionChange)="onConfigurationChange($event.value)"
+<!-- TODO: Remove this conditional when user roles and access are defined -->
+@if ((loadingSubject | async) === false && userConfigurations.length === 0) {
+  <mat-dialog-content class="modal">
+    <mat-error
+      >You don't have active configurations. Please go to
+      <a [routerLink]="providersUrl" (click)="dialogRef.close()"> this page </a>
+      to create one</mat-error
+    >
+  </mat-dialog-content>
+} @else {
+  <div class="form-container">
+    <h2 class="page-title">Import Polls</h2>
+    <div class="container-form-answer">
+      <form [formGroup]="form" (ngSubmit)="onSubmit()">
+        <div class="row">
+          <mat-form-field class="input" appearance="outline">
+            <mat-label>Select a configuration to start</mat-label>
+            <mat-select
+              formControlName="configuration"
+              (selectionChange)="onConfigurationChange($event.value)"
+            >
+              @for (configuration of userConfigurations; track configuration) {
+                <mat-option [value]="configuration"
+                  >{{ configuration.configurationName }} -
+                  {{ getServiceProviderName(configuration) }}</mat-option
+                >
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="row">
+          <mat-form-field class="input" appearance="outline">
+            <mat-label>Select a survey from Cosmic Latte</mat-label>
+            <mat-select formControlName="pollName">
+              @for (poll of pollsNames; track poll) {
+                <mat-option [value]="poll.name"
+                  >{{ poll.name }} - Id:
+                  {{ poll.parent.replace('evaluationSets:', '') }}</mat-option
+                >
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="row">
+          <mat-form-field class="input">
+            <mat-label>Enter a date range</mat-label>
+            <mat-date-range-input [rangePicker]="picker">
+              <input
+                matStartDate
+                placeholder="Start date"
+                formControlName="start"
+              />
+              <input matEndDate placeholder="End date" formControlName="end" />
+            </mat-date-range-input>
+            <mat-datepicker-toggle
+              matIconSuffix
+              [for]="picker"
+            ></mat-datepicker-toggle>
+            <mat-date-range-picker #picker></mat-date-range-picker>
+            <mat-hint>Not required</mat-hint>
+          </mat-form-field>
+        </div>
+        <div class="row">
+          <button
+            class="button"
+            mat-flat-button
+            type="submit"
+            [disabled]="form.invalid || !form.get('pollName')?.value"
           >
-            @for (configuration of userConfigurations; track configuration) {
-              <mat-option [value]="configuration"
-                >{{ configuration.configurationName }} -
-                {{ getServiceProviderName(configuration) }}</mat-option
-              >
-            }
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <mat-form-field class="input" appearance="outline">
-          <mat-label>Select a survey from Cosmic Latte</mat-label>
-          <mat-select formControlName="pollName">
-            @for (poll of pollsNames; track poll) {
-              <mat-option [value]="poll.name"
-                >{{ poll.name }} - Id:
-                {{ poll.parent.replace('evaluationSets:', '') }}</mat-option
-              >
-            }
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <mat-form-field class="input">
-          <mat-label>Enter a date range</mat-label>
-          <mat-date-range-input [rangePicker]="picker">
-            <input
-              matStartDate
-              placeholder="Start date"
-              formControlName="start"
-            />
-            <input matEndDate placeholder="End date" formControlName="end" />
-          </mat-date-range-input>
-          <mat-datepicker-toggle
-            matIconSuffix
-            [for]="picker"
-          ></mat-datepicker-toggle>
-          <mat-date-range-picker #picker></mat-date-range-picker>
-          <mat-hint>Not required</mat-hint>
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <button
-          class="button"
-          mat-flat-button
-          type="submit"
-          [disabled]="form.invalid || !form.get('pollName')?.value"
-        >
-          Import Answers
-        </button>
-      </div>
-    </form>
+            Import Answers
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+}

--- a/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.ts
+++ b/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import {
   FormBuilder,
@@ -12,7 +12,11 @@ import { UserDataService } from '@core/services/access/user-data.service';
 import { ConfigurationsService } from '@core/services/api/configurations.service';
 import { ServiceProvidersService } from '@core/services/api/service-providers.service';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogContent,
+  MatDialogRef,
+} from '@angular/material/dialog';
 import { BehaviorSubject } from 'rxjs';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatTableModule } from '@angular/material/table';
@@ -29,13 +33,13 @@ import { DialogService } from '@core/services/dialog.service';
 import { CosmicLatteService } from '@core/services/api/cosmic-latte.service';
 import { provideNativeDateAdapter } from '@angular/material/core';
 import { NewConfigurationModalComponent } from '@shared/components/modals/new-configuration-modal/new-configuration-modal.component';
-import { PreselectedPoll } from '@modules/imports/models/preselected-poll';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-modal-import-answers-form',
   imports: [
+    AsyncPipe,
     FormsModule,
-    ReactiveFormsModule,
     MatFormFieldModule,
     MatTableModule,
     MatPaginatorModule,
@@ -44,6 +48,9 @@ import { PreselectedPoll } from '@modules/imports/models/preselected-poll';
     MatButtonModule,
     MatCardModule,
     MatSelectModule,
+    MatDialogContent,
+    ReactiveFormsModule,
+    RouterLink,
   ],
   providers: [provideNativeDateAdapter(), DatePipe],
   templateUrl: './modal-import-answers-form.component.html',
@@ -60,13 +67,15 @@ export class ModalImportAnswersFormComponent implements OnInit {
   );
   private datePipe: DatePipe = inject(DatePipe);
   private readonly userData: UserDataService = inject(UserDataService);
-  private preselectedPollState: PreselectedPoll = inject(MAT_DIALOG_DATA);
+  private preselectedPollState = inject(MAT_DIALOG_DATA);
   private dialogService: DialogService = inject(DialogService);
   private cosmicLatteService: CosmicLatteService = inject(CosmicLatteService);
-  private dialogRef: MatDialogRef<NewConfigurationModalComponent> = inject(
+
+  dialogRef: MatDialogRef<NewConfigurationModalComponent> = inject(
     MatDialogRef<NewConfigurationModalComponent>
   );
 
+  providersUrl = '/cosmic-latte';
   pollsNames: PollName[] = [];
   userConfigurations: ConfigurationsModel[] = [];
   serviceProviders: ServiceProviderModel[] = [];
@@ -126,11 +135,25 @@ export class ModalImportAnswersFormComponent implements OnInit {
       next: data => {
         this.userConfigurations = data;
         if (!isEmpty(this.userConfigurations)) {
-          this.selectedConfiguration = this.userConfigurations[0];
-          this.form.get('configuration')?.setValue(this.selectedConfiguration);
-          this.getPollDetails(this.selectedConfiguration.id);
-          this._fillUpState(this.selectedConfiguration);
-          this._fillPollsForm();
+          const configurationId = this.preselectedPollState.configurationId;
+
+          this.selectedConfiguration =
+            this.userConfigurations.find(
+              userConfiguration => userConfiguration.id === configurationId
+            ) || null;
+
+          if (this.selectedConfiguration !== null) {
+            this.form
+              .get('configuration')
+              ?.setValue(this.selectedConfiguration);
+            this.getPollDetails(this.selectedConfiguration.id);
+            this._fillUpState(this.selectedConfiguration);
+            this._fillPollsForm();
+          } else {
+            console.error(
+              `No configuration with id ${configurationId} was found.`
+            );
+          }
         }
         this.loadingSubject.next(false);
       },


### PR DESCRIPTION
## Description
Added a workaround to user having access to Evaluation Processes data withouth configuration.
When user has no configurations, an error message should be shown:
<img width="931" height="385" alt="message" src="https://github.com/user-attachments/assets/be8c60a1-6584-4235-8047-ac9b33879d47" />

This workaround only checkes if a user has any configuration. On the next release, a more integral solution should be considered.

Also, a fix was added, ensuring that, when multiple configurations are created, the one associated with the Evaluation Process selected is selected on the form.


## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


