### PR TITLE
feat(FE-120): add a scrolldown for multiple actions

### DIFF
--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -90,14 +90,14 @@ export class EvaluationProcessListComponent implements OnInit {
       id: 'openModalDetails',
       label: 'Actions',
       ngIconName: 'edit',
-      tooltip: 'Edit evaluation',
+      text: 'Edit evaluation',
     },
     {
       columnId: 'actions',
       id: 'goImport',
       label: 'Actions',
       ngIconName: 'drive_file_move',
-      tooltip: 'Go to import',
+      text: 'Go to import',
       isVisible: this.isVisible.bind(this),
     },
   ];

--- a/src/app/shared/components/buttons/action-button/action-button.component.html
+++ b/src/app/shared/components/buttons/action-button/action-button.component.html
@@ -1,6 +1,6 @@
 @if (item && actionData && actionData.label) {
   @if (actionData.hasOwnProperty('text') && actionData.text) {
-    <button mat-menu-item (click)="onButtonClick($event)">
+    <button mat-button (click)="onButtonClick($event)">
       <ng-container *ngTemplateOutlet="loadContent"></ng-container>
     </button>
   } @else {

--- a/src/app/shared/components/buttons/action-button/action-button.component.ts
+++ b/src/app/shared/components/buttons/action-button/action-button.component.ts
@@ -2,21 +2,12 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 
 import { MatButton, MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-
-import { ActionData } from '../../list/types/action';
-import { EventAction } from '../../../../core/models/load';
+import { EventAction } from '@core/models/load';
+import { ActionData } from '@shared/components/list/types/action';
 
 @Component({
   selector: 'app-action-button',
-  imports: [
-    MatMenuModule,
-    MatButton,
-    NgTemplateOutlet,
-    MatIconModule,
-    MatButtonModule,
-  ],
+  imports: [MatButton, NgTemplateOutlet, MatButtonModule],
   templateUrl: './action-button.component.html',
   styleUrl: './action-button.component.scss',
 })

--- a/src/app/shared/components/list/list.component.html
+++ b/src/app/shared/components/list/list.component.html
@@ -40,7 +40,7 @@
         [templateMap]="templateMap"
         [actionDatas]="actionDatas"
         (actionCalled)="handleAction($event)"
-      ></app-table-with-actions>
+      />
       <br />
       <mat-paginator
         [className]="mapClass?.paginator"

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.html
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.html
@@ -44,9 +44,9 @@
             </span>
           </div>
         </mat-card-content>
-        @if (getTotalActionDatas() > 0) {
+        @if (actionDatas().length > 0) {
           <mat-card-actions [class]="mapClass?.card?.actions ?? ''">
-            @for (actionData of getActionDatas(); track $index) {
+            @for (actionData of actionDatas(); track $index) {
               @if (isVisible(actionData, item) && actionData.ngIconName) {
                 <app-action-button
                   [matTooltip]="actionData.tooltip ?? 'action'"
@@ -125,71 +125,111 @@
         </td>
       </ng-container>
 
-      <ng-container *ngIf="getTotalActionDatas() > 0" matColumnDef="Actions">
-        <th
-          mat-header-cell
-          [class]="mapClass?.table?.header ?? ''"
-          *matHeaderCellDef
-          class="action-column-header"
-        >
-          <b>Actions</b>
-        </th>
-        <td
-          mat-cell
-          [class]="mapClass?.table?.cell ?? ''"
-          *matCellDef="let item"
-          class="action-column-cell"
-        >
-          <!-- TODO: Refactor this when decide to change all grids. -->
-          @if (!hasTextAttribute()) {
-            <span *ngFor="let actionData of getActionDatas()">
-              <app-action-button
-                *ngIf="isVisible(actionData, item)"
-                [item]="item"
-                [actionData]="actionData"
-                (actionCalled)="handleAction($event)"
-              >
-                <mat-icon
-                  *ngIf="!actionData.text && actionData.ngIconName"
-                  [matTooltip]="actionData.tooltip ?? 'action'"
-                >
-                  {{ actionData.ngIconName }}
-                </mat-icon>
-                <span *ngIf="actionData.text && !actionData.ngIconName">{{
-                  actionData.text
-                }}</span>
-              </app-action-button>
-            </span>
-          } @else {
-            <button
-              matIconButton
-              class="mat-mdc-icon-button"
-              [matMenuTriggerFor]="menu"
-              aria-label="Actions"
-            >
-              <mat-icon>more_vert</mat-icon>
-            </button>
-            <mat-menu #menu="matMenu">
-              <app-action-button
-                *ngFor="let actionData of getActionDatas()"
-                [item]="item"
-                [actionData]="actionData"
-                (actionCalled)="handleAction($event)"
-              >
-                <div class="wrapper-content">
-                  <mat-icon
-                    *ngIf="actionData.ngIconName"
-                    [matTooltip]="actionData.tooltip ?? 'action'"
+      @if (actionDatas().length > 0) {
+        <ng-container matColumnDef="Actions">
+          <th
+            mat-header-cell
+            [class]="mapClass?.table?.header ?? ''"
+            *matHeaderCellDef
+            class="action-column-header"
+          >
+            <b>Actions</b>
+          </th>
+          <td
+            mat-cell
+            [class]="mapClass?.table?.cell ?? ''"
+            *matCellDef="let item"
+            class="action-column-cell"
+          >
+            @if (actionDatas().length === 1) {
+              @let actionData = actionDatas()[0];
+
+              @if (isVisible(actionData, item)) {
+                @if (!hasTextAttribute()) {
+                  <app-action-button
+                    [item]="item"
+                    [actionData]="actionData"
+                    (actionCalled)="handleAction($event)"
                   >
-                    {{ actionData.ngIconName }}
-                  </mat-icon>
-                  <span *ngIf="actionData.text">{{ actionData.text }}</span>
+                    @if (!actionData.text && actionData.ngIconName) {
+                      <mat-icon [matTooltip]="actionData.tooltip ?? 'action'">
+                        {{ actionData.ngIconName }}
+                      </mat-icon>
+                    }
+                    @if (actionData.text && !actionData.ngIconName) {
+                      <span>{{ actionData.text }}</span>
+                    }
+                  </app-action-button>
+                } @else {
+                  <app-action-button
+                    [item]="item"
+                    [actionData]="actionData"
+                    (actionCalled)="handleAction($event)"
+                  >
+                    <div class="wrapper-content">
+                      @if (actionData.ngIconName) {
+                        <mat-icon [matTooltip]="actionData.tooltip ?? 'action'">
+                          {{ actionData.ngIconName }}
+                        </mat-icon>
+                      }
+                      <span>{{ actionData.text }}</span>
+                    </div>
+                  </app-action-button>
+                }
+              }
+            } @else {
+              <button mat-icon-button [matMenuTriggerFor]="actionMenu">
+                <mat-icon>more_vert</mat-icon>
+              </button>
+              <mat-menu #actionMenu="matMenu">
+                <div mat-menu-content>
+                  @for (actionData of actionDatas(); track actionData.id) {
+                    @if (isVisible(actionData, item)) {
+                      <a mat-menu-item>
+                        @if (!hasTextAttribute()) {
+                          <app-action-button
+                            [item]="item"
+                            [actionData]="actionData"
+                            (actionCalled)="handleAction($event)"
+                          >
+                            @if (!actionData.text && actionData.ngIconName) {
+                              <mat-icon
+                                [matTooltip]="actionData.tooltip ?? 'action'"
+                              >
+                                {{ actionData.ngIconName }}
+                              </mat-icon>
+                            }
+                            @if (actionData.text && !actionData.ngIconName) {
+                              <span>{{ actionData.text }}</span>
+                            }
+                          </app-action-button>
+                        } @else {
+                          <app-action-button
+                            [item]="item"
+                            [actionData]="actionData"
+                            (actionCalled)="handleAction($event)"
+                          >
+                            <div class="wrapper-content">
+                              @if (actionData.ngIconName) {
+                                <mat-icon
+                                  [matTooltip]="actionData.tooltip ?? 'action'"
+                                >
+                                  {{ actionData.ngIconName }}
+                                </mat-icon>
+                              }
+                              <span>{{ actionData.text }}</span>
+                            </div>
+                          </app-action-button>
+                        }
+                      </a>
+                    }
+                  }
                 </div>
-              </app-action-button>
-            </mat-menu>
-          }
-        </td>
-      </ng-container>
+              </mat-menu>
+            }
+          </td>
+        </ng-container>
+      }
 
       <tr
         mat-header-row

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.spec.ts
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.spec.ts
@@ -72,7 +72,7 @@ describe('TableWithActionsComponent', () => {
 
     component.items = mockItems;
     component.columns = mockColumns;
-    component.actionDatas = mockActionDatas;
+    fixture.componentRef.setInput('actionDatas', mockActionDatas);
 
     fixture.detectChanges();
   });

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.ts
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.ts
@@ -8,6 +8,7 @@ import {
   EventEmitter,
   TemplateRef,
   CUSTOM_ELEMENTS_SCHEMA,
+  input,
 } from '@angular/core';
 
 import { MatButtonModule } from '@angular/material/button';
@@ -27,7 +28,6 @@ import {
 import { EventAction } from '../../../core/models/load';
 import { Column } from '../list/types/column';
 import { MapClass } from '../list/types/class';
-
 import { ActionButtonComponent } from '../buttons/action-button/action-button.component';
 
 @Component({
@@ -60,7 +60,7 @@ export class TableWithActionsComponent<T extends object> implements OnInit {
     TemplateRef<unknown>
   >();
   @Input() columnTemplates: Column<T>[] = [];
-  @Input() actionDatas: ActionDatas = [];
+  actionDatas = input.required<ActionDatas>();
   @Input() mapClass?: MapClass;
 
   @Output() actionCalled = new EventEmitter<EventAction>();
@@ -98,19 +98,11 @@ export class TableWithActionsComponent<T extends object> implements OnInit {
       columnKeys = columnKeys.concat(this.columnTemplates.map(ct => ct.key));
     }
 
-    if (this.getTotalActionDatas() > 0) {
+    if (this.actionDatas().length > 0) {
       columnKeys = columnKeys.concat(this.actionColumns);
     }
 
     return columnKeys;
-  }
-
-  getActionDatas() {
-    return this.actionDatas;
-  }
-
-  getTotalActionDatas() {
-    return this.getActionDatas().length;
   }
 
   getTotalTemplateColumns() {
@@ -148,7 +140,7 @@ export class TableWithActionsComponent<T extends object> implements OnInit {
   }
 
   hasTextAttribute() {
-    return this.actionDatas.some(
+    return this.actionDatas().some(
       (actionData: ActionData) => 'text' in actionData
     );
   }


### PR DESCRIPTION
## Description
Changed the table on /evaluation-process. Now, on the Actions column is expected to have one icon if the list of actions has length 1. If more, a button will be shown. When clicked the list of actions will be displayed.
<img width="1616" height="536" alt="table" src="https://github.com/user-attachments/assets/b8f06fc0-9d95-4065-9b88-cb5c2ce40c84" />


## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


