### PR TITLE
fix(BF-716): show chart's legend when have a single series

### DIFF
--- a/src/app/core/utils/apex-chart/heat-map-config.ts
+++ b/src/app/core/utils/apex-chart/heat-map-config.ts
@@ -39,6 +39,12 @@ export function GetChartOptions(
         },
       },
     },
+    legend: {
+      show: true,
+      showForSingleSeries: true,
+      position: 'top',
+      horizontalAlign: 'center',
+    },
     title: {
       text: title,
     },
@@ -54,6 +60,7 @@ export function GetChartOptions(
     plotOptions: {
       heatmap: {
         distributed: false,
+        // enableShades: false,
         ...(fixColors && {
           colorScale: {
             inverse: false,

--- a/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.html
+++ b/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.html
@@ -51,6 +51,7 @@
             [plotOptions]="chartOption.plotOptions!"
             [title]="chartOption.title!"
             [tooltip]="chartOption.tooltip!"
+            [legend]="chartOption.legend!"
           >
           </apx-chart>
         </div>


### PR DESCRIPTION
## Description

Show chart's legend when we have a single series


## Type of change

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#716 
