### PR TITLE
fix: use Math.floor instead of Math.trunc for consistent risk level g…

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts/dynamic-column-chart/dynamic-column-chart.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts/dynamic-column-chart/dynamic-column-chart.component.ts
@@ -155,7 +155,7 @@ export class DynamicColumnChartComponent {
   private _getAnswersRisks(questions: PollCountQuestion[], riskLevel: number) {
     return questions.map(question => {
       const filteredAnswers = question.answers.filter(
-        answer => Math.trunc(answer.answerRisk) === riskLevel
+        answer => Math.floor(answer.answerRisk) === riskLevel
       );
 
       const totalCount = filteredAnswers.reduce(


### PR DESCRIPTION

## Description

### Problem
Students with decimal risk scores (e.g. 2.5, 4.3) were not showing up 
in the detail modal when clicking a chart column. The chart was grouping 
them correctly visually but the detail list appeared empty.

### Root Cause
`_getAnswersRisks` was using `Math.trunc` to group students by risk level, 
but the rest of the system (riskLevel.ts constants) uses `Math.round`. 
This mismatch caused the frontend to send a rounded risk level to the 
backend that didn't match how the student was grouped in the chart.

### Fix
Replaced `Math.trunc` with `Math.floor` in `_getAnswersRisks` inside 
`dynamic-column-chart.component.ts` to keep the original grouping behavior 
(decimals always go to the lower integer) while being consistent with 
what is sent to the backend.

### Files changed
- `ERAS-FE/src/app/modules/reports/components/dynamic-column-chart/dynamic-column-chart.component.ts`


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


