### PR TITLE
Fix(fe 745): Add pagination for students lists

### DIFF
--- a/src/app/core/services/api/evaluation-details.service.ts
+++ b/src/app/core/services/api/evaluation-details.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BaseApiService } from './base-api.service';
 import { HttpParams } from '@angular/common/http';
 import { EvaluationDetailsStudentResponse } from '@core/models/evaluation-details-student.model';
+import { PagedResult } from '../interfaces/page.type';
 
 @Injectable({
   providedIn: 'root',
@@ -14,9 +15,14 @@ export class EvaluationDetailsService extends BaseApiService {
     componentNames: string[],
     cohortIds: number[],
     variableIds: number[],
+    pageSize: number,
+    page: number,
     riskLevels?: number[]
   ) {
-    let params = new HttpParams().set('PollUuid', pollUuid);
+    let params = new HttpParams()
+      .set('PollUuid', pollUuid)
+      .set('PageSize', pageSize.toString())
+      .set('Page', page.toString());
 
     const appendArray = (name: string, items: (string | number)[]) => {
       if (items && items.length > 0) {
@@ -37,7 +43,7 @@ export class EvaluationDetailsService extends BaseApiService {
       appendArray('RiskLevels', riskLevels);
     }
 
-    return this.get<EvaluationDetailsStudentResponse[]>(
+    return this.get<PagedResult<EvaluationDetailsStudentResponse>>(
       `StudentsByFilters`,
       params
     );

--- a/src/app/core/services/api/student.service.ts
+++ b/src/app/core/services/api/student.service.ts
@@ -85,22 +85,37 @@ export class StudentService extends BaseApiService {
     pollUuid: string,
     componentName: string,
     cohortId: number,
-    lastVersion: boolean
+    lastVersion: boolean,
+    pageSize: number,
+    page: number
   ) {
-    return this.get<StudentRiskResponse[]>(
+    return this.get<PagedResult<StudentRiskResponse>>(
       `polls/${pollUuid}/components/top`,
       new HttpParams()
         .set('componentName', componentName)
         .set('cohortId', cohortId)
         .set('LastVersion', lastVersion)
+        .set('PageSize', pageSize.toString())
+        .set('Page', page.toString())
     );
   }
 
-  getPollTopStudents(pollUuid: string, cohortId: number, lastVersion: boolean) {
+  getPollTopStudents(
+    pollUuid: string,
+    cohortId: number,
+    lastVersion: boolean,
+    pageSize: number,
+    page: number
+  ) {
     const params = new HttpParams()
       .set('CohortId', cohortId)
-      .set('LastVersion', lastVersion);
-    return this.get<StudentRiskResponse[]>(`polls/${pollUuid}/top`, params);
+      .set('LastVersion', lastVersion)
+      .set('PageSize', pageSize.toString())
+      .set('Page', page.toString());
+    return this.get<PagedResult<StudentRiskResponse>>(
+      `polls/${pollUuid}/top`,
+      params
+    );
   }
 
   getPollStudentsRiskSum(pollUuid: string, cohortId: number) {
@@ -135,13 +150,17 @@ export class StudentService extends BaseApiService {
   getTopRiskStudentsByComponent(
     pollUuid: string,
     componentName: string,
-    cohortId: number
+    cohortId: number,
+    pageSize: number,
+    page: number
   ) {
     return this.get<StudentRiskResponse[]>(
       `/polls/${pollUuid}/components/top`,
       new HttpParams()
         .set('ComponentName', componentName)
         .set('CohortId', cohortId)
+        .set('PageSize', pageSize.toString())
+        .set('Page', page.toString())
     );
   }
 }

--- a/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
+++ b/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
@@ -114,14 +114,15 @@ export default class RiskDetailsComponent {
         pollInstanceUUID,
         [this.data.data.componentName.toLowerCase()],
         this.data.data.cohorts,
-        [this.variableId]
+        [this.variableId],
+        this.pagination.pageSize,
+        this.pagination.page
       )
       .subscribe(data => {
-        this.riskStudentData.set(risk.position, {
-          items: data || [],
-          total: data.length || 0,
-        });
-        this.totalStudentRisks.set(data.length);
+        const items = data?.items ?? [];
+        const total = data?.count ?? 0;
+        this.riskStudentData.set(risk.position, { items, total });
+        this.totalStudentRisks.set(total);
       });
   }
 

--- a/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.html
+++ b/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.html
@@ -130,7 +130,7 @@
               [columnTemplates]="columnTemplates"
               [actionDatas]="actionDatas"
               [items]="filteredStudents"
-              [totalItems]="filteredStudents.length"
+              [totalItems]="totalStudents"
               [title]="'Top Risk Students'"
             >
               <ng-template #riskSum let-item>
@@ -162,7 +162,9 @@
             </mat-expansion-panel-header>
             <div>
               <app-list
-                (loadCalled)="handleLoad()"
+                (loadCalled)="
+                  handleLoadComponent($event, component.key.toLowerCase())
+                "
                 (actionCalled)="handleActionCalled($event)"
                 [mapClass]="mapClass"
                 [columns]="columns"

--- a/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.html
+++ b/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.html
@@ -173,10 +173,7 @@
                 [items]="
                   componentStudentRisk[component.key.toLowerCase()] || []
                 "
-                [totalItems]="
-                  (componentStudentRisk[component.key.toLowerCase()] || [])
-                    .length
-                "
+                [totalItems]="totalStudentsComponent"
               >
                 <ng-template #riskSum let-item>
                   <app-badge-risk-level [riskLevel]="item.riskSum" />

--- a/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.ts
+++ b/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.ts
@@ -94,6 +94,7 @@ export class StudentDetailOptionComponent implements OnInit {
   cohorts: CohortComponents[] = [];
   pagination = { page: 0, pageSize: 10 };
   totalStudents = 0;
+  totalStudentsComponent = 0;
   readonly panelOpenState = signal(false);
   riskStudentsDetail: StudentRiskResponse[] = [];
   filteredStudents = [...this.riskStudentsDetail];
@@ -228,6 +229,7 @@ export class StudentDetailOptionComponent implements OnInit {
       )
       .subscribe(data => {
         this.componentStudentRisk[componentKey] = data.items;
+        this.totalStudentsComponent = data.count;
         this.cdr.detectChanges();
       });
   }

--- a/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.ts
+++ b/src/app/modules/student-monitoring/student-detail-option/student-detail-option.component.ts
@@ -92,6 +92,8 @@ export class StudentDetailOptionComponent implements OnInit {
   polls: PollModel[] = [];
   studentRisk: StudentRiskResponse[] = [];
   cohorts: CohortComponents[] = [];
+  pagination = { page: 0, pageSize: 10 };
+  totalStudents = 0;
   readonly panelOpenState = signal(false);
   riskStudentsDetail: StudentRiskResponse[] = [];
   filteredStudents = [...this.riskStudentsDetail];
@@ -220,10 +222,12 @@ export class StudentDetailOptionComponent implements OnInit {
         this.pollSelected.uuid,
         componentKey,
         this.cohortSelected.cohortId,
-        this.lastVersion
+        this.lastVersion,
+        this.pagination.pageSize,
+        this.pagination.page
       )
       .subscribe(data => {
-        this.componentStudentRisk[componentKey] = data;
+        this.componentStudentRisk[componentKey] = data.items;
         this.cdr.detectChanges();
       });
   }
@@ -269,11 +273,14 @@ export class StudentDetailOptionComponent implements OnInit {
       .getPollTopStudents(
         this.pollSelected.uuid,
         this.cohortSelected.cohortId,
-        this.lastVersion
+        this.lastVersion,
+        this.pagination.pageSize,
+        this.pagination.page
       )
       .subscribe({
         next: data => {
-          this.riskStudentsDetail = data;
+          this.riskStudentsDetail = data.items;
+          this.totalStudents = data.count;
           this.updateTable();
         },
         error: error => {
@@ -298,11 +305,14 @@ export class StudentDetailOptionComponent implements OnInit {
         .getPollTopStudents(
           this.pollSelected.uuid,
           this.cohortSelected.cohortId,
-          this.lastVersion
+          this.lastVersion,
+          this.pagination.pageSize,
+          this.pagination.page
         )
         .subscribe({
           next: data => {
-            this.riskStudentsDetail = data;
+            this.riskStudentsDetail = data.items;
+            this.totalStudents = data.count;
             this.updateTable();
           },
           error: error => {

--- a/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.html
+++ b/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.html
@@ -29,13 +29,13 @@
         <div class="custom-divider"></div>
         <app-list
           [mapClass]="mapClass"
-          (loadCalled)="handleLoad()"
+          (loadCalled)="handleLoad($event)"
           (actionCalled)="handleActionCalled($event)"
           [columns]="columns"
           [columnTemplates]="columnTemplates"
           [actionDatas]="actionDatas"
           [items]="filteredStudents"
-          [totalItems]="filteredStudents.length"
+          [totalItems]="totalStudents"
           [title]="'Top Risk Students'"
         >
           <ng-template #riskSum let-item>
@@ -67,7 +67,9 @@
 
           <div>
             <app-list
-              (loadCalled)="handleLoad()"
+              (loadCalled)="
+                handleLoadComponent($event, component.key.toLowerCase())
+              "
               (actionCalled)="handleActionCalled($event)"
               [mapClass]="mapClass"
               [columns]="columns"

--- a/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.html
+++ b/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.html
@@ -76,9 +76,7 @@
               [columnTemplates]="columnTemplates"
               [actionDatas]="actionDatas"
               [items]="componentStudentRisk[component.key.toLowerCase()] || []"
-              [totalItems]="
-                (componentStudentRisk[component.key.toLowerCase()] || []).length
-              "
+              [totalItems]="totalStudentsComponent"
             >
               <ng-template #riskSum let-item>
                 <app-badge-risk-level [riskLevel]="item.riskSum" />

--- a/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.ts
+++ b/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.ts
@@ -25,11 +25,12 @@ import { PollService } from '@core/services/api/poll.service';
 import { PollInstanceService } from '@core/services/api/poll-instance.service';
 import { StudentService } from '@core/services/api/student.service';
 import { toSentenceCase } from '@core/utils/helpers/string-utils';
-import { EventAction } from '@core/models/load';
+import { EventAction, EventLoad } from '@core/models/load';
 import { ModalStudentDetailComponent } from '@shared/components/modals/modal-student-detail/modal-student-detail.component';
 import { MapClass } from '@shared/components/list/types/class';
 import { ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Pagination } from '@core/services/interfaces/server.type';
 
 @Component({
   selector: 'app-student-monitoring-details',
@@ -67,7 +68,7 @@ export class StudentMonitoringDetailsComponent implements OnInit {
   riskStudentsDetail: StudentRiskResponse[] = [];
   filteredStudents: StudentRiskResponse[] = [];
   studentRisk: StudentRiskResponse[] = [];
-
+  private listInitialized = false;
   public chartOptions: ApexOptions = {
     chart: {
       type: 'donut',
@@ -127,6 +128,11 @@ export class StudentMonitoringDetailsComponent implements OnInit {
   quantities = [3, 5, 10, 15, 20];
   selectedQuantity = 3;
   polls: PollModel[] = [];
+  pagination: Pagination = {
+    page: 0,
+    pageSize: 10,
+  };
+  totalStudents = 0;
 
   constructor(
     private route: ActivatedRoute,
@@ -215,9 +221,16 @@ export class StudentMonitoringDetailsComponent implements OnInit {
     const cohortId = this.cohortSelected?.cohortId;
     if (!uuid || cohortId === undefined) return;
     this.studentService
-      .getPollTopStudents(uuid, cohortId, this.lastVersion)
+      .getPollTopStudents(
+        uuid,
+        cohortId,
+        this.lastVersion,
+        this.pagination.pageSize,
+        this.pagination.page
+      )
       .subscribe(data => {
-        this.riskStudentsDetail = data;
+        this.riskStudentsDetail = data.items;
+        this.totalStudents = data.count;
         this.updateTable();
       });
   }
@@ -248,34 +261,55 @@ export class StudentMonitoringDetailsComponent implements OnInit {
         this.pollSelected.uuid,
         componentKey,
         this.cohortSelected.cohortId,
-        this.lastVersion
+        this.lastVersion,
+        10,
+        0
       )
       .subscribe(data => {
-        this.componentStudentRisk[componentKey] = data;
+        this.componentStudentRisk[componentKey] = data.items;
         this.cdr.detectChanges();
       });
   }
-
-  handleLoad(): void {
+  handleLoad(event: EventLoad): void {
     if (!this.pollSelected || !this.cohortSelected) return;
-
+    if (!this.listInitialized) {
+      this.listInitialized = true;
+      return;
+    }
+    this.pagination = { page: event.page, pageSize: event.pageSize };
     this.studentService
       .getPollTopStudents(
         this.pollSelected.uuid,
         this.cohortSelected.cohortId,
-        this.lastVersion
+        this.lastVersion,
+        this.pagination.pageSize,
+        this.pagination.page
       )
       .subscribe(data => {
-        this.riskStudentsDetail = data;
+        this.riskStudentsDetail = data.items;
+        this.totalStudents = data.count;
         this.updateTable();
       });
   }
 
+  handleLoadComponent(event: EventLoad, componentKey: string): void {
+    this.studentService
+      .getPollComponentTopStudents(
+        this.pollSelected!.uuid,
+        componentKey,
+        this.cohortSelected!.cohortId,
+        this.lastVersion,
+        event.pageSize,
+        event.page
+      )
+      .subscribe(data => {
+        this.componentStudentRisk[componentKey] = data.items;
+        this.cdr.detectChanges();
+      });
+  }
+
   updateTable(): void {
-    this.filteredStudents = this.riskStudentsDetail.slice(
-      0,
-      this.selectedQuantity
-    );
+    this.filteredStudents = this.riskStudentsDetail;
   }
 
   handleActionCalled(event: EventAction) {

--- a/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.ts
+++ b/src/app/modules/student-monitoring/student-monitoring-details/student-monitoring-details.component.ts
@@ -133,6 +133,7 @@ export class StudentMonitoringDetailsComponent implements OnInit {
     pageSize: 10,
   };
   totalStudents = 0;
+  totalStudentsComponent = 0;
 
   constructor(
     private route: ActivatedRoute,
@@ -267,6 +268,7 @@ export class StudentMonitoringDetailsComponent implements OnInit {
       )
       .subscribe(data => {
         this.componentStudentRisk[componentKey] = data.items;
+        this.totalStudentsComponent = data.count;
         this.cdr.detectChanges();
       });
   }
@@ -304,6 +306,7 @@ export class StudentMonitoringDetailsComponent implements OnInit {
       )
       .subscribe(data => {
         this.componentStudentRisk[componentKey] = data.items;
+        this.totalStudentsComponent = data.count;
         this.cdr.detectChanges();
       });
   }

--- a/src/app/shared/components/modals/modal-question-details/modal-question-details.component.ts
+++ b/src/app/shared/components/modals/modal-question-details/modal-question-details.component.ts
@@ -135,11 +135,15 @@ export class ModalQuestionDetailsComponent implements AfterViewInit {
         [this.inputQuestion.componentName.toLowerCase()],
         this.inputQuestion.cohortId.split(',').map(id => Number(id.trim())),
         [this.variableId],
+        this.pagination.pageSize,
+        this.pagination.page,
         [this.inputQuestion.riskLevel!]
       )
       .subscribe(data => {
-        this.studentList.set(data);
-        this.totalStudentRisks.set(data.length);
+        const items = data?.items ?? [];
+        const total = data?.count ?? items.length;
+        this.studentList.set(items);
+        this.totalStudentRisks.set(total);
       });
   }
 


### PR DESCRIPTION
## Description

### Problem
The pagination to watch and manipulate the list of students in monitoring students, dynamic heatmap chart, dynamic column chart and summary column chart did not work correctly, always it displayed all values in the list.

### Root Cause
GetStudentsByFilters, GetCohortTopRiskStudents and GetCohortTopRiskStudentsByComponent did not return Page and PageSize, and the query params were not passed in the service.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues
#745 

