### PR TITLE
Fix for issue 655: summary charts display student lists

### DIFF
--- a/src/app/core/services/api/student.service.ts
+++ b/src/app/core/services/api/student.service.ts
@@ -37,20 +37,20 @@ export class StudentService extends BaseApiService {
     pageSize,
     cohortIds,
     pollUuid,
-    // lastVersion,
+    lastVersion,
   }: {
     cohortIds: number[];
     page: number;
     pageSize: number;
     pollUuid: string;
-    // lastVersion: boolean;
+    lastVersion: boolean;
   }) {
     const params = new HttpParams()
       .set('cohortIds', this.arrayAsStringParams(cohortIds))
       .set('pollUuid', pollUuid)
       .set('page', page)
-      .set('pageSize', pageSize);
-    // .set('lastVersion', lastVersion);
+      .set('pageSize', pageSize)
+      .set('lastVersion', lastVersion);
     return this.get<PagedResult<StudentRiskAverage>>('average', params).pipe(
       map(result => {
         result.items = sortArray(result.items, 'studentName');

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -69,6 +69,7 @@ export class PollFiltersComponent implements OnInit {
     uuid: string;
     cohortIds: number[];
     variableIds: number[];
+    lastVersion: boolean;
   }>();
 
   filterForm = new FormGroup({
@@ -267,7 +268,8 @@ export class PollFiltersComponent implements OnInit {
     const uuid = this.filterForm.value.selectedPoll?.uuid || '';
     const cohortIds = this.filterForm.value.cohortIds!.filter(Boolean);
     const variableIds = this.filterForm.value.variables || [];
+    const lastVersion = true;
 
-    this.filters.emit({ title, uuid, cohortIds, variableIds });
+    this.filters.emit({ title, uuid, cohortIds, variableIds, lastVersion });
   }
 }

--- a/src/app/modules/reports/components/poll-filters/types/filters.ts
+++ b/src/app/modules/reports/components/poll-filters/types/filters.ts
@@ -3,6 +3,7 @@ export interface Filter {
   uuid: string;
   cohortIds: number[];
   variableIds: number[];
+  lastVersion: boolean;
 }
 
 export type FormKey =

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
@@ -216,7 +216,7 @@ export class PollsAnsweredComponent implements OnInit {
   handleFilterSelect(filters: Filter) {
     this.selectedPollUuid = filters.uuid;
     this.selectedCohortIds = filters.cohortIds;
-    // this.lastVersion = filters.lastVersion;
+    this.lastVersion = filters.lastVersion;
     this.loading = true;
     this.load();
   }

--- a/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
+++ b/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
@@ -8,11 +8,7 @@ import { ActionDatas } from '@shared/components/list/types/action';
 import { Column } from '@shared/components/list/types/column';
 import { EventAction, EventLoad } from '@core/models/load';
 import { Pagination } from '@core/services/interfaces/server.type';
-import {
-  PollAvgQuestion,
-  PollTopReport,
-  StudentReportAnswerRiskLevel,
-} from '@core/models/summary.model';
+import { PollAvgQuestion, PollTopReport } from '@core/models/summary.model';
 
 import { PollService } from '@core/services/api/poll.service';
 import { ReportService } from '@core/services/api/report.service';
@@ -134,15 +130,15 @@ export default class RiskDetailsComponent {
   handleActionCalled(event: EventAction) {
     const actions: Record<
       string,
-      (item: StudentReportAnswerRiskLevel) => void
+      (item: EvaluationDetailsStudentResponse) => void
     > = {
-      openStudentDetails: (element: StudentReportAnswerRiskLevel) => {
-        this.openStudentDetails(element.studentId);
+      openStudentDetails: (element: EvaluationDetailsStudentResponse) => {
+        this.openStudentDetails(element.id);
       },
     };
 
     if (actions[event.data.id]) {
-      actions[event.data.id](event.item as StudentReportAnswerRiskLevel);
+      actions[event.data.id](event.item as EvaluationDetailsStudentResponse);
     }
   }
 

--- a/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
+++ b/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
@@ -119,7 +119,12 @@ export default class RiskDetailsComponent {
         this.pagination.page
       )
       .subscribe(data => {
-        const items = data?.items ?? [];
+        const items = (data?.items ?? []).sort((a, b) => {
+          if (b.riskLevel !== a.riskLevel) {
+            return b.riskLevel - a.riskLevel;
+          }
+          return a.answerText.localeCompare(b.answerText);
+        });
         const total = data?.count ?? 0;
         this.riskStudentData.set(risk.position, { items, total });
         this.totalStudentRisks.set(total);

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
@@ -97,7 +97,7 @@ describe('SummaryChartsComponent', () => {
       pollUuid: 'poll-uuid',
       page: 0,
       pageSize: 10,
-      // lastVersion: true,
+      lastVersion: true,
     });
     expect(component.students).toEqual(mockStudents.items);
     expect(component.totalStudents).toBe(1);

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
@@ -122,7 +122,7 @@ export class SummaryChartsComponent {
           pageSize: event.pageSize,
           cohortIds: this.cohortIds,
           pollUuid: this.pollUuid,
-          // lastVersion: this.lastVersion,
+          lastVersion: this.lastVersion,
         })
         .subscribe(response => {
           this.students = response.items;
@@ -251,7 +251,7 @@ export class SummaryChartsComponent {
     this.cohortIds = filters.cohortIds;
     this.title = filters.title;
     this.pollUuid = filters.uuid;
-    // this.lastVersion = filters.lastVersion;
+    this.lastVersion = filters.lastVersion;
     this.getStudentsByCohortAndPoll({ pageSize: 10, page: 0 });
     this.getHeatMap();
   }

--- a/src/app/shared/components/modals/modal-question-details/modal-question-details.component.ts
+++ b/src/app/shared/components/modals/modal-question-details/modal-question-details.component.ts
@@ -137,10 +137,17 @@ export class ModalQuestionDetailsComponent implements AfterViewInit {
         [this.variableId],
         this.pagination.pageSize,
         this.pagination.page,
-        [this.inputQuestion.riskLevel!]
+        this.inputQuestion.riskLevel
+          ? [this.inputQuestion.riskLevel]
+          : undefined
       )
       .subscribe(data => {
-        const items = data?.items ?? [];
+        const items = (data?.items ?? []).sort((a, b) => {
+          if (b.riskLevel !== a.riskLevel) {
+            return b.riskLevel - a.riskLevel;
+          }
+          return a.answerText.localeCompare(b.answerText);
+        });
         const total = data?.count ?? items.length;
         this.studentList.set(items);
         this.totalStudentRisks.set(total);


### PR DESCRIPTION
## Description

The summary heatmap did not display any student in the modals and when a student was selected to view details it did not show any information in Risk By Components and Student Answers

### Cause:

LastVersion param was commented and the student list was not returning the model of response defined.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [x] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#655 

