### PR TITLE
Fix(FE-692): Poll and evaluation dropdowns with dynamic changes in chart and display all evaluations

### DIFF
--- a/src/app/core/services/api/evaluations.service.ts
+++ b/src/app/core/services/api/evaluations.service.ts
@@ -24,7 +24,7 @@ export class EvaluationsService extends BaseApiService {
   getAllEvalProc(pagination?: Pagination) {
     let params = undefined;
 
-    if (pagination && pagination.page && pagination.pageSize) {
+    if (pagination) {
       params = new HttpParams()
         .set('PageSize', pagination.pageSize)
         .set('Page', pagination.page);

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
@@ -18,7 +18,6 @@
   [items]="evaluationProcessList"
   [totalItems]="totalEvaluations"
   [actionDatas]="actionDatas"
-  [pageIndex]="currentPage"
 >
   <ng-template #status let-element>
     <app-badge-status [element]="element" />

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -32,6 +32,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { RouteDataService } from '@core/services/route-data.service';
 import { ModalImportAnswersFormComponent } from '@modules/lists/components/modal-import-answers-form/modal-import-answers-form.component';
 import { PreselectedPoll } from '@modules/imports/models/preselected-poll';
+import { Pagination } from '@core/services/interfaces/server.type';
 
 @Component({
   selector: 'app-evaluation-process-list',
@@ -104,12 +105,14 @@ export class EvaluationProcessListComponent implements OnInit {
     },
   ];
   evaluationProcessList: EvaluationModel[] = [];
-  pageSize = 5;
-  currentPage = 0;
   totalEvaluations = 0;
   isMobile = false;
   isLoading = false;
   importPollsDisabled = [Status.INCOMPLETE, Status.NOT_STARTED];
+  pagination: Pagination = {
+    page: 0,
+    pageSize: 10,
+  };
 
   @HostListener('window:resize', ['$event'])
   onResize(event: UIEvent): void {
@@ -122,8 +125,10 @@ export class EvaluationProcessListComponent implements OnInit {
   }
 
   handleLoadCalled(event: EventLoad) {
-    this.currentPage = event.page;
-    this.pageSize = event.pageSize;
+    this.pagination = {
+      page: event.page,
+      pageSize: event.pageSize,
+    };
     this.getEvaluationProcess();
   }
 
@@ -176,39 +181,24 @@ export class EvaluationProcessListComponent implements OnInit {
         },
       });
   }
-  onPageChange({
-    pageSize,
-    pageIndex,
-  }: {
-    pageIndex: number;
-    pageSize: number;
-  }): void {
-    this.currentPage = pageIndex;
-    this.pageSize = pageSize;
-    this.getEvaluationProcess();
-  }
+
   getEvaluationProcess() {
     this.isLoading = true;
-    this.evaluationProcessService
-      .getAllEvalProc({
-        page: this.currentPage,
-        pageSize: this.pageSize,
-      })
-      .subscribe({
-        next: (data: PagedReadEvaluationProcess) => {
-          this.evaluationProcessList = this.normalizeData(data.items);
-          this.totalEvaluations = data.count;
-          this.isLoading = false;
-        },
-        error: err => {
-          this.openAlertDialog(
-            'Error: An error occurred while trying to access information : ' +
-              err.message,
-            'error'
-          );
-          this.isLoading = false;
-        },
-      });
+    this.evaluationProcessService.getAllEvalProc(this.pagination).subscribe({
+      next: (data: PagedReadEvaluationProcess) => {
+        this.evaluationProcessList = this.normalizeData(data.items);
+        this.totalEvaluations = data.count;
+        this.isLoading = false;
+      },
+      error: err => {
+        this.openAlertDialog(
+          'Error: An error occurred while trying to access information : ' +
+            err.message,
+          'error'
+        );
+        this.isLoading = false;
+      },
+    });
   }
 
   openModalNewEvaluationProcess(): void {
@@ -331,10 +321,12 @@ export class EvaluationProcessListComponent implements OnInit {
 
   private _updatePaginator() {
     this.totalEvaluations = Math.max(0, this.totalEvaluations - 1);
-    const totalPages = Math.ceil(this.totalEvaluations / this.pageSize);
+    const totalPages = Math.ceil(
+      this.totalEvaluations / this.pagination.pageSize
+    );
 
-    if (this.currentPage >= totalPages && this.currentPage > 0) {
-      this.currentPage -= 1;
+    if (this.pagination.page >= totalPages && this.pagination.page > 0) {
+      this.pagination.page -= 1;
     }
   }
 }

--- a/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.html
+++ b/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.html
@@ -2,74 +2,76 @@
 <h2 class="page-subtitle">{{ title }}</h2>
 <app-poll-filters (filters)="handleFilterSelect($event)"></app-poll-filters>
 
-@defer (when isLoading) {
-  <ng-container>
-    <div class="action-section">
-      <button
-        id="print-button"
-        class="export-button"
-        matTooltip="Download pdf"
-        mat-icon-button
-        color="primary"
-        [disabled]="!chartsOptions.length || isGeneratingPDF"
-        (click)="exportReportPdf()"
-      >
-        <mat-icon>print</mat-icon>
-      </button>
-      <button
-        matButton
-        [matMenuTriggerFor]="beforeMenu"
-        class="export-button"
-        matTooltip="Charts"
-        mat-icon-button
-        color="primary"
-        [disabled]="!chartsOptions.length || isGeneratingPDF"
-      >
-        <mat-icon>bar_chart</mat-icon>
-      </button>
-      <mat-menu #beforeMenu="matMenu" xPosition="before">
-        <button mat-menu-item (click)="toggleChart('heatmap')">
-          Heatmap Chart
-        </button>
-        <button mat-menu-item (click)="toggleChart('chart')">
-          Column Chart
-        </button>
-      </mat-menu>
-    </div>
-  </ng-container>
-
-  @if (heatmapChart) {
-    <div #contentToExport>
-      @for (chartOption of chartsOptions; track $index) {
-        <div class="chart-container">
-          <apx-chart
-            [series]="chartOption.series!"
-            [chart]="chartOption.chart!"
-            [xaxis]="chartOption.xaxis!"
-            [yaxis]="chartOption.yaxis!"
-            [colors]="chartOption.colors!"
-            [plotOptions]="chartOption.plotOptions!"
-            [title]="chartOption.title!"
-            [tooltip]="chartOption.tooltip!"
-            [legend]="chartOption.legend!"
-          >
-          </apx-chart>
-        </div>
-      }
-    </div>
-  } @else {
-    <div #contentToExport>
-      <app-dynamic-column-chart
-        [components]="components()!"
-        [identifier]="uuid!"
-        [cohortsIds]="cohortIds"
-      ></app-dynamic-column-chart>
-    </div>
-  }
-} @loading {
-  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-} @placeholder {
+@if (showEmpty) {
   <app-empty-data-message
     description="Please select the required fields to generate the charts."
   />
+} @else if (isLoading) {
+  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+} @else {
+  @defer {
+    <ng-container>
+      <div class="action-section">
+        <button
+          id="print-button"
+          class="export-button"
+          matTooltip="Download pdf"
+          mat-icon-button
+          color="primary"
+          [disabled]="!chartsOptions.length || isGeneratingPDF"
+          (click)="exportReportPdf()"
+        >
+          <mat-icon>print</mat-icon>
+        </button>
+        <button
+          matButton
+          [matMenuTriggerFor]="beforeMenu"
+          class="export-button"
+          matTooltip="Charts"
+          mat-icon-button
+          color="primary"
+          [disabled]="!chartsOptions.length || isGeneratingPDF"
+        >
+          <mat-icon>bar_chart</mat-icon>
+        </button>
+        <mat-menu #beforeMenu="matMenu" xPosition="before">
+          <button mat-menu-item (click)="toggleChart('heatmap')">
+            Heatmap Chart
+          </button>
+          <button mat-menu-item (click)="toggleChart('chart')">
+            Column Chart
+          </button>
+        </mat-menu>
+      </div>
+    </ng-container>
+
+    @if (heatmapChart) {
+      <div #contentToExport>
+        @for (chartOption of chartsOptions; track $index) {
+          <div class="chart-container">
+            <apx-chart
+              [series]="chartOption.series!"
+              [chart]="chartOption.chart!"
+              [xaxis]="chartOption.xaxis!"
+              [yaxis]="chartOption.yaxis!"
+              [colors]="chartOption.colors!"
+              [plotOptions]="chartOption.plotOptions!"
+              [title]="chartOption.title!"
+              [tooltip]="chartOption.tooltip!"
+              [legend]="chartOption.legend!"
+            >
+            </apx-chart>
+          </div>
+        }
+      </div>
+    } @else {
+      <div #contentToExport>
+        <app-dynamic-column-chart
+          [components]="components()!"
+          [identifier]="uuid!"
+          [cohortsIds]="cohortIds"
+        ></app-dynamic-column-chart>
+      </div>
+    }
+  }
 }

--- a/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts/dynamic-charts.component.ts
@@ -183,6 +183,7 @@ export class DynamicChartsComponent {
     if (!filters.cohortIds || !filters.variableIds) {
       this.chartsOptions = [];
       this.components.set(null);
+      this.uuid = null;
       return;
     }
     this.generateHeatMap(filters.cohortIds, filters.variableIds);
@@ -215,5 +216,9 @@ export class DynamicChartsComponent {
 
   toggleChart(chart: string) {
     this.heatmapChart = chart === 'heatmap';
+  }
+
+  get showEmpty(): boolean {
+    return !this.uuid;
   }
 }

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -16,9 +16,11 @@
           (openedChange)="$event && onDropdownScroll()"
         >
           @for (evaluation of evaluations; track $index) {
-            <mat-option class="versioned-option" [value]="evaluation">
-              <p>{{ `${evaluation.name} - ${evaluation.status}`}}</p>
-            </mat-option>
+            @if (evaluation.status === 'Completed') {
+              <mat-option class="versioned-option" [value]="evaluation">
+                <p>{{ `${evaluation.name} - ${evaluation.status}`}}</p>
+              </mat-option>
+            }
           }
         </mat-select>
         @if (filterForm.get('selectedEvaluation')?.errors) {
@@ -26,26 +28,7 @@
         }
       </mat-form-field>
     }
-    @if (polls.length > 0) {
-      <mat-form-field appearance="fill">
-        <mat-label for="sl-poll">Poll</mat-label>
-        <mat-select
-          id="sl-poll"
-          formControlName="selectedPoll"
-          (selectionChange)="handlePollSelect($event)"
-        >
-          @for (poll of polls; track $index) {
-            <mat-option class="versioned-option" [value]="poll">
-              <p>{{ poll.name }}</p>
-            </mat-option>
-          }
-        </mat-select>
-        @if (filterForm.get('selectedPoll')?.errors) {
-          <mat-error>This field is required</mat-error>
-        }
-      </mat-form-field>
-    }
-    @if (filterForm.value.selectedPoll) {
+    @if (polls[0]) {
       <mat-form-field appearance="fill">
         <mat-label for="sl-cohort">Cohort</mat-label>
         <mat-select

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -13,6 +13,7 @@
           id="sl-evaluation"
           formControlName="selectedEvaluation"
           (selectionChange)="handleEvaluationSelect($event)"
+          (openedChange)="$event && onDropdownScroll()"
         >
           @for (evaluation of evaluations; track $index) {
             <mat-option class="versioned-option" [value]="evaluation">

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -103,6 +103,13 @@ export class PollFiltersComponent implements OnInit {
     this._resetField('selectedPoll');
     this._resetField('cohortIds');
     this._getPolls(newSelectedEvaluation);
+    this.filters.emit({
+      title: '',
+      uuid: '',
+      cohortIds: [],
+      variableIds: [],
+      lastVersion: false,
+    });
   }
 
   handlePollSelect(itemSelected: MatSelectChange) {

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -84,9 +84,6 @@ export class PollFiltersComponent implements OnInit {
     selectedEvaluation: new FormControl<EvaluationModel | null>(null, [
       Validators.required,
     ]),
-    selectedPoll: new FormControl<PollModel | null>(null, [
-      Validators.required,
-    ]),
     cohortIds: new FormControl<number[] | null>([], null),
     componentNames: new FormControl<string[] | null>(null, [
       Validators.required,
@@ -100,20 +97,10 @@ export class PollFiltersComponent implements OnInit {
 
   handleEvaluationSelect(itemSelected: MatSelectChange) {
     const newSelectedEvaluation: EvaluationModel = itemSelected.value;
-    this._resetField('selectedPoll');
     this._resetField('cohortIds');
     this._getPolls(newSelectedEvaluation);
-    this.filters.emit({
-      title: '',
-      uuid: '',
-      cohortIds: [],
-      variableIds: [],
-      lastVersion: false,
-    });
-  }
-
-  handlePollSelect(itemSelected: MatSelectChange) {
-    const newSelectedPoll = itemSelected.value;
+    const newSelectedPoll = this.polls[0];
+    if (!newSelectedPoll) return;
     this._getCohorts(newSelectedPoll.uuid);
   }
 
@@ -242,14 +229,14 @@ export class PollFiltersComponent implements OnInit {
   }
 
   private _getVariables() {
-    if (!this.filterForm.value.selectedPoll?.uuid) return;
+    if (!this.polls[0]?.uuid) return;
     this.componentNames = [];
     this.variables = [];
     this._resetField('variables');
 
     this.pollsService
       .getVariablesByComponents(
-        this.filterForm.value.selectedPoll.uuid,
+        this.polls[0].uuid,
         [...this.componentNames],
         true
       )
@@ -277,12 +264,10 @@ export class PollFiltersComponent implements OnInit {
 
   private _sendFilters() {
     if (!this.polls) return;
-    const poll = this.polls.find(
-      p => p.uuid === this.filterForm.value.selectedPoll?.uuid
-    );
+    const poll = this.polls.find(p => p.uuid === this.polls[0]?.uuid);
     const cohorts = this.filterForm.value.cohortIds || [];
     const title = `Poll: ${poll?.name} - Cohort(s): ${cohorts.map(cohortId => this.cohorts.find(c => c.id == cohortId)?.name)}`;
-    const uuid = this.filterForm.value.selectedPoll?.uuid || '';
+    const uuid = this.polls[0]?.uuid || '';
     const cohortIds = this.filterForm.value.cohortIds!.filter(Boolean);
     const variableIds = this.filterForm.value.variables || [];
     const lastVersion = true;

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -30,6 +30,7 @@ import { SelectedItemsComponent } from './selected-items/selected-items.componen
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EvaluationsService } from '@core/services/api/evaluations.service';
 import { EvaluationModel } from '@core/models/evaluation.model';
+import { Pagination } from '@core/services/interfaces/server.type';
 
 @Component({
   selector: 'app-poll-filters',
@@ -63,6 +64,13 @@ export class PollFiltersComponent implements OnInit {
   variableGroups: VariableModel[][] = [];
   variables: VariableModel[] = [];
   variablesClone: VariableModel[] = [];
+
+  pagination: Pagination = {
+    page: 0,
+    pageSize: 10,
+  };
+  isLoadingMore = false;
+  totalEvaluations = 0;
 
   filters = output<{
     title: string;
@@ -195,11 +203,13 @@ export class PollFiltersComponent implements OnInit {
 
   private _loadEvaluations() {
     this.evaluationsService
-      .getAllEvalProc()
+      .getAllEvalProc(this.pagination)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: evaluations => {
-          this.evaluations = evaluations.items;
+        next: result => {
+          this.evaluations = [...(this.evaluations ?? []), ...result.items];
+          this.totalEvaluations = result.count;
+          this.isLoadingMore = false;
         },
         error: () => (this.evaluations = null),
       });
@@ -271,5 +281,15 @@ export class PollFiltersComponent implements OnInit {
     const lastVersion = true;
 
     this.filters.emit({ title, uuid, cohortIds, variableIds, lastVersion });
+  }
+
+  onDropdownScroll() {
+    if (this.isLoadingMore) return;
+    const hasMore = (this.evaluations?.length ?? 0) < this.totalEvaluations;
+    if (!hasMore) return;
+
+    this.isLoadingMore = true;
+    this.pagination = { page: this.pagination.page + 1, pageSize: 5 };
+    this._loadEvaluations();
   }
 }

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.html
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.html
@@ -9,21 +9,19 @@
   ></app-poll-filters>
 </div>
 
-@if (loading) {
+@if (showEmpty) {
+  <app-empty-data-message
+    description="Please select the required fields to list Polls Answered."
+  ></app-empty-data-message>
+} @else if (loading) {
   <mat-spinner></mat-spinner>
 } @else {
-  @if (!pollInstances.length) {
-    <app-empty-data-message
-      description="Please select the required fields to list Polls Answered."
-    ></app-empty-data-message>
-  } @else {
-    <app-list
-      (actionCalled)="goToDetails($event)"
-      (loadCalled)="loadPollInstances($event)"
-      [items]="pollInstances"
-      [totalItems]="totalPollInstances"
-      [columns]="columns"
-      [actionDatas]="actionDatas"
-    />
-  }
+  <app-list
+    (actionCalled)="goToDetails($event)"
+    (loadCalled)="loadPollInstances($event)"
+    [items]="pollInstances"
+    [totalItems]="totalPollInstances"
+    [columns]="columns"
+    [actionDatas]="actionDatas"
+  />
 }

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.spec.ts
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.spec.ts
@@ -65,4 +65,18 @@ describe('PollsAnsweredComponent', () => {
     expect(component.getWidth('email')).toBe('20%');
     expect(component.getWidth('uuid')).toBe('');
   });
+
+  describe('showEmpty', () => {
+    it('should return true when pollUuid is empty', () => {
+      component.selectedPollUuid = '';
+
+      expect(component.showEmpty).toBeTrue();
+    });
+
+    it('should return false when pollUuid exists', () => {
+      component.selectedPollUuid = 'poll-123';
+
+      expect(component.showEmpty).toBeFalse();
+    });
+  });
 });

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
@@ -177,6 +177,7 @@ export class PollsAnsweredComponent implements OnInit {
   }
 
   load(): void {
+    if (this.selectedPollUuid === '') return;
     this.loading = true;
     this.pollInstanceService
       .getPollInstancesByFilters({
@@ -232,5 +233,9 @@ export class PollsAnsweredComponent implements OnInit {
       default:
         return '';
     }
+  }
+
+  get showEmpty(): boolean {
+    return !this.selectedPollUuid;
   }
 }

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.html
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.html
@@ -6,7 +6,11 @@
   (filters)="handleFilterSelect($event)"
 ></app-poll-filters>
 
-@defer (when isLoading()) {
+@if (showEmpty) {
+  <app-empty-data-message
+    description="Please select the required fields to generate the charts."
+  />
+} @else {
   <ng-container>
     <div class="action-section">
       <button
@@ -38,49 +42,39 @@
       </mat-menu>
     </div>
   </ng-container>
-  @if (chartOptions && students.length) {
-    <div class="table-container" #contentToExport>
-      @if (heatmapChart) {
-        <div class="chart-container">
-          <apx-chart
-            id="heatmap"
-            [series]="chartOptions.series!"
-            [chart]="chartOptions.chart!"
-            [xaxis]="chartOptions.xaxis!"
-            [yaxis]="chartOptions.yaxis!"
-            [colors]="chartOptions.colors!"
-            [plotOptions]="chartOptions.plotOptions!"
-            [title]="chartOptions.title!"
-            [tooltip]="chartOptions.tooltip!"
-          >
-          </apx-chart>
-        </div>
-      } @else {
-        <app-summary-column-charts
-          [components]="components()!"
-          [pollUuid]="pollUuid"
-          [cohortsIds]="cohortIds"
-          [data]="title"
-        ></app-summary-column-charts>
-      }
-
-      <div id="table-container">
-        <app-list
-          (actionCalled)="(null)"
-          (loadCalled)="getStudentsByCohortAndPoll($event)"
-          [items]="students"
-          [totalItems]="totalStudents"
-          [columns]="columns"
-          [actionDatas]="[]"
-          [title]="'Students Risk'"
-        />
-      </div>
+  @if (heatmapChart) {
+    <div class="chart-container">
+      <apx-chart
+        id="heatmap"
+        [series]="chartOptions.series!"
+        [chart]="chartOptions.chart!"
+        [xaxis]="chartOptions.xaxis!"
+        [yaxis]="chartOptions.yaxis!"
+        [colors]="chartOptions.colors!"
+        [plotOptions]="chartOptions.plotOptions!"
+        [title]="chartOptions.title!"
+        [tooltip]="chartOptions.tooltip!"
+      >
+      </apx-chart>
     </div>
+  } @else {
+    <app-summary-column-charts
+      [components]="components()!"
+      [pollUuid]="pollUuid"
+      [cohortsIds]="cohortIds"
+      [data]="title"
+    ></app-summary-column-charts>
   }
-} @loading {
-  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-} @placeholder {
-  <app-empty-data-message
-    description="Please select the required fields to generate the charts."
-  />
+
+  <div id="table-container">
+    <app-list
+      (actionCalled)="(null)"
+      (loadCalled)="getStudentsByCohortAndPoll($event)"
+      [items]="students"
+      [totalItems]="totalStudents"
+      [columns]="columns"
+      [actionDatas]="[]"
+      [title]="'Students Risk'"
+    />
+  </div>
 }

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
@@ -101,7 +101,6 @@ describe('SummaryChartsComponent', () => {
     });
     expect(component.students).toEqual(mockStudents.items);
     expect(component.totalStudents).toBe(1);
-    expect(component.isLoading()).toBeFalse();
   });
 
   it('should call getAvgPoolReport and set chartOptions in getHeatMap', () => {

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.spec.ts
@@ -152,15 +152,17 @@ describe('SummaryChartsComponent', () => {
     await component.exportReportPdf();
   });
 
-  it('should update filters and call getStudentsByCohortAndPoll and getHeatMap on handleFilterSelect', () => {
-    spyOn(component, 'getStudentsByCohortAndPoll');
+  it('should update filters and call _loadStudents and getHeatMap on handleFilterSelect', () => {
     spyOn(component, 'getHeatMap');
+    spyOn(
+      component as unknown as { _loadStudents: () => void },
+      '_loadStudents'
+    ).and.stub();
     const filters = { cohortIds: [1], title: 'Test', uuid: 'poll-uuid' };
     component.handleFilterSelect(filters as Filter);
     expect(component.cohortIds).toEqual([1]);
     expect(component.title).toBe('Test');
     expect(component.pollUuid).toBe('poll-uuid');
-    expect(component.getStudentsByCohortAndPoll).toHaveBeenCalled();
     expect(component.getHeatMap).toHaveBeenCalled();
   });
 
@@ -172,5 +174,19 @@ describe('SummaryChartsComponent', () => {
       { x: 'Q', y: 1 } as SummarySerie
     );
     expect(result).toBeNull();
+  });
+
+  describe('showEmpty', () => {
+    it('should return true when pollUuid is empty', () => {
+      component.pollUuid = '';
+
+      expect(component.showEmpty).toBeTrue();
+    });
+
+    it('should return false when pollUuid exists', () => {
+      component.pollUuid = 'poll-123';
+
+      expect(component.showEmpty).toBeFalse();
+    });
   });
 });

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
@@ -98,6 +98,7 @@ export class SummaryChartsComponent {
   variableColumns = ['variableName'];
 
   cohortIds: number[] = [];
+
   selectedCohort?: CohortModel;
   lastVersion = true;
   pollUuid = '';
@@ -105,7 +106,7 @@ export class SummaryChartsComponent {
   students: StudentRiskAverage[] = [];
   totalStudents = 0;
 
-  isLoading = signal(false);
+  isLoading = false;
   isGeneratingPDF = false;
   title = '';
   components = signal<PollAvgReport | null>(null);
@@ -114,25 +115,7 @@ export class SummaryChartsComponent {
   constructor(private snackBar: MatSnackBar) {}
 
   getStudentsByCohortAndPoll(event: EventLoad) {
-    if (this.cohortIds.length && this.pollUuid) {
-      this.isLoading.set(true);
-      this.studentService
-        .getAllAverageByCohortsAndPoll({
-          page: event.page,
-          pageSize: event.pageSize,
-          cohortIds: this.cohortIds,
-          pollUuid: this.pollUuid,
-          lastVersion: this.lastVersion,
-        })
-        .subscribe(response => {
-          this.students = response.items;
-          this.totalStudents = response.count;
-          this.isLoading.set(false);
-        });
-    } else {
-      this.students = [];
-      this.totalStudents = 0;
-    }
+    this._loadStudents(event);
   }
 
   getHeatMap() {
@@ -162,7 +145,6 @@ export class SummaryChartsComponent {
               component.description,
               serieQuestion
             );
-
             if (!pollAvgQuestion) {
               console.error('Error getting question from report.');
             } else {
@@ -252,11 +234,37 @@ export class SummaryChartsComponent {
     this.title = filters.title;
     this.pollUuid = filters.uuid;
     this.lastVersion = filters.lastVersion;
-    this.getStudentsByCohortAndPoll({ pageSize: 10, page: 0 });
+    this._loadStudents({ pageSize: 10, page: 0 });
     this.getHeatMap();
   }
 
   toggleChart(chart: string) {
     this.heatmapChart = chart === 'heatmap';
+  }
+
+  get showEmpty(): boolean {
+    return !this.pollUuid;
+  }
+
+  private _loadStudents(event: EventLoad) {
+    if (this.cohortIds.length && this.pollUuid) {
+      this.isLoading = true;
+      this.studentService
+        .getAllAverageByCohortsAndPoll({
+          page: event.page,
+          pageSize: event.pageSize,
+          cohortIds: this.cohortIds,
+          pollUuid: this.pollUuid,
+          lastVersion: this.lastVersion,
+        })
+        .subscribe(response => {
+          this.students = response.items;
+          this.totalStudents = response.count;
+          this.isLoading = false;
+        });
+    } else {
+      this.students = [];
+      this.totalStudents = 0;
+    }
   }
 }


### PR DESCRIPTION
## Description

The evaluation dropdown only showed 10 evaluations. Changing the evaluation dropdown did not affect the already displayed charts. The dropdown menu for poll selection was removed, and it now only allows to select "completed" evaluations.

### Root reason:

Pagination was not called in poll-filters, and the poll filters were not update with the emit function in the poll answer, dynamic chart, and summary chart. The templates were updated in order to show or not if the pollUuid is passed.It includes more fixes because the app list has an additional initialization and includes conflicts with the brief solution.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [X] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#692 
