### PR TITLE
feat: show already imported students with save switch off in poll re-…

### DIFF
--- a/src/app/core/models/poll-instance.model.ts
+++ b/src/app/core/models/poll-instance.model.ts
@@ -17,4 +17,5 @@ export interface PollInstance extends BaseModel {
   version: string;
   finishedAt: string;
   components: Component[];
+  isAlreadyImported?: boolean;
 }

--- a/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
@@ -114,6 +114,12 @@ export class ImportAnswersPreviewComponent implements OnChanges {
     if (changes['importedPollData']) {
       this.mapDataCreatedPoll(this.importedPollData);
       this.getInvalidStudents(this.studentPreviews);
+      const alreadyImported = this.importedPollData
+        .filter(p => p.isAlreadyImported)
+        .map(p => p.components[0].variables[0].answer.student.email);
+      this.studentExcludedEmailsSubject.next(alreadyImported);
+      this.allStudentsCheckedSubject.next(alreadyImported.length === 0);
+
       this.selectedStudents$ = this.studentExcludedEmails$.pipe(
         map(
           excluded =>
@@ -217,7 +223,7 @@ export class ImportAnswersPreviewComponent implements OnChanges {
         name: name,
         email: email,
         cohort: cohort,
-        save: true,
+        save: !data[i].isAlreadyImported,
       };
 
       studentPreviews.push(student);


### PR DESCRIPTION
## Description

When re-importing a poll, students who already have answers in the system are now detected and shown with their Save switch in the Off state by default. This prevents accidental duplicate imports while still allowing the user to manually enable the switch if a re-import is intended.

### Changes:

- Added isAlreadyImported field to PollInstance model
- Updated import-answers-preview to set save=false for already imported students
- Pre-populates excluded emails list with already imported students on load

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


