### PR TITLE
fix: navigate to evaluation-process on cancel in import poll preview

### DIFF
--- a/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.html
+++ b/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.html
@@ -86,11 +86,7 @@
                 <button class="button" mat-flat-button (click)="savePolls()">
                   Save
                 </button>
-                <button
-                  class="button"
-                  mat-flat-button
-                  (click)="resetAllDataPolls()"
-                >
+                <button class="button" mat-flat-button (click)="cancel()">
                   Cancel
                 </button>
               </span>
@@ -152,11 +148,7 @@
                   >
                     Save
                   </button>
-                  <button
-                    class="button"
-                    mat-flat-button
-                    (click)="resetAllDataPolls()"
-                  >
+                  <button class="button" mat-flat-button (click)="cancel()">
                     Cancel
                   </button>
                 </span>

--- a/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-answers-preview/import-answers-preview.component.ts
@@ -85,6 +85,8 @@ export class ImportAnswersPreviewComponent implements OnChanges {
     data: unknown;
   }>();
 
+  @Output() cancelImport = new EventEmitter<void>();
+
   studentExcludedEmailsSubject = new BehaviorSubject<string[]>([]);
   studentExcludedEmails$ = this.studentExcludedEmailsSubject.asObservable();
 
@@ -164,6 +166,12 @@ export class ImportAnswersPreviewComponent implements OnChanges {
         },
       });
   }
+
+  cancel() {
+    this.resetAllDataPolls();
+    this.cancelImport.emit();
+  }
+
   resetAllDataPolls() {
     this.dataStudents = new MatTableDataSource<StudentPreview>([]);
     this.studentPreviews = [];

--- a/src/app/modules/imports/components/import-preview/import-preview.component.html
+++ b/src/app/modules/imports/components/import-preview/import-preview.component.html
@@ -4,6 +4,7 @@
     [evaluationId]="evaluationId"
     [importedPollData]="importedPollData"
     (saveCompleted)="handleSavePollState($event)"
+    (cancelImport)="handleCancel()"
   />
 }
 <div *ngIf="isLoading$ | async" class="spinner-container">

--- a/src/app/modules/imports/components/import-preview/import-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-preview.component.ts
@@ -120,4 +120,7 @@ export class ImportPreviewComponent implements OnInit {
       );
     }
   }
+  handleCancel() {
+    this.router.navigate(['evaluation-process']);
+  }
 }


### PR DESCRIPTION
## Description

The Cancel button in the Import Poll preview page was calling resetAllDataPolls() 
which only cleared local data but did not redirect the user anywhere, 
leaving the page blank.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


