### PR TITLE
Fix -740: Import students, validation message when a non csv file is selected

### DIFF
--- a/src/app/modules/imports/components/import-students/import-students.component.html
+++ b/src/app/modules/imports/components/import-students/import-students.component.html
@@ -28,6 +28,7 @@
       <input
         #fileInput
         type="file"
+        accept=".csv,text/csv"
         (change)="onFileSelected($event)"
         style="display: none"
       />

--- a/src/app/modules/imports/components/import-students/import-students.component.ts
+++ b/src/app/modules/imports/components/import-students/import-students.component.ts
@@ -83,38 +83,45 @@ export class ImportStudentsComponent {
 
   onFileSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
 
-    if (input.files && input.files.length > 0) {
-      this.selectedFile = input.files[0];
-      this.csvErrors = [];
-      this.validateFile(this.selectedFile);
-    }
+    if (!file) return;
+
+    this.selectedFile = file;
+    this.csvErrors = [];
+    this.validateFile(this.selectedFile);
+  }
+
+  private rejectFile(msg: string): void {
+    this.fileError = msg;
+    this.selectedFile = null;
+    this.openDialog(GENERAL_MESSAGES.DETAILS, false);
   }
 
   private async validateFile(file: File): Promise<void> {
     const maxFileSize = 5 * 1024 * 1024;
     if (file.type !== 'text/csv') {
-      this.fileError = VALIDATION_MESSAGES.INVALID_FILE_TYPE + '(.csv)';
-      this.selectedFile = null;
-      this.openDialog(GENERAL_MESSAGES.DETAILS, false);
+      this.rejectFile(VALIDATION_MESSAGES.INVALID_FILE_TYPE + '(.csv)');
       return;
     }
 
     if (file.size > maxFileSize) {
-      this.fileError = VALIDATION_MESSAGES.FILE_SIZE_EXCEEDED + '(5MB)';
-      this.selectedFile = null;
-      this.openDialog(GENERAL_MESSAGES.DETAILS, false);
+      this.rejectFile(VALIDATION_MESSAGES.FILE_SIZE_EXCEEDED + '(5MB)');
       return;
     }
 
-    await this.csvCheckerService.validateCSV(file);
+    try {
+      await this.csvCheckerService.validateCSV(file);
+    } catch (err) {
+      console.error(err);
+      this.rejectFile(VALIDATION_MESSAGES.CSV_SCAN_ERROR);
+      return;
+    }
     this.csvErrors = this.csvCheckerService.getErrors();
 
     if (this.csvErrors.length > 0) {
-      this.fileError = VALIDATION_MESSAGES.CSV_SCAN_ERROR;
       this.csvErrors = this.processErrors(this.csvErrors);
-      this.openDialog(GENERAL_MESSAGES.DETAILS, false);
-
+      this.rejectFile(VALIDATION_MESSAGES.CSV_SCAN_ERROR);
       return;
     }
     this.fileError = null;

--- a/src/app/modules/imports/components/import-students/import-students.component.ts
+++ b/src/app/modules/imports/components/import-students/import-students.component.ts
@@ -61,6 +61,7 @@ export class ImportStudentsComponent {
         title: isSuccess
           ? GENERAL_MESSAGES.SUCCESS_IMPORT_TITLE
           : GENERAL_MESSAGES.ERROR_IMPORT_TITLE,
+        message: this.csvErrors.length > 0 ? this.csvErrors : this.fileError,
         success: {
           details: text,
         },
@@ -92,17 +93,20 @@ export class ImportStudentsComponent {
 
   private async validateFile(file: File): Promise<void> {
     const maxFileSize = 5 * 1024 * 1024;
-    if (file.size > maxFileSize) {
-      this.fileError = VALIDATION_MESSAGES.FILE_SIZE_EXCEEDED + '(5MB)';
-      this.selectedFile = null;
-      return;
-    }
-
     if (file.type !== 'text/csv') {
       this.fileError = VALIDATION_MESSAGES.INVALID_FILE_TYPE + '(.csv)';
       this.selectedFile = null;
+      this.openDialog(GENERAL_MESSAGES.DETAILS, false);
       return;
     }
+
+    if (file.size > maxFileSize) {
+      this.fileError = VALIDATION_MESSAGES.FILE_SIZE_EXCEEDED + '(5MB)';
+      this.selectedFile = null;
+      this.openDialog(GENERAL_MESSAGES.DETAILS, false);
+      return;
+    }
+
     await this.csvCheckerService.validateCSV(file);
     this.csvErrors = this.csvCheckerService.getErrors();
 


### PR DESCRIPTION
## Description

Add the validation messages by importing file to import students, if the file is greater than 5MB, if has a different extension than csv, if does not contain required headers. Every case shows as a message in the dialog.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues
#740 

