### PR TITLE
Bugfix-693: Dynamic charts create infinite scroll dropdown component

### DIFF
--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-form/evaluation-process-form.component.spec.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-form/evaluation-process-form.component.spec.ts
@@ -22,6 +22,7 @@ import { Component, Input } from '@angular/core';
 import { NgApexchartsModule } from 'ng-apexcharts';
 
 @Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'apx-chart',
   standalone: true,
   template: '<div></div>',

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -13,7 +13,8 @@
           id="sl-evaluation"
           formControlName="selectedEvaluation"
           (selectionChange)="handleEvaluationSelect($event)"
-          (openedChange)="$event && onDropdownScroll()"
+          #evaluationSelect
+          (openedChange)="handleEvaluationDropdownOpen($event)"
         >
           @for (evaluation of evaluations; track $index) {
             @if (evaluation.status === 'Completed') {

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -30,105 +30,39 @@
       </mat-form-field>
     }
     @if (polls[0]) {
-      <mat-form-field appearance="fill">
-        <mat-label for="sl-cohort">Cohort</mat-label>
-        <mat-select
-          id="sl-cohort"
-          multiple
-          formControlName="cohortIds"
-          (openedChange)="handleCohortSelect($event)"
-        >
-          <mat-select-trigger>
-            <app-selected-items
-              [items]="getCohortsSelection()"
-            ></app-selected-items>
-          </mat-select-trigger>
-          @if (cohorts.length > 0) {
-            <mat-option appSelectAll [allValues]="cohorts"
-              >Select all</mat-option
-            >
-          }
-          @for (cohort of cohorts; track $index) {
-            <mat-option [value]="cohort.id">
-              {{ cohort.name }}
-            </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+      <app-select-multiple-virtual-scroll
+        [items]="cohortsToScroll()"
+        [control]="filterForm.controls.cohortIds"
+        [id]="'sl-cohort'"
+        [label]="'Cohorts'"
+        (openedChange)="handleCohortSelect($event)"
+      />
     }
     @if (
       filterForm.value.cohortIds &&
       filterForm.value.cohortIds.length &&
       showVariables
     ) {
-      <mat-form-field appearance="fill">
-        <mat-label for="sl-component">Components</mat-label>
-        <mat-select
-          required
-          id="sl-components"
-          multiple
-          (openedChange)="handleComponentsSelect($event)"
-          formControlName="componentNames"
-        >
-          <mat-select-trigger>
-            <app-selected-items
-              [items]="getComponentsSelection()"
-            ></app-selected-items>
-          </mat-select-trigger>
-          @if (!!componentNames.length) {
-            <mat-option appSelectAll [allValues]="componentNames"
-              >Select all</mat-option
-            >
-          }
-          @for (component of componentNames; track $index) {
-            <mat-option [value]="component">
-              {{ component }}
-            </mat-option>
-          }
-        </mat-select>
-        @if (filterForm.get('componentNames')?.errors) {
-          <mat-error>This field is required</mat-error>
-        }
-      </mat-form-field>
+      <app-select-multiple-virtual-scroll
+        [items]="componentsToScroll()"
+        [control]="filterForm.controls.componentNames"
+        [id]="'sl-components'"
+        [label]="'Components'"
+        (openedChange)="handleComponentsSelect($event)"
+      />
     }
     @if (
       filterForm.value.cohortIds &&
       filterForm.value.cohortIds.length &&
       showVariables
     ) {
-      <mat-form-field appearance="fill">
-        <mat-label for="variables">Variables</mat-label>
-        <mat-select
-          id="sl-variables"
-          multiple
-          (openedChange)="handleVariableSelect($event)"
-          formControlName="variables"
-        >
-          <mat-select-trigger>
-            <app-selected-items
-              [items]="getVariablesSelection()"
-            ></app-selected-items>
-          </mat-select-trigger>
-          @if (!!variables.length) {
-            <mat-option appSelectAll [allValues]="getAllVariableIds()"
-              >Select all</mat-option
-            >
-          }
-          @for (group of variableGroups; track group) {
-            @if (!!group.length) {
-              <mat-optgroup [label]="group[0].componentName | uppercase">
-                @for (variable of group; track variable.pollVariableId) {
-                  <mat-option
-                    class="group-option"
-                    [value]="variable.pollVariableId"
-                    >{{ variable.name }}</mat-option
-                  >
-                }
-              </mat-optgroup>
-            }
-          }
-        </mat-select>
-      </mat-form-field>
+      <app-select-multiple-virtual-scroll
+        [control]="filterForm.controls.variables"
+        [id]="'sl-variables'"
+        [label]="'Variables'"
+        [groups]="variableSelectGroups()"
+        (openedChange)="handleVariableSelect($event)"
+      />
     }
   </div>
 </form>

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -1,34 +1,19 @@
 <form [formGroup]="filterForm">
-  @if (!evaluations) {
+  @if (evaluations() === null) {
     <p class="error-message">
       There was an error looking for evaluation processes. Please contact
       support.
     </p>
   }
   <div class="form-container">
-    @if (evaluations && evaluations.length > 0) {
-      <mat-form-field appearance="fill">
-        <mat-label for="sl-evaluation">Evaluation</mat-label>
-        <mat-select
-          id="sl-evaluation"
-          formControlName="selectedEvaluation"
-          (selectionChange)="handleEvaluationSelect($event)"
-          #evaluationSelect
-          (openedChange)="handleEvaluationDropdownOpen($event)"
-        >
-          @for (evaluation of evaluations; track $index) {
-            @if (evaluation.status === 'Completed') {
-              <mat-option class="versioned-option" [value]="evaluation">
-                <p>{{ `${evaluation.name} - ${evaluation.status}`}}</p>
-              </mat-option>
-            }
-          }
-        </mat-select>
-        @if (filterForm.get('selectedEvaluation')?.errors) {
-          <mat-error>This field is required</mat-error>
-        }
-      </mat-form-field>
-    }
+    <app-select-virtual-scroll
+      [items]="evaluationsToScroll()"
+      [control]="filterForm.controls.selectedEvaluation"
+      [id]="'sl-evaluation'"
+      [label]="'Evaluation'"
+      (selectionChange)="handleEvaluationSelect($event)"
+    />
+
     @if (polls[0]) {
       <app-select-multiple-virtual-scroll
         [items]="cohortsToScroll()"

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -3,7 +3,6 @@ import {
   DestroyRef,
   Input,
   OnInit,
-  ViewChild,
   inject,
   output,
   computed,
@@ -18,11 +17,7 @@ import {
 } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import {
-  MatSelect,
-  MatSelectChange,
-  MatSelectModule,
-} from '@angular/material/select';
+import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 
 import { CohortModel } from '@core/models/cohort.model';
 import { PollModel } from '@core/models/poll.model';
@@ -36,13 +31,15 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EvaluationsService } from '@core/services/api/evaluations.service';
 import { EvaluationModel } from '@core/models/evaluation.model';
 import { Pagination } from '@core/services/interfaces/server.type';
-// import { SelectVirtualScrollComponent } from '@shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component';
+import { SelectVirtualScrollComponent } from '@shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component';
 import { SelectMultipleVirtualScrollComponent } from '@shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component';
 import {
   MultipleSelectCommonItem,
   MultipleSelectItem,
   SelectGroup,
+  SingleSelectItem,
 } from '@shared/components/form-field-virtual-scroll/interfaces/select';
+import { switchMap } from 'rxjs';
 
 @Component({
   selector: 'app-poll-filters',
@@ -53,6 +50,7 @@ import {
     MatIconModule,
     CommonModule,
     SelectMultipleVirtualScrollComponent,
+    SelectVirtualScrollComponent,
   ],
   providers: [DatePipe],
   templateUrl: './poll-filters.component.html',
@@ -60,7 +58,6 @@ import {
 })
 export class PollFiltersComponent implements OnInit {
   @Input() showVariables = true;
-  @ViewChild('evaluationSelect') evaluationSelect!: MatSelect;
 
   private cohortsService = inject(CohortService);
   private destroyRef = inject(DestroyRef);
@@ -69,7 +66,7 @@ export class PollFiltersComponent implements OnInit {
 
   cohorts = signal<CohortModel[]>([]);
   componentNames = signal<string[]>([]);
-  evaluations: EvaluationModel[] | null = [];
+  evaluations = signal<EvaluationModel[] | null>([]);
   polls: PollModel[] = [];
   prevCohortIds: number[] = [];
   prevComponentSelections: string[] = [];
@@ -83,8 +80,6 @@ export class PollFiltersComponent implements OnInit {
     page: 0,
     pageSize: 10,
   };
-  isLoadingMore = false;
-  totalEvaluations = 0;
 
   filters = output<{
     title: string;
@@ -103,6 +98,15 @@ export class PollFiltersComponent implements OnInit {
       Validators.required,
     ]),
     variables: new FormControl<number[] | null>(null, [Validators.required]),
+  });
+
+  readonly evaluationsToScroll = computed<SingleSelectItem[]>(() => {
+    return (this.evaluations() ?? [])
+      .filter(e => e.status === 'Completed')
+      .map(e => ({
+        label: `${e.name} - ${e.status}`,
+        value: e,
+      }));
   });
 
   readonly cohortsToScroll = computed<MultipleSelectCommonItem[]>(() => {
@@ -136,15 +140,6 @@ export class PollFiltersComponent implements OnInit {
 
   ngOnInit() {
     this._loadEvaluations();
-  }
-
-  handleEvaluationDropdownOpen(isOpen: boolean) {
-    if (!isOpen) return;
-    setTimeout(() => {
-      const panel = this.evaluationSelect.panel?.nativeElement;
-      if (!panel) return;
-      panel.addEventListener('scroll', () => this._onPanelScroll(panel));
-    });
   }
 
   handleEvaluationSelect(itemSelected: MatSelectChange) {
@@ -262,14 +257,17 @@ export class PollFiltersComponent implements OnInit {
   private _loadEvaluations() {
     this.evaluationsService
       .getAllEvalProc(this.pagination)
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        switchMap(({ count }) =>
+          this.evaluationsService.getAllEvalProc({ page: 0, pageSize: count })
+        )
+      )
       .subscribe({
         next: result => {
-          this.evaluations = [...(this.evaluations ?? []), ...result.items];
-          this.totalEvaluations = result.count;
-          this.isLoadingMore = false;
+          this.evaluations.set(result.items);
         },
-        error: () => (this.evaluations = null),
+        error: () => this.evaluations.set(null),
       });
   }
 
@@ -350,17 +348,5 @@ export class PollFiltersComponent implements OnInit {
     const lastVersion = true;
 
     this.filters.emit({ title, uuid, cohortIds, variableIds, lastVersion });
-  }
-
-  private _onPanelScroll(panel: HTMLElement) {
-    const nearBottom =
-      panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 50;
-    if (!nearBottom || this.isLoadingMore) return;
-    const hasMore = (this.evaluations?.length ?? 0) < this.totalEvaluations;
-    if (!hasMore) return;
-
-    this.isLoadingMore = true;
-    this.pagination = { page: this.pagination.page + 1, pageSize: 10 };
-    this._loadEvaluations();
   }
 }

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -6,8 +6,10 @@ import {
   ViewChild,
   inject,
   output,
+  computed,
+  signal,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import {
   FormControl,
   FormGroup,
@@ -27,15 +29,20 @@ import { PollModel } from '@core/models/poll.model';
 import { VariableModel } from '@core/models/variable.model';
 
 import { areArraysEqual } from '@core/utils/helpers/are-arrays-equal';
-import { SelectAllDirective } from '@shared/directives/select-all.directive';
 
 import { CohortService } from '@core/services/api/cohort.service';
 import { PollService } from '@core/services/api/poll.service';
-import { SelectedItemsComponent } from './selected-items/selected-items.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EvaluationsService } from '@core/services/api/evaluations.service';
 import { EvaluationModel } from '@core/models/evaluation.model';
 import { Pagination } from '@core/services/interfaces/server.type';
+// import { SelectVirtualScrollComponent } from '@shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component';
+import { SelectMultipleVirtualScrollComponent } from '@shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component';
+import {
+  MultipleSelectCommonItem,
+  MultipleSelectItem,
+  SelectGroup,
+} from '@shared/components/form-field-virtual-scroll/interfaces/select';
 
 @Component({
   selector: 'app-poll-filters',
@@ -45,9 +52,9 @@ import { Pagination } from '@core/services/interfaces/server.type';
     MatSelectModule,
     MatIconModule,
     CommonModule,
-    SelectAllDirective,
-    SelectedItemsComponent,
+    SelectMultipleVirtualScrollComponent,
   ],
+  providers: [DatePipe],
   templateUrl: './poll-filters.component.html',
   styleUrl: './poll-filters.component.scss',
 })
@@ -60,16 +67,17 @@ export class PollFiltersComponent implements OnInit {
   private pollsService = inject(PollService);
   private evaluationsService = inject(EvaluationsService);
 
-  cohorts: CohortModel[] = [];
-  componentNames: string[] = [];
+  cohorts = signal<CohortModel[]>([]);
+  componentNames = signal<string[]>([]);
   evaluations: EvaluationModel[] | null = [];
   polls: PollModel[] = [];
   prevCohortIds: number[] = [];
   prevComponentSelections: string[] = [];
   prevVariablesSelections: number[] = [];
   variableGroups: VariableModel[][] = [];
-  variables: VariableModel[] = [];
+  variables = signal<VariableModel[]>([]);
   variablesClone: VariableModel[] = [];
+  variableSelectGroups = signal<SelectGroup[]>([]);
 
   pagination: Pagination = {
     page: 0,
@@ -95,6 +103,35 @@ export class PollFiltersComponent implements OnInit {
       Validators.required,
     ]),
     variables: new FormControl<number[] | null>(null, [Validators.required]),
+  });
+
+  readonly cohortsToScroll = computed<MultipleSelectCommonItem[]>(() => {
+    const cohorts = this.cohorts();
+
+    return cohorts
+      ? cohorts.map(cohort => {
+          return { label: cohort.name, value: cohort.id };
+        })
+      : [];
+  });
+
+  readonly componentsToScroll = computed<MultipleSelectItem[]>(() => {
+    const componentNames = this.componentNames();
+    return componentNames
+      ? componentNames.map(componentName => {
+          return { label: componentName, value: componentName };
+        })
+      : [];
+  });
+
+  readonly variablesGroupsToScroll = computed<MultipleSelectItem[]>(() => {
+    const variables = this.variables();
+
+    return variables
+      ? variables.map(variable => {
+          return { label: variable.name, value: variable.pollVariableId };
+        })
+      : [];
   });
 
   ngOnInit() {
@@ -137,25 +174,36 @@ export class PollFiltersComponent implements OnInit {
     if (!this.filterForm.value.componentNames?.length) {
       this.variableGroups = [];
       this._resetField('variables');
-      this.variables = [];
+      this.variables.set([]);
       this._sendFilters();
       return;
     }
 
-    this.variables = [];
-    setTimeout(() => {
-      this.variableGroups =
-        this.filterForm.value.componentNames?.map(c =>
-          this.variablesClone.filter(v => v.componentName === c)
+    this.variableGroups =
+      this.filterForm.value.componentNames
+        ?.filter(c => !!c)
+        .map(c =>
+          this.variablesClone.filter(v => !!v && v.componentName === c)
         ) || [];
-
-      this.variables = this.variableGroups.flat();
-      this.filterForm.controls.variables.setValue(
-        this.variableGroups.flat().map(v => v.pollVariableId)
-      );
-      this.prevVariablesSelections = this.variables.map(v => v.pollVariableId);
-      this._sendFilters();
-    });
+    const variableGroupsFlat = this.variableGroups.flat();
+    this.variables.set(variableGroupsFlat);
+    this.filterForm.controls.variables.setValue(
+      variableGroupsFlat.map(v => !!v && v.pollVariableId)
+    );
+    const result = this.variableGroups.flatMap(variableGroup => [
+      {
+        label: variableGroup[0].componentName.toLocaleUpperCase(),
+        items: [
+          ...variableGroup.map(g => ({
+            label: g.name,
+            value: g.pollVariableId,
+          })),
+        ],
+      },
+    ]);
+    this.variableSelectGroups.set(result);
+    this.prevVariablesSelections = this.variables().map(v => v.pollVariableId);
+    this._sendFilters();
   }
 
   handleVariableSelect(isOpen: boolean) {
@@ -178,7 +226,8 @@ export class PollFiltersComponent implements OnInit {
     return cohortIds?.length === this.cohorts.length
       ? ['Select all']
       : cohortIds?.map(
-          cohortId => this.cohorts.find(cohort => cohort.id === cohortId)?.name
+          cohortId =>
+            this.cohorts().find(cohort => cohort.id === cohortId)?.name
         );
   }
 
@@ -190,12 +239,12 @@ export class PollFiltersComponent implements OnInit {
     return componentNames?.length === this.componentNames.length
       ? ['Select all']
       : componentNames?.map(componentName =>
-          this.componentNames.find(cN => cN === componentName)
+          this.componentNames().find(cN => cN === componentName)
         );
   }
 
   getAllVariableIds() {
-    return this.variables.map(variable => variable.pollVariableId);
+    return this.variables().map(variable => variable.pollVariableId);
   }
 
   getVariablesSelection() {
@@ -206,7 +255,7 @@ export class PollFiltersComponent implements OnInit {
     return variables?.length === this.variables.length
       ? ['Select all']
       : variables?.map(
-          id => this.variables.find(v => v.pollVariableId === id)?.name
+          id => this.variables().find(v => v.pollVariableId === id)?.name
         );
   }
 
@@ -229,47 +278,57 @@ export class PollFiltersComponent implements OnInit {
   }
 
   private _getCohorts(pollUuid: string) {
-    this.cohorts = [];
-    this.cohortsService.getCohorts(pollUuid).subscribe(response => {
-      this.cohorts = response.body;
-      this.filterForm.controls.cohortIds.setValue(
-        this.cohorts.map(cohort => cohort.id)
-      );
-      this.prevCohortIds = this.filterForm.value.cohortIds || [];
-      this.componentNames = [];
-      this.variables = [];
-      this.filterForm.controls.variables.reset();
-      this._getVariables();
+    this.cohorts.set([]);
+    this.variables.set([]);
+    this._resetField('cohortIds');
+    this._resetField('variables');
+    this.cohortsService.getCohorts(pollUuid).subscribe({
+      next: response => {
+        this.cohorts.set(response.body);
+        this.filterForm.controls.cohortIds.setValue(
+          response.body.map(cohort => cohort.id)
+        );
+        this.prevCohortIds = this.filterForm.value.cohortIds || [];
+        this._getVariables();
+      },
+      error: () => this.cohorts.set([]),
     });
   }
 
   private _getVariables() {
     if (!this.polls[0]?.uuid) return;
-    this.componentNames = [];
-    this.variables = [];
-    this._resetField('variables');
+    const componentNames = this.componentNames();
 
     this.pollsService
-      .getVariablesByComponents(
-        this.polls[0].uuid,
-        [...this.componentNames],
-        true
-      )
-      .subscribe(variables => {
-        this.variables = variables;
-        this.variablesClone = [...this.variables];
-        this.componentNames = [...new Set(variables.map(v => v.componentName))];
-        this.prevComponentSelections = [...this.componentNames];
+      .getVariablesByComponents(this.polls[0].uuid, [...componentNames], true)
+      .subscribe({
+        next: variables => {
+          const newComponentNames = [
+            ...new Set(variables.map(v => v.componentName)),
+          ];
+          this.variables.set(variables);
+          this.variablesClone = [...variables];
+          this.componentNames.set(newComponentNames);
 
-        this.variableGroups = this.componentNames.map(c =>
-          variables.filter(v => v.componentName === c)
-        );
-        this.filterForm.controls.componentNames.setValue(this.componentNames);
-        this.filterForm.controls.variables.setValue(
-          this.variables.map(v => v.pollVariableId)
-        );
-        this.prevVariablesSelections = this.filterForm.value.variables || [];
-        this._sendFilters();
+          this.variableGroups = newComponentNames.map(c =>
+            variables.filter(v => v.componentName === c)
+          );
+          const groups = this.variableGroups.flatMap(variableGroup => [
+            {
+              label: variableGroup[0].componentName.toLocaleUpperCase(),
+              items: variableGroup.map(g => ({
+                label: g.name,
+                value: g.pollVariableId,
+              })),
+            },
+          ]);
+          this.variableSelectGroups.set(groups);
+          this.filterForm.controls.variables.setValue(
+            variables.map(v => v.pollVariableId)
+          );
+          this.prevVariablesSelections = this.filterForm.value.variables || [];
+          this._sendFilters();
+        },
       });
   }
 
@@ -281,7 +340,10 @@ export class PollFiltersComponent implements OnInit {
     if (!this.polls) return;
     const poll = this.polls.find(p => p.uuid === this.polls[0]?.uuid);
     const cohorts = this.filterForm.value.cohortIds || [];
-    const title = `Poll: ${poll?.name} - Cohort(s): ${cohorts.map(cohortId => this.cohorts.find(c => c.id == cohortId)?.name)}`;
+    const cohortNames = cohorts.map(
+      cohortId => this.cohorts().find(c => c.id == cohortId)?.name
+    );
+    const title = `Poll: ${poll?.name} - Cohort(s): ${cohortNames}`;
     const uuid = this.polls[0]?.uuid || '';
     const cohortIds = this.filterForm.value.cohortIds!.filter(Boolean);
     const variableIds = this.filterForm.value.variables || [];

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -3,6 +3,7 @@ import {
   DestroyRef,
   Input,
   OnInit,
+  ViewChild,
   inject,
   output,
 } from '@angular/core';
@@ -15,7 +16,11 @@ import {
 } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import {
+  MatSelect,
+  MatSelectChange,
+  MatSelectModule,
+} from '@angular/material/select';
 
 import { CohortModel } from '@core/models/cohort.model';
 import { PollModel } from '@core/models/poll.model';
@@ -48,6 +53,7 @@ import { Pagination } from '@core/services/interfaces/server.type';
 })
 export class PollFiltersComponent implements OnInit {
   @Input() showVariables = true;
+  @ViewChild('evaluationSelect') evaluationSelect!: MatSelect;
 
   private cohortsService = inject(CohortService);
   private destroyRef = inject(DestroyRef);
@@ -93,6 +99,15 @@ export class PollFiltersComponent implements OnInit {
 
   ngOnInit() {
     this._loadEvaluations();
+  }
+
+  handleEvaluationDropdownOpen(isOpen: boolean) {
+    if (!isOpen) return;
+    setTimeout(() => {
+      const panel = this.evaluationSelect.panel?.nativeElement;
+      if (!panel) return;
+      panel.addEventListener('scroll', () => this._onPanelScroll(panel));
+    });
   }
 
   handleEvaluationSelect(itemSelected: MatSelectChange) {
@@ -275,13 +290,15 @@ export class PollFiltersComponent implements OnInit {
     this.filters.emit({ title, uuid, cohortIds, variableIds, lastVersion });
   }
 
-  onDropdownScroll() {
-    if (this.isLoadingMore) return;
+  private _onPanelScroll(panel: HTMLElement) {
+    const nearBottom =
+      panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 50;
+    if (!nearBottom || this.isLoadingMore) return;
     const hasMore = (this.evaluations?.length ?? 0) < this.totalEvaluations;
     if (!hasMore) return;
 
     this.isLoadingMore = true;
-    this.pagination = { page: this.pagination.page + 1, pageSize: 5 };
+    this.pagination = { page: this.pagination.page + 1, pageSize: 10 };
     this._loadEvaluations();
   }
 }

--- a/src/app/shared/components/form-field-virtual-scroll/interfaces/select.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/interfaces/select.ts
@@ -1,0 +1,25 @@
+import { SelectAllValue } from '@shared/directives/select-all-value';
+
+export interface SelectGroup {
+  label: string;
+  items: MultipleSelectItem[];
+}
+
+export interface BaseItem {
+  label: string;
+}
+
+export interface SingleSelectItem extends BaseItem {
+  value: string | number | boolean | { id: number };
+}
+
+export interface MultipleSelectCommonItem extends BaseItem {
+  type?: 'common';
+  value: SelectAllValue;
+}
+
+export interface MultipleSelectGroup extends BaseItem {
+  type: 'group';
+}
+
+export type MultipleSelectItem = MultipleSelectCommonItem | MultipleSelectGroup;

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
@@ -1,0 +1,42 @@
+<mat-form-field appearance="fill">
+  <mat-label [attr.for]="id()">{{ label() }}</mat-label>
+
+  <mat-select
+    multiple
+    [id]="id()"
+    [formControl]="control()"
+    (openedChange)="openedChange.emit($event)"
+  >
+    <mat-select-trigger>
+      <app-selected-items [items]="getItemSelection()" />
+    </mat-select-trigger>
+
+    <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
+      <mat-option appSelectAll [allValues]="scrollItemsValues()">
+        Select all
+      </mat-option>
+
+      <ng-container *cdkVirtualFor="let item of scrollItems()">
+        @if (isGroupItem(item)) {
+          <mat-option disabled class="group-header">
+            {{ item.label | uppercase }}
+          </mat-option>
+        } @else {
+          <mat-option
+            class="group-option versioned-option"
+            [value]="item.value"
+            >{{ item.label }}</mat-option
+          >
+        }
+      </ng-container>
+    </cdk-virtual-scroll-viewport>
+  </mat-select>
+
+  @if (control().invalid) {
+    <mat-error>
+      @if (control().hasError('required')) {
+        This field is required
+      }
+    </mat-error>
+  }
+</mat-form-field>

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.scss
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.scss
@@ -1,0 +1,21 @@
+.viewport {
+  /* Show 5 mat-option on select */
+  height: calc(5 * 48px);
+  max-height: calc(5 * 48px);
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+::ng-deep {
+  .mat-mdc-option.group-header {
+    .mat-pseudo-checkbox {
+      display: none !important;
+    }
+
+    .mdc-list-item__primary-text {
+      opacity: 1 !important;
+    }
+  }
+}

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.spec.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.spec.ts
@@ -1,0 +1,117 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { SelectMultipleVirtualScrollComponent } from './select-multiple-virtual-scroll.component';
+import { MultipleSelectItem, SelectGroup } from '../interfaces/select';
+
+describe('SelectMultipleVirtualScrollComponent', () => {
+  let component: SelectMultipleVirtualScrollComponent;
+  let fixture: ComponentFixture<SelectMultipleVirtualScrollComponent>;
+
+  const mockItems: MultipleSelectItem[] = [
+    { label: 'Option 1', value: 1 },
+    { label: 'Option 2', value: 2 },
+  ];
+
+  const mockGroups: SelectGroup[] = [
+    {
+      label: 'Group A',
+      items: [
+        { label: 'Item A1', value: 'a1' },
+        { label: 'Item A2', value: 'a2' },
+      ],
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        SelectMultipleVirtualScrollComponent,
+        ReactiveFormsModule,
+        BrowserAnimationsModule, // Necesario para componentes de Angular Material
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectMultipleVirtualScrollComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('control', new FormControl([]));
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should build scrollItems based on simple items', () => {
+    fixture.componentRef.setInput('control', new FormControl([]));
+    fixture.componentRef.setInput('items', mockItems);
+
+    fixture.detectChanges();
+
+    expect(component.scrollItems()).toEqual(mockItems);
+  });
+
+  it('should build scrollItems based on groups when empty', () => {
+    fixture.componentRef.setInput('control', new FormControl([]));
+    fixture.componentRef.setInput('items', []);
+    fixture.componentRef.setInput('groups', mockGroups);
+
+    fixture.detectChanges();
+
+    const expected = [
+      { label: 'Group A', type: 'group' },
+      { label: 'Item A1', value: 'a1' },
+      { label: 'Item A2', value: 'a2' },
+    ];
+    expect(component.scrollItems()).toEqual(expected as MultipleSelectItem[]);
+  });
+
+  it('should calculate scrollItemsValues', () => {
+    fixture.componentRef.setInput('control', new FormControl([]));
+    fixture.componentRef.setInput('groups', mockGroups);
+
+    fixture.detectChanges();
+
+    expect(component.scrollItemsValues()).toEqual(['a1', 'a2']);
+  });
+
+  it('should emit event openedChange(false) when items initialize', () => {
+    spyOn(component.openedChange, 'emit');
+    fixture.componentRef.setInput('control', new FormControl([]));
+    fixture.componentRef.setInput('items', mockItems);
+
+    fixture.detectChanges();
+
+    expect(component.openedChange.emit).toHaveBeenCalledWith(false);
+  });
+
+  it('should return ["Select all"] when all elements are selected', () => {
+    const control = new FormControl([1, 2]);
+    fixture.componentRef.setInput('control', control);
+    fixture.componentRef.setInput('items', mockItems);
+
+    fixture.detectChanges();
+
+    const selection = component.getItemSelection();
+    expect(selection).toEqual(['Select all']);
+  });
+
+  it('should return [""] when control has no value', () => {
+    const control = new FormControl(null);
+    fixture.componentRef.setInput('control', control);
+
+    fixture.detectChanges();
+
+    expect(component.getItemSelection()).toEqual(['']);
+  });
+
+  it('should return true when type is group', () => {
+    const item: MultipleSelectItem = { label: 'Test', type: 'group' };
+    expect(component.isGroupItem(item)).toBeTrue();
+  });
+
+  it('should return false when type is not group', () => {
+    const item: MultipleSelectItem = { label: 'Test', value: 1 };
+    expect(component.isGroupItem(item)).toBeFalse();
+  });
+});

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -1,0 +1,124 @@
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  output,
+} from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import {
+  MultipleSelectCommonItem,
+  MultipleSelectGroup,
+  MultipleSelectItem,
+  SelectGroup,
+} from '../interfaces/select';
+import { SelectAllDirective } from '@shared/directives/select-all.directive';
+import { SelectedItemsComponent } from '@modules/reports/components/poll-filters/selected-items/selected-items.component';
+import { SelectAllValue } from '@shared/directives/select-all-value';
+import { UpperCasePipe } from '@angular/common';
+
+@Component({
+  selector: 'app-select-multiple-virtual-scroll',
+  standalone: true,
+  imports: [
+    MatFormFieldModule,
+    MatSelectModule,
+    MatIconModule,
+    ReactiveFormsModule,
+    ScrollingModule,
+    SelectAllDirective,
+    SelectedItemsComponent,
+    UpperCasePipe,
+  ],
+  templateUrl: './select-multiple-virtual-scroll.component.html',
+  styleUrl: './select-multiple-virtual-scroll.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SelectMultipleVirtualScrollComponent {
+  readonly templateCacheSize = 10;
+  readonly itemSize = 48;
+  readonly label = input<string>('');
+  readonly id = input<string>('');
+  readonly control = input.required<FormControl>();
+  readonly items = input<MultipleSelectItem[]>([]);
+  readonly groups = input<SelectGroup[]>([]);
+  readonly scrollItems = computed<MultipleSelectItem[]>(() =>
+    this.buildScrollItems()
+  );
+  readonly scrollItemsValues = computed<SelectAllValue[]>(() =>
+    this.scrollItems()
+      .filter(
+        (item): item is MultipleSelectCommonItem => !this.isGroupItem(item)
+      )
+
+      .map(scrollItem => scrollItem.value)
+  );
+  readonly openedChange = output<boolean>();
+
+  constructor() {
+    effect(() => {
+      const currentItems = this.scrollItems();
+      const defaultValue = this.scrollItemsValues();
+
+      if (currentItems && currentItems.length > 0) {
+        this.control().patchValue(defaultValue);
+        this.openedChange.emit(false);
+      }
+    });
+  }
+
+  buildScrollItems() {
+    let scrollItems: MultipleSelectItem[] = this.items ? this.items() : [];
+
+    if (!scrollItems || scrollItems.length === 0) {
+      const groups = this.groups ? this.groups() : [];
+
+      if (groups.length > 0) {
+        scrollItems = groups.flatMap(g => [
+          { label: g.label, type: 'group' },
+          ...g.items,
+        ]);
+      }
+    }
+
+    return scrollItems;
+  }
+
+  getItemSelection() {
+    const value = this.control().value;
+
+    let toReturn = [''];
+
+    if (value) {
+      // SelectAll directive adds an option with value undefined
+      const selectedItems = value.filter((item: MultipleSelectItem) => !!item);
+      const scrollItems = this.scrollItems().filter(
+        scrollItem => !scrollItem.type || scrollItem.type !== 'group'
+      );
+
+      if (selectedItems.length === scrollItems.length) {
+        toReturn = ['Select all'];
+      } else {
+        toReturn = selectedItems?.map((selectedItem: unknown) => {
+          const match = scrollItems.find(
+            (item: MultipleSelectItem) =>
+              !this.isGroupItem(item) && item.value === selectedItem
+          );
+
+          return match ? match.label : '';
+        });
+      }
+    }
+
+    return toReturn;
+  }
+
+  isGroupItem(item: MultipleSelectItem): item is MultipleSelectGroup {
+    return !!(item.type && item.type === 'group');
+  }
+}

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -59,13 +59,14 @@ export class SelectMultipleVirtualScrollComponent {
       .map(scrollItem => scrollItem.value)
   );
   readonly openedChange = output<boolean>();
+  readonly autoSelect = input<boolean>(true);
 
   constructor() {
     effect(() => {
       const currentItems = this.scrollItems();
       const defaultValue = this.scrollItemsValues();
 
-      if (currentItems && currentItems.length > 0) {
+      if (currentItems && currentItems.length > 0 && this.autoSelect()) {
         this.control().patchValue(defaultValue);
         this.openedChange.emit(false);
       }

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
@@ -1,0 +1,27 @@
+<mat-form-field appearance="fill">
+  <mat-label [attr.for]="id()">{{ label() }}</mat-label>
+
+  <mat-select
+    [id]="id()"
+    [formControl]="control()"
+    (selectionChange)="selectionChange.emit($event)"
+  >
+    <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
+      <mat-option
+        *cdkVirtualFor="let item of items(); templateCacheSize: 50"
+        class="versioned-option"
+        [value]="item.value"
+      >
+        <p>{{ item.label }}</p>
+      </mat-option>
+    </cdk-virtual-scroll-viewport>
+  </mat-select>
+
+  @if (control().invalid) {
+    <mat-error>
+      @if (control().hasError('required')) {
+        This field is required
+      }
+    </mat-error>
+  }
+</mat-form-field>

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
@@ -6,7 +6,7 @@
     [formControl]="control()"
     (selectionChange)="selectionChange.emit($event)"
   >
-    <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
+    <cdk-virtual-scroll-viewport [itemSize]="35" class="viewport">
       <mat-option
         *cdkVirtualFor="let item of items(); templateCacheSize: 50"
         class="versioned-option"

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.scss
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.scss
@@ -1,0 +1,7 @@
+.viewport {
+  /* Show 5 mat-option on select */
+  height: calc(5 * 48px);
+}
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.spec.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { SelectVirtualScrollComponent } from './select-virtual-scroll.component';
+
+describe('SelectVirtualScrollComponent', () => {
+  let component: SelectVirtualScrollComponent;
+  let fixture: ComponentFixture<SelectVirtualScrollComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        SelectVirtualScrollComponent,
+        ReactiveFormsModule,
+        BrowserAnimationsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectVirtualScrollComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('control', new FormControl());
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should update label', () => {
+    fixture.componentRef.setInput('control', new FormControl());
+    fixture.componentRef.setInput('label', 'LabelValue');
+
+    fixture.detectChanges();
+
+    expect(component.label()).toBe('LabelValue');
+  });
+
+  it('should receive id', () => {
+    fixture.componentRef.setInput('control', new FormControl());
+    fixture.componentRef.setInput('id', 'IdValue');
+
+    fixture.detectChanges();
+
+    expect(component.id()).toBe('IdValue');
+  });
+});

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
@@ -1,0 +1,35 @@
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import { SingleSelectItem } from '../interfaces/select';
+
+@Component({
+  selector: 'app-select-virtual-scroll',
+  standalone: true,
+  imports: [
+    MatFormFieldModule,
+    MatSelectModule,
+    MatIconModule,
+    ReactiveFormsModule,
+    ScrollingModule,
+  ],
+  templateUrl: './select-virtual-scroll.component.html',
+  styleUrl: './select-virtual-scroll.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SelectVirtualScrollComponent {
+  readonly itemSize = 48;
+  readonly label = input<string>('');
+  readonly items = input<SingleSelectItem[]>([]);
+  readonly id = input<string>('');
+  readonly control = input.required<FormControl>();
+  readonly selectionChange = output<MatSelectChange>();
+}

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
@@ -26,7 +26,6 @@ import { SingleSelectItem } from '../interfaces/select';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectVirtualScrollComponent {
-  readonly itemSize = 48;
   readonly label = input<string>('');
   readonly items = input<SingleSelectItem[]>([]);
   readonly id = input<string>('');

--- a/src/app/shared/directives/select-all-value.ts
+++ b/src/app/shared/directives/select-all-value.ts
@@ -1,0 +1,1 @@
+export type SelectAllValue = { id: number } | number | string;

--- a/src/app/shared/directives/select-all.directive.ts
+++ b/src/app/shared/directives/select-all.directive.ts
@@ -9,8 +9,7 @@ import {
 } from '@angular/core';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { Subscription } from 'rxjs';
-
-type SelectAllValue = { id: number } | number | string;
+import { SelectAllValue } from './select-all-value';
 
 @Directive({
   selector: 'mat-option[appSelectAll]',


### PR DESCRIPTION
## Description

Fix duplicated list of evaluations in dropdown when it has more than 10 evaluations. Because of a different way to use infinite scroll in dropdown.

### Solution

Use of cdk-virtual-scroll-viewport library that computes visible ranges without measuring DOM elements, moreover in #732 the select-virtual-scroll and select-multiple-virtual-scroll components were made. This branch integrated the work.

## Type of change

- [X] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#693 
