### PR TITLE
fix-693: Use virtual-scroll or select depend on the amount of data

### DIFF
--- a/src/app/core/constants/select.ts
+++ b/src/app/core/constants/select.ts
@@ -1,0 +1,1 @@
+export const VIRTUAL_SCROLL_THRESHOLD = 200;

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import { MatSelectModule } from '@angular/material/select';
 
 import { CohortModel } from '@core/models/cohort.model';
 import { PollModel } from '@core/models/poll.model';
@@ -40,6 +40,7 @@ import {
   SingleSelectItem,
 } from '@shared/components/form-field-virtual-scroll/interfaces/select';
 import { switchMap } from 'rxjs';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 
 @Component({
   selector: 'app-poll-filters',
@@ -101,12 +102,10 @@ export class PollFiltersComponent implements OnInit {
   });
 
   readonly evaluationsToScroll = computed<SingleSelectItem[]>(() => {
-    return (this.evaluations() ?? [])
-      .filter(e => e.status === 'Completed')
-      .map(e => ({
-        label: `${e.name} - ${e.status}`,
-        value: e,
-      }));
+    return (this.evaluations() ?? []).map(e => ({
+      label: `${e.name} - ${e.status}`,
+      value: e,
+    }));
   });
 
   readonly cohortsToScroll = computed<MultipleSelectCommonItem[]>(() => {
@@ -142,8 +141,8 @@ export class PollFiltersComponent implements OnInit {
     this._loadEvaluations();
   }
 
-  handleEvaluationSelect(itemSelected: MatSelectChange) {
-    const newSelectedEvaluation: EvaluationModel = itemSelected.value;
+  handleEvaluationSelect(itemSelected: MatAutocompleteSelectedEvent) {
+    const newSelectedEvaluation: EvaluationModel = itemSelected.option.value;
     this._resetField('cohortIds');
     this._getPolls(newSelectedEvaluation);
     const newSelectedPoll = this.polls[0];
@@ -265,7 +264,8 @@ export class PollFiltersComponent implements OnInit {
       )
       .subscribe({
         next: result => {
-          this.evaluations.set(result.items);
+          const completed = result.items.filter(e => e.status === 'Completed');
+          this.evaluations.set(completed);
         },
         error: () => this.evaluations.set(null),
       });

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
@@ -11,12 +11,29 @@
       <app-selected-items [items]="getItemSelection()" />
     </mat-select-trigger>
 
-    <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
-      <mat-option appSelectAll [allValues]="scrollItemsValues()">
-        Select all
-      </mat-option>
+    <mat-option appSelectAll [allValues]="scrollItemsValues()">
+      Select all
+    </mat-option>
 
-      <ng-container *cdkVirtualFor="let item of scrollItems()">
+    @if (useVirtualScroll()) {
+      <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
+        <ng-container *cdkVirtualFor="let item of scrollItems()">
+          @if (isGroupItem(item)) {
+            <mat-option disabled class="group-header">
+              {{ item.label | uppercase }}
+            </mat-option>
+          } @else {
+            <mat-option
+              class="group-option versioned-option"
+              [value]="item.value"
+            >
+              {{ item.label }}
+            </mat-option>
+          }
+        </ng-container>
+      </cdk-virtual-scroll-viewport>
+    } @else {
+      @for (item of scrollItems(); track item.label) {
         @if (isGroupItem(item)) {
           <mat-option disabled class="group-header">
             {{ item.label | uppercase }}
@@ -25,11 +42,12 @@
           <mat-option
             class="group-option versioned-option"
             [value]="item.value"
-            >{{ item.label }}</mat-option
           >
+            {{ item.label }}
+          </mat-option>
         }
-      </ng-container>
-    </cdk-virtual-scroll-viewport>
+      }
+    }
   </mat-select>
 
   @if (control().invalid) {

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -21,6 +21,7 @@ import { SelectAllDirective } from '@shared/directives/select-all.directive';
 import { SelectedItemsComponent } from '@modules/reports/components/poll-filters/selected-items/selected-items.component';
 import { SelectAllValue } from '@shared/directives/select-all-value';
 import { UpperCasePipe } from '@angular/common';
+import { VIRTUAL_SCROLL_THRESHOLD } from '@core/constants/select';
 
 @Component({
   selector: 'app-select-multiple-virtual-scroll',
@@ -122,4 +123,8 @@ export class SelectMultipleVirtualScrollComponent {
   isGroupItem(item: MultipleSelectItem): item is MultipleSelectGroup {
     return !!(item.type && item.type === 'group');
   }
+
+  readonly useVirtualScroll = computed(
+    () => this.scrollItems().length > VIRTUAL_SCROLL_THRESHOLD
+  );
 }

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.html
@@ -1,21 +1,42 @@
 <mat-form-field appearance="fill">
   <mat-label [attr.for]="id()">{{ label() }}</mat-label>
-
-  <mat-select
+  <input
+    matInput
     [id]="id()"
     [formControl]="control()"
-    (selectionChange)="selectionChange.emit($event)"
+    [matAutocomplete]="auto"
+    (input)="onInput($event)"
+  />
+  <mat-icon matSuffix>
+    {{ auto.isOpen ? 'arrow_drop_up' : 'arrow_drop_down' }}
+  </mat-icon>
+
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    [displayWith]="displayFn"
+    (optionSelected)="selectionChange.emit($event)"
   >
-    <cdk-virtual-scroll-viewport [itemSize]="35" class="viewport">
-      <mat-option
-        *cdkVirtualFor="let item of items(); templateCacheSize: 50"
-        class="versioned-option"
-        [value]="item.value"
-      >
-        <p>{{ item.label }}</p>
-      </mat-option>
-    </cdk-virtual-scroll-viewport>
-  </mat-select>
+    @if (useVirtualScroll()) {
+      <cdk-virtual-scroll-viewport [itemSize]="itemSize" class="viewport">
+        <mat-option
+          *cdkVirtualFor="
+            let item of filteredItems();
+            trackBy: trackByFn;
+            templateCacheSize: 50
+          "
+          [value]="item.value"
+        >
+          {{ item.label }}
+        </mat-option>
+      </cdk-virtual-scroll-viewport>
+    } @else {
+      @for (item of filteredItems(); track item.value) {
+        <mat-option [value]="item.value">
+          {{ item.label }}
+        </mat-option>
+      }
+    }
+  </mat-autocomplete>
 
   @if (control().invalid) {
     <mat-error>

--- a/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-virtual-scroll/select-virtual-scroll.component.ts
@@ -2,14 +2,22 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
   output,
+  signal,
 } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import { MatSelectModule } from '@angular/material/select';
 import { SingleSelectItem } from '../interfaces/select';
+import { MatInputModule } from '@angular/material/input';
+import {
+  MatAutocompleteModule,
+  MatAutocompleteSelectedEvent,
+} from '@angular/material/autocomplete';
+import { VIRTUAL_SCROLL_THRESHOLD } from '@core/constants/select';
 
 @Component({
   selector: 'app-select-virtual-scroll',
@@ -20,15 +28,44 @@ import { SingleSelectItem } from '../interfaces/select';
     MatIconModule,
     ReactiveFormsModule,
     ScrollingModule,
+    MatInputModule,
+    MatAutocompleteModule,
   ],
   templateUrl: './select-virtual-scroll.component.html',
   styleUrl: './select-virtual-scroll.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectVirtualScrollComponent {
+  readonly templateCacheSize = 50;
+  readonly itemSize = 48;
   readonly label = input<string>('');
   readonly items = input<SingleSelectItem[]>([]);
   readonly id = input<string>('');
   readonly control = input.required<FormControl>();
-  readonly selectionChange = output<MatSelectChange>();
+  readonly selectionChange = output<MatAutocompleteSelectedEvent>();
+
+  private searchText = signal('');
+  filteredItems = computed(() => {
+    const search = this.searchText().toLocaleLowerCase().trim();
+    if (!search) return this.items();
+    return this.items().filter(item =>
+      item.label.toLowerCase().includes(search)
+    );
+  });
+
+  onInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.searchText.set(value);
+  }
+
+  displayFn = (value: unknown): string => {
+    const match = this.items().find(item => item.value === value);
+    return match?.label ?? '';
+  };
+
+  trackByFn = (_: number, item: SingleSelectItem) => item.value;
+
+  readonly useVirtualScroll = computed(
+    () => this.items().length > VIRTUAL_SCROLL_THRESHOLD
+  );
 }


### PR DESCRIPTION
## Description

Sometimes, when the data (evaluations) have an 'in progress' status, the dropdown does not display the complete list of evaluations correctly.

### Root cause:

Using select-virtual-scroll from cdk-virtual-scroll causes issues with a small amount of data in Angular Material. To fix this, the cdk can only be used when there are more than 150 evaluations; for less data, we use select with Angular Material.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues
#693 

