### PR TITLE
fix: remove max-height property from chart-container class

### DIFF
--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.scss
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.scss
@@ -32,7 +32,6 @@
   width: 100%;
   height: auto;
   max-width: 100%;
-  max-height: 100%;
   white-space: nowrap;
   padding: 10px;
 }
@@ -57,7 +56,6 @@
   .chart-container {
     width: 768px;
     max-width: none;
-    max-height: none;
   }
 }
 


### PR DESCRIPTION
## Description

Removed max-height: 100% property from chart-container CSS class to avoid overlap issue with heatmap chart inside Summary Charts page.

Please make sure to review other places where the chart-container class is used:

- [ ] Student detail modal
- [ ] Dynamic Charts page
- [ ] Home page (swipe cards details)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

[Bug] Summary chart - Graph is overlapped to student details table #786 
