### PR TITLE
fix: improve filters layout and disable components until evaluation i…

### DIFF
--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.html
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.html
@@ -15,37 +15,31 @@
       (selectionChange)="handleEvaluationSelect($event)"
     />
 
-    @if (polls[0]) {
-      <app-select-multiple-virtual-scroll
-        [items]="cohortsToScroll()"
-        [control]="filterForm.controls.cohortIds"
-        [id]="'sl-cohort'"
-        [label]="'Cohort'"
-        (openedChange)="handleCohortSelect($event)"
-      />
-    }
+    <app-select-multiple-virtual-scroll
+      [items]="cohortsToScroll()"
+      [control]="filterForm.controls.cohortIds"
+      [id]="'sl-cohort'"
+      [label]="'Cohort'"
+      (openedChange)="handleCohortSelect($event)"
+    />
 
     @if (showVariables) {
-      @if (filterForm.value.selectedEvaluation) {
-        <app-select-multiple-virtual-scroll
-          [items]="componentsToScroll()"
-          [control]="filterForm.controls.componentNames"
-          [id]="'sl-components'"
-          [label]="'Component'"
-          (openedChange)="handleComponentsSelect($event)"
-        />
-      }
+      <app-select-multiple-virtual-scroll
+        [items]="componentsToScroll()"
+        [control]="filterForm.controls.componentNames"
+        [id]="'sl-components'"
+        [label]="'Component'"
+        (openedChange)="handleComponentsSelect($event)"
+      />
 
-      @if (filterForm.value.cohortIds?.length && showVariables) {
-        <app-select-multiple-virtual-scroll
-          class="variable-field"
-          [control]="filterForm.controls.variables"
-          [id]="'sl-variables'"
-          [label]="'Variable'"
-          [groups]="variableSelectGroups()"
-          (openedChange)="handleVariableSelect($event)"
-        />
-      }
+      <app-select-multiple-virtual-scroll
+        class="variable-field"
+        [control]="filterForm.controls.variables"
+        [id]="'sl-variables'"
+        [label]="'Variable'"
+        [groups]="variableSelectGroups()"
+        (openedChange)="handleVariableSelect($event)"
+      />
     }
 
     <div class="button-container">

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -135,6 +135,7 @@ export class PollFiltersComponent implements OnInit {
   ngOnInit() {
     this._loadEvaluations();
     this._setupDynamicValidators();
+    this._disableSecondaryControls();
   }
 
   handleEvaluationSelect(itemSelected: MatAutocompleteSelectedEvent) {
@@ -146,6 +147,12 @@ export class PollFiltersComponent implements OnInit {
       componentNames: [],
       variables: [],
     });
+
+    this.filterForm.controls.cohortIds.enable();
+    if (this.showVariables) {
+      this.filterForm.controls.componentNames.enable();
+      this.filterForm.controls.variables.disable();
+    }
 
     this._getPolls(newSelectedEvaluation);
     if (this.polls[0]) {
@@ -172,9 +179,12 @@ export class PollFiltersComponent implements OnInit {
       this.variableGroups = [];
       this._resetField('variables');
       this.filterForm.controls.variables.markAsTouched();
+      this.filterForm.controls.variables.disable();
       this.variables.set([]);
       return;
     }
+
+    this.filterForm.controls.variables.enable();
 
     this.variableGroups =
       this.filterForm.value.componentNames
@@ -373,5 +383,13 @@ export class PollFiltersComponent implements OnInit {
       lastVersion: true,
       evaluationId,
     });
+  }
+
+  private _disableSecondaryControls() {
+    this.filterForm.controls.cohortIds.disable();
+    if (this.showVariables) {
+      this.filterForm.controls.componentNames.disable();
+      this.filterForm.controls.variables.disable();
+    }
   }
 }

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.html
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h2 class="page-title">Polls Answered</h2>
 </div>
-<div class="form-container">
+<div>
   <app-poll-filters
     [showVariables]="false"
     (filters)="handleFilterSelect($event)"

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.scss
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.scss
@@ -2,7 +2,7 @@
 
 .form-container {
   display: flex;
-  gap: 1em;
+  gap: 1rem;
   justify-content: space-between;
   padding-bottom: 1.5em;
 


### PR DESCRIPTION
## Description

- Updated filters layout to fill the entire central panel as per Figma designs
- Fixed dropdown visibility so all filter components are displayed
- Disabled dependent fields until an evaluation is selected
- Applied consistent behavior across Dynamic Charts, Summary Charts, and Polls Answered
- Adjusted layout in Polls Answered to avoid unused empty space

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


