### PR TITLE
Fix eras v2  action icons download pdf charts should be included within in each chart component top right corner

### DIFF
--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.html
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.html
@@ -4,13 +4,21 @@
   [class.card--dimmed]="dimmed"
   #cardRef
 >
-  <button class="pdf-export" (click)="onExportPdf()">Export</button>
-  <button class="change-to-column" (click)="changeToColumn()">
+  <button class="pdf-export" matTooltip="Download pdf" (click)="onExportPdf()">
+    Export
+  </button>
+  <button
+    class="change-to-column"
+    matTooltip="Charts"
+    mat-icon-button
+    (click)="changeToColumn()"
+  >
     <img src="assets/icons/graphic.svg" alt="bar_chart" />
   </button>
   <button
     class="toggle-btn"
-    [attr.aria-label]="expanded ? 'Colapsar' : 'Expandir'"
+    [matTooltip]="expanded ? 'Collapse' : 'Expand'"
+    [attr.aria-label]="expanded ? 'Collapse' : 'Expand'"
     (click)="onToggle()"
     type="button"
   >

--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.html
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.html
@@ -11,10 +11,19 @@
     class="change-to-column"
     matTooltip="Charts"
     mat-icon-button
+    [matMenuTriggerFor]="chartMenu"
     (click)="changeToColumn()"
   >
     <img src="assets/icons/graphic.svg" alt="bar_chart" />
   </button>
+  <mat-menu #chartMenu="matMenu">
+    <button mat-menu-item disabled="true" (click)="changeToHeatmap()">
+      Heatmap chart
+    </button>
+    <button mat-menu-item disabled="true" (click)="changeToColumn()">
+      Column chart
+    </button>
+  </mat-menu>
   <button
     class="toggle-btn"
     [matTooltip]="expanded ? 'Collapse' : 'Expand'"

--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.scss
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.scss
@@ -135,6 +135,10 @@ $spring-collapse: 340ms cubic-bezier(0.4, 0, 1, 1);
   font-weight: 450;
 }
 
+.mat-mdc-menu-item {
+  min-height: 36px;
+}
+
 .card-body {
   padding: 8px 0;
   flex: 1;

--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.ts
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.ts
@@ -14,10 +14,11 @@ import {
 import { MatIconModule } from '@angular/material/icon';
 import { PdfHelper } from '@core/utils/reports/exportReport.util';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 
 @Component({
   selector: 'app-expandable-card',
-  imports: [MatIconModule, MatTooltipModule],
+  imports: [MatIconModule, MatTooltipModule, MatMenuModule],
   templateUrl: './expandable-card.component.html',
   styleUrl: './expandable-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -66,5 +67,9 @@ export class ExpandableCardComponent implements OnChanges {
 
   changeToColumn(): void {
     //it will be implemented on the #793 feature
+  }
+
+  changeToHeatmap(): void {
+    // it will be implemented on the #793 feature
   }
 }

--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.ts
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.ts
@@ -13,10 +13,11 @@ import {
 } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { PdfHelper } from '@core/utils/reports/exportReport.util';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-expandable-card',
-  imports: [MatIconModule],
+  imports: [MatIconModule, MatTooltipModule],
   templateUrl: './expandable-card.component.html',
   styleUrl: './expandable-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Description

Since the rejected cases, the icons now have tooltips to indicate whether to expand or collapse, as well as options for charts and downloading PDFs.
A menu option to change charts has also been added, but it is disabled because work is ongoing on issue 793.

### Where was it implemented?
In the 'Reports' section, in 'Dynamic charts'.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#795 
