### PR TITLE
809 bug dynamic charts variable dropdown is disabled when navigating and expanding through cohort and component without modifying its elements

### DIFF
--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -148,14 +148,20 @@ export class PollFiltersComponent implements OnInit {
       variables: [],
     });
 
+    this.componentNames.set([]);
+    this.variables.set([]);
+    this.prevComponentSelections = [];
+    this.prevCohortIds = [];
+    this.prevVariablesSelections = [];
+
     this.filterForm.controls.cohortIds.enable();
     if (this.showVariables) {
-      this.filterForm.controls.componentNames.enable();
+      this.filterForm.controls.componentNames.disable();
       this.filterForm.controls.variables.disable();
     }
 
     this._getPolls(newSelectedEvaluation);
-    if (this.polls[0]) {
+    if (this.polls?.length) {
       this._getCohorts(this.polls[0].uuid);
     }
   }
@@ -171,6 +177,8 @@ export class PollFiltersComponent implements OnInit {
 
   handleComponentsSelect(isOpen: boolean) {
     if (isOpen) return;
+    if (this.filterForm.controls.componentNames.disabled) return;
+
     const componentNames = this.filterForm.value.componentNames || [];
     if (areArraysEqual(this.prevComponentSelections, componentNames)) return;
     this.prevComponentSelections = [...componentNames];
@@ -322,12 +330,14 @@ export class PollFiltersComponent implements OnInit {
     });
   }
 
-  private _getVariables() {
+  private _getVariables(filterNames?: string[]) {
     if (!this.polls || !this.polls[0]?.uuid) return;
-    const componentNames = this.componentNames() || [];
+
+    const namesToQuery =
+      filterNames ?? this.filterForm.value.componentNames ?? [];
 
     this.pollsService
-      .getVariablesByComponents(this.polls[0].uuid, [...componentNames], true)
+      .getVariablesByComponents(this.polls[0].uuid, [...namesToQuery], true)
       .subscribe({
         next: variables => {
           if (!variables) return;
@@ -337,7 +347,18 @@ export class PollFiltersComponent implements OnInit {
           const newComponentNames = [
             ...new Set(variables.map(v => v.componentName).filter(Boolean)),
           ];
+
           this.componentNames.set(newComponentNames);
+
+          if (filterNames) {
+            this.filterForm.controls.componentNames.setValue(newComponentNames);
+            this.prevComponentSelections = [...newComponentNames];
+          }
+
+          if (this.showVariables) {
+            this.filterForm.controls.componentNames.enable();
+            this.filterForm.controls.variables.enable();
+          }
 
           const groups = newComponentNames.map(compName => ({
             label: compName.toUpperCase(),

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -70,9 +70,10 @@ export class SelectMultipleVirtualScrollComponent {
     effect(() => {
       const currentItems = this.scrollItems();
       const defaultValue = this.scrollItemsValues();
+      const ctrl = this.control();
 
       if (currentItems && currentItems.length > 0 && this.autoSelect()) {
-        this.control().patchValue(defaultValue);
+        ctrl.patchValue(defaultValue);
         this.openedChange.emit(false);
       }
     });

--- a/src/app/shared/directives/select-all.directive.ts
+++ b/src/app/shared/directives/select-all.directive.ts
@@ -4,8 +4,8 @@ import {
   inject,
   Input,
   OnDestroy,
-  SimpleChanges,
   OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { Subscription } from 'rxjs';
@@ -19,45 +19,56 @@ export class SelectAllDirective<T extends SelectAllValue>
   implements AfterViewInit, OnDestroy, OnChanges
 {
   @Input() allValues: T[] = [];
-  private _allValues: T[] = [];
 
   private _matSelect = inject(MatSelect);
   private _matOption = inject(MatOption);
-
   private _subscriptions: Subscription[] = [];
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['allValues']) {
-      this._allValues = changes['allValues'].currentValue || [];
+      const ctrl = this._matSelect.ngControl?.control;
+      if (ctrl) {
+        this._updateState(ctrl.value);
+      }
     }
   }
-  private getAllIds(): number[] | string[] {
-    const all = this._allValues;
 
+  private getAllIds(): (number | string)[] {
+    const all = this.allValues;
+    if (!all || all.length === 0) return [];
     if (typeof all[0] === 'object' && all[0] !== null && 'id' in all[0]) {
-      return (all as { id: number }[]).map(item => item.id);
+      return (all as { id: number | string }[]).map(item => item.id);
     }
-    return typeof all[0] == 'string' ? (all as string[]) : (all as number[]);
+    return all as (number | string)[];
   }
 
-  private isAllSelected(selected: T[]): boolean {
-    selected = selected.filter(s => s);
-    const allIds = this.getAllIds();
-    const selectedIds = Array.isArray(selected)
-      ? selected.map((item: T) =>
-          typeof item === 'object' && item !== null && 'id' in item
-            ? item.id
-            : item
-        )
-      : [];
-    return allIds.length === selectedIds.length;
+  private isAllSelected(selected: T[] | null | undefined): boolean {
+    if (!this.allValues || this.allValues.length === 0) return false;
+    const safeSelected = (selected || []).filter(
+      (s): s is T => s !== null && s !== undefined
+    );
+    return (
+      this.getAllIds().length > 0 &&
+      this.getAllIds().length === safeSelected.length
+    );
+  }
+
+  private _updateState(currentValue: T[] | null | undefined): void {
+    if (!this.allValues || this.allValues.length === 0) {
+      this._matOption.deselect(false);
+      return;
+    }
+    if (this.isAllSelected(currentValue)) {
+      this._matOption.select(false);
+    } else {
+      this._matOption.deselect(false);
+    }
   }
 
   ngAfterViewInit(): void {
     const parentSelect = this._matSelect;
-    const parentFormControl = parentSelect.ngControl.control;
+    const parentFormControl = parentSelect.ngControl?.control;
 
-    // When select all option is clicked
     this._subscriptions.push(
       this._matOption.onSelectionChange.subscribe(event => {
         if (event.isUserInput) {
@@ -71,21 +82,15 @@ export class SelectAllDirective<T extends SelectAllValue>
         }
       })
     );
-    // For changing select all based on other option selection
+
     this._subscriptions.push(
       parentSelect.optionSelectionChanges.subscribe(v => {
         if (v.isUserInput && v.source.value !== this._matOption.value) {
-          if (!v.source.selected) {
-            this._matOption.deselect(false);
-          } else {
-            if (this.isAllSelected(parentFormControl?.value || [])) {
-              this._matOption.select(false);
-            }
-          }
+          this._updateState(parentFormControl?.value);
         }
       })
     );
-    // If user has kept all values selected in select's form-control from the beginning
+
     setTimeout(() => {
       if (this.isAllSelected(parentFormControl?.value || [])) {
         this._matOption.select(false);


### PR DESCRIPTION
## Description

This issue occurs in Dynamic Charts. After selecting an evaluation and navigating through Cohort, Components, or Variable by expanding elements without making changes, switching to another evaluation causes the Variable dropdown to become disabled.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


