### PR TITLE
Refactor/fe 800/refactor user profile popover menu

### DIFF
--- a/src/app/core/components/layout/user-menu/user-menu.component.html
+++ b/src/app/core/components/layout/user-menu/user-menu.component.html
@@ -1,24 +1,38 @@
-<mat-toolbar>
-  <div class="user-info">
-    <button
-      [matMenuTriggerFor]="beforeMenu"
-      #menuTrigger="matMenuTrigger"
-      (mouseenter)="menuTrigger.openMenu()"
-      (mouseleave)="mouseLeave(menuTrigger)"
-    >
-      <mat-icon>person</mat-icon>
-    </button>
-    <mat-menu #beforeMenu="matMenu" xPosition="before" hasBackdrop="false">
-      <button
-        mat-menu-item
-        class="menu-button"
-        (click)="logout()"
-        (mouseenter)="mouseEnter(menuTrigger)"
-        (mouseleave)="mouseLeave(menuTrigger)"
-      >
-        <mat-icon>logout</mat-icon>
-        <span>Logout</span>
-      </button>
-    </mat-menu>
+<div class="main-button-container">
+  <button [matMenuTriggerFor]="beforeMenu" class="main-button">
+    <mat-icon>account_circle</mat-icon>
+  </button>
+</div>
+
+<mat-menu #beforeMenu="matMenu" xPosition="before" hasBackdrop="false">
+  <div class="user-info-container">
+    <!-- TODO: Add component/img for profile picture -->
+    <mat-icon class="profile-picture">account_circle</mat-icon>
+    <div class="user-info">
+      <p class="user-name">{{ user()?.firstName }} {{ user()?.lastName }}</p>
+      <p class="user-role">{{ userRole }}</p>
+    </div>
   </div>
-</mat-toolbar>
+  <hr />
+  <div class="options-container">
+    <button mat-menu-item class="menu-button option-button">
+      <mat-icon>person</mat-icon>
+      Account and Information
+    </button>
+    <button
+      mat-menu-item
+      class="menu-button option-button"
+      (click)="redirectToSettings()"
+    >
+      <mat-icon>settings</mat-icon>
+      Platform Settings
+    </button>
+  </div>
+  <hr />
+  <div class="logout-container">
+    <button mat-menu-item class="menu-button logout-button" (click)="logout()">
+      <mat-icon>logout</mat-icon>
+      Log out
+    </button>
+  </div>
+</mat-menu>

--- a/src/app/core/components/layout/user-menu/user-menu.component.html
+++ b/src/app/core/components/layout/user-menu/user-menu.component.html
@@ -10,7 +10,7 @@
     <mat-icon class="profile-picture">account_circle</mat-icon>
     <div class="user-info">
       <p class="user-name">{{ user()?.firstName }} {{ user()?.lastName }}</p>
-      <p class="user-role">{{ userRole }}</p>
+      <p class="user-role">{{ user()?.role }}</p>
     </div>
   </div>
   <hr />

--- a/src/app/core/components/layout/user-menu/user-menu.component.scss
+++ b/src/app/core/components/layout/user-menu/user-menu.component.scss
@@ -1,44 +1,82 @@
+@use '@angular/material' as mat;
 @use 'index.scss' as main-styles;
 
-mat-toolbar {
-  height: auto;
+.logout-button {
+  color: main-styles.get-color('error', 50);
 }
 
-.user-info {
-  display: flex;
-  align-items: center;
-  margin-left: auto;
-  margin-right: main-styles.get-size(margin, lg);
-}
-
-.user-info button {
-  width: main-styles.get-size(icon-size, extra-large);
+.main-button-container {
   height: main-styles.get-size(icon-size, extra-large);
-  margin: main-styles.get-size(margin, xs);
-  border-radius: 50%;
-  border: none;
-  background-color: main-styles.get-color('neutral', 100);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  outline: none;
-}
+  width: main-styles.get-size(icon-size, extra-large);
 
-.user-info button:hover {
-  box-shadow: 1px 2px 2px var(--mat-sys-primary);
+  .main-button {
+    background: none;
+    border: none;
+    border-radius: 50%;
+    color: main-styles.get-color('primary', 30);
+
+    mat-icon {
+      height: main-styles.get-size(icon-size, large);
+      width: main-styles.get-size(icon-size, large);
+      font-size: main-styles.get-size(icon-size, large);
+    }
+  }
 }
 
 .menu-button {
-  background-color: transparent;
-  border: none;
-  color: main-styles.get-color('primary', 30);
   display: flex;
   align-items: center;
   width: 100%;
+  gap: 4px;
+  padding: 8px 16px 8px 16px;
+  background-color: transparent;
+  border: none;
+  font-size: main-styles.get-font-size(label, large);
+
+  &:hover {
+    background-color: main-styles.get-color('neutral', 90);
+  }
 }
-.menu-button:hover {
-  text-decoration: underline;
+
+.user-info-container {
+  cursor: default;
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  gap: 8px;
+
+  .profile-picture {
+    height: 40px;
+    width: 40px;
+    font-size: 40px;
+  }
+
+  .user-info {
+    font-size: main-styles.get-font-size(label, large);
+
+    p {
+      margin: 0px;
+    }
+
+    .user-name {
+      color: main-styles.get-color('neutral', 4);
+      font-weight: main-styles.get-font-weight(semi-bold);
+    }
+
+    .user-role {
+      color: main-styles.get-color('neutral', 50);
+    }
+  }
 }
+
+.option-button {
+  color: main-styles.get-color('neutral', 10);
+}
+
 button {
   cursor: pointer;
+}
+
+hr {
+  border: 1px solid main-styles.get-color('neutral', 90);
 }

--- a/src/app/core/components/layout/user-menu/user-menu.component.ts
+++ b/src/app/core/components/layout/user-menu/user-menu.component.ts
@@ -2,37 +2,32 @@ import { Component, inject } from '@angular/core';
 
 import { MatIcon } from '@angular/material/icon';
 import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
-import { MatToolbar } from '@angular/material/toolbar';
 
 import { UserDataService } from '@core/services/access/user-data.service';
 import { AuthService } from '@core/services/access/access.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-user-menu',
   templateUrl: './user-menu.component.html',
   styleUrls: ['./user-menu.component.scss'],
-  imports: [MatMenu, MatIcon, MatToolbar, MatMenuTrigger],
+  imports: [MatMenu, MatIcon, MatMenuTrigger],
 })
 export class UserMenuComponent {
-  timedOutCloser: ReturnType<typeof setTimeout> | null = null;
   private readonly authService = inject(AuthService);
   private readonly userData = inject(UserDataService);
+  private readonly router = inject(Router);
+
+  user = this.userData.user;
+  // TODO: Add logic for userRole when roles are implemented
+  userRole = 'User';
 
   logout() {
     this.userData.clear();
     this.authService.logout();
   }
 
-  mouseEnter(trigger: MatMenuTrigger) {
-    if (this.timedOutCloser) {
-      clearTimeout(this.timedOutCloser);
-    }
-    trigger.openMenu();
-  }
-
-  mouseLeave(trigger: MatMenuTrigger) {
-    this.timedOutCloser = setTimeout(() => {
-      trigger.closeMenu();
-    }, 100);
+  redirectToSettings() {
+    this.router.navigate(['cosmic-latte']);
   }
 }

--- a/src/app/core/components/layout/user-menu/user-menu.component.ts
+++ b/src/app/core/components/layout/user-menu/user-menu.component.ts
@@ -19,8 +19,6 @@ export class UserMenuComponent {
   private readonly router = inject(Router);
 
   user = this.userData.user;
-  // TODO: Add logic for userRole when roles are implemented
-  userRole = 'User';
 
   logout() {
     this.userData.clear();

--- a/src/app/core/models/profile.model.ts
+++ b/src/app/core/models/profile.model.ts
@@ -1,5 +1,17 @@
+export type ErasRole =
+  | 'Eras Admin'
+  | 'Professional'
+  | 'Student Service'
+  | 'User';
+
 export interface Profile {
   firstName?: string;
   id?: string;
   lastName?: string;
+  role?: ErasRole;
+}
+
+export function isErasRole(role: string): role is ErasRole {
+  const erasRoles = ['Eras Admin', 'Professional', 'Student Service', 'User'];
+  return erasRoles.includes(role);
 }

--- a/src/app/core/models/profile.model.ts
+++ b/src/app/core/models/profile.model.ts
@@ -1,4 +1,5 @@
 export interface Profile {
   firstName?: string;
   id?: string;
+  lastName?: string;
 }

--- a/src/app/core/services/access/user-data.service.spec.ts
+++ b/src/app/core/services/access/user-data.service.spec.ts
@@ -47,7 +47,11 @@ describe('UserDataService', () => {
   });
 
   it('Should fill user, if current user is null, at initUser method.', async () => {
-    const profile: Profile = { firstName: 'user1', id: '2' } as Profile;
+    const profile: Profile = {
+      firstName: 'user1',
+      id: '2',
+      lastName: 'last1',
+    } as Profile;
     mockKeycloak.loadUserProfile.and.returnValue(Promise.resolve(profile));
     service = TestBed.inject(UserDataService);
     await service.initUser();

--- a/src/app/core/services/access/user-data.service.spec.ts
+++ b/src/app/core/services/access/user-data.service.spec.ts
@@ -51,6 +51,7 @@ describe('UserDataService', () => {
       firstName: 'user1',
       id: '2',
       lastName: 'last1',
+      role: 'User',
     } as Profile;
     mockKeycloak.loadUserProfile.and.returnValue(Promise.resolve(profile));
     service = TestBed.inject(UserDataService);

--- a/src/app/core/services/access/user-data.service.ts
+++ b/src/app/core/services/access/user-data.service.ts
@@ -23,8 +23,8 @@ export class UserDataService {
     this.saveToSession(profile as Profile);
   }
 
-  private saveToSession({ firstName, id }: Profile) {
-    const sessionProfile: Profile = { firstName, id };
+  private saveToSession({ firstName, id, lastName }: Profile) {
+    const sessionProfile: Profile = { firstName, id, lastName };
     sessionStorage.setItem(this.STORAGE_KEY, JSON.stringify(sessionProfile));
     this._user.set(sessionProfile);
   }

--- a/src/app/core/services/access/user-data.service.ts
+++ b/src/app/core/services/access/user-data.service.ts
@@ -1,6 +1,6 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
-import { Profile } from '@core/models/profile.model';
-import keycloak from 'keycloak-js';
+import { isErasRole, Profile } from '@core/models/profile.model';
+import keycloak, { KeycloakProfile } from 'keycloak-js';
 
 @Injectable({
   providedIn: 'root',
@@ -19,14 +19,26 @@ export class UserDataService {
   async initUser(): Promise<void> {
     if (this._user()) return;
 
-    const profile = await this.keycloak.loadUserProfile();
-    this.saveToSession(profile as Profile);
+    const keycloakProfile = await this.keycloak.loadUserProfile();
+    const profile = this.mapToProfileModel(keycloakProfile);
+    this.saveToSession(profile);
   }
 
-  private saveToSession({ firstName, id, lastName }: Profile) {
-    const sessionProfile: Profile = { firstName, id, lastName };
-    sessionStorage.setItem(this.STORAGE_KEY, JSON.stringify(sessionProfile));
-    this._user.set(sessionProfile);
+  private mapToProfileModel(userProfile: KeycloakProfile): Profile {
+    const userRole = this.keycloak.realmAccess?.roles.find(role =>
+      isErasRole(role)
+    );
+    return {
+      firstName: userProfile.firstName,
+      id: userProfile.id,
+      lastName: userProfile.lastName,
+      role: userRole ? userRole : 'User',
+    };
+  }
+
+  private saveToSession(profile: Profile) {
+    sessionStorage.setItem(this.STORAGE_KEY, JSON.stringify(profile));
+    this._user.set(profile);
   }
 
   private loadFromSession() {


### PR DESCRIPTION
## Description
Add new user profile popover menu

NOTES:
- Currently Keycloak is not sending the profile picture information thus a mat-icon is shown instead
- The Log out and the Platform setting are working. The Account and Information option is a button that does nothing currently.


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [x] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#800 
