### PR TITLE
fix: preserve component dropdown options on cohort change

### DIFF
--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -173,8 +173,6 @@ export class PollFiltersComponent implements OnInit {
     const cohortIds = this.filterForm.value.cohortIds || [];
     if (areArraysEqual(this['prevCohortIds'], cohortIds)) return;
     this.prevCohortIds = [...cohortIds];
-
-    this._getVariables();
   }
 
   handleComponentsSelect(isOpen: boolean) {

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -205,9 +205,6 @@ export class PollFiltersComponent implements OnInit {
     const variableGroupsFlat = this.variableGroups.flat();
     this.variables.set(variableGroupsFlat);
 
-    this.filterForm.controls.variables.setValue(
-      variableGroupsFlat.map(v => !!v && v.pollVariableId)
-    );
     const result = this.variableGroups.flatMap(variableGroup => [
       {
         label: variableGroup[0].componentName.toLocaleUpperCase(),
@@ -219,8 +216,15 @@ export class PollFiltersComponent implements OnInit {
         ],
       },
     ]);
+
     this.variableSelectGroups.set(result);
     this.prevVariablesSelections = this.variables().map(v => v.pollVariableId);
+
+    setTimeout(() => {
+      this.filterForm.controls.variables.setValue(
+        variableGroupsFlat.map(v => !!v && v.pollVariableId)
+      );
+    });
   }
 
   handleVariableSelect(isOpen: boolean) {
@@ -372,11 +376,14 @@ export class PollFiltersComponent implements OnInit {
               .filter(v => v.componentName === compName)
               .map(v => ({ label: v.name, value: v.pollVariableId })),
           }));
-          this.variableSelectGroups.set(groups);
 
+          this.variableSelectGroups.set(groups);
           const allVariableIds = variables.map(v => v.pollVariableId);
-          this.filterForm.controls.variables.setValue(allVariableIds);
           this.prevVariablesSelections = allVariableIds;
+
+          setTimeout(() => {
+            this.filterForm.controls.variables.setValue(allVariableIds);
+          });
         },
         error: () => {
           this.variables.set([]);

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -70,6 +70,7 @@ export class PollFiltersComponent implements OnInit {
 
   cohorts = signal<CohortModel[]>([]);
   componentNames = signal<string[]>([]);
+  allComponentNames = signal<string[]>([]);
   evaluations = signal<EvaluationModel[] | null>([]);
   polls: PollModel[] = [];
   prevCohortIds: number[] = [];
@@ -114,7 +115,7 @@ export class PollFiltersComponent implements OnInit {
   });
 
   readonly componentsToScroll = computed<MultipleSelectItem[]>(() => {
-    const componentNames = this.componentNames();
+    const componentNames = this.allComponentNames();
     return componentNames
       ? componentNames.map(componentName => {
           return { label: componentName, value: componentName };
@@ -149,6 +150,7 @@ export class PollFiltersComponent implements OnInit {
     });
 
     this.componentNames.set([]);
+    this.allComponentNames.set([]);
     this.variables.set([]);
     this.prevComponentSelections = [];
     this.prevCohortIds = [];
@@ -323,16 +325,15 @@ export class PollFiltersComponent implements OnInit {
         this.prevCohortIds = allIds;
 
         if (this.showVariables) {
-          this._getVariables();
+          this._getVariables(undefined, true);
         }
       },
       error: () => this.cohorts.set([]),
     });
   }
 
-  private _getVariables(filterNames?: string[]) {
+  private _getVariables(filterNames?: string[], isInitialLoad = false) {
     if (!this.polls || !this.polls[0]?.uuid) return;
-
     const namesToQuery =
       filterNames ?? this.filterForm.value.componentNames ?? [];
 
@@ -348,7 +349,12 @@ export class PollFiltersComponent implements OnInit {
             ...new Set(variables.map(v => v.componentName).filter(Boolean)),
           ];
 
-          this.componentNames.set(newComponentNames);
+          if (isInitialLoad) {
+            this.allComponentNames.set(newComponentNames);
+            this.componentNames.set(newComponentNames);
+            this.filterForm.controls.componentNames.setValue(newComponentNames);
+            this.prevComponentSelections = [...newComponentNames];
+          }
 
           if (filterNames) {
             this.filterForm.controls.componentNames.setValue(newComponentNames);

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.spec.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SelectMultipleVirtualScrollComponent } from './select-multiple-virtual-scroll.component';
@@ -75,15 +80,16 @@ describe('SelectMultipleVirtualScrollComponent', () => {
     expect(component.scrollItemsValues()).toEqual(['a1', 'a2']);
   });
 
-  it('should emit event openedChange(false) when items initialize', () => {
+  it('should emit event openedChange(false) when items initialize', fakeAsync(() => {
     spyOn(component.openedChange, 'emit');
     fixture.componentRef.setInput('control', new FormControl([]));
     fixture.componentRef.setInput('items', mockItems);
 
     fixture.detectChanges();
 
+    tick();
     expect(component.openedChange.emit).toHaveBeenCalledWith(false);
-  });
+  }));
 
   it('should return ["Select all"] when all elements are selected', () => {
     const control = new FormControl([1, 2]);

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -67,14 +67,18 @@ export class SelectMultipleVirtualScrollComponent {
   );
 
   constructor() {
-    effect(() => {
+    effect(onCleanup => {
       const currentItems = this.scrollItems();
       const defaultValue = this.scrollItemsValues();
       const ctrl = this.control();
 
       if (currentItems?.length > 0 && this.autoSelect()) {
-        ctrl.patchValue(defaultValue);
-        this.openedChange.emit(false);
+        const timeoutId = setTimeout(() => {
+          ctrl.patchValue(defaultValue);
+          this.openedChange.emit(false);
+        });
+
+        onCleanup(() => clearTimeout(timeoutId));
       }
     });
   }

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.ts
@@ -72,7 +72,7 @@ export class SelectMultipleVirtualScrollComponent {
       const defaultValue = this.scrollItemsValues();
       const ctrl = this.control();
 
-      if (currentItems && currentItems.length > 0 && this.autoSelect()) {
+      if (currentItems?.length > 0 && this.autoSelect()) {
         ctrl.patchValue(defaultValue);
         this.openedChange.emit(false);
       }

--- a/src/app/shared/directives/select-all.directive.ts
+++ b/src/app/shared/directives/select-all.directive.ts
@@ -43,13 +43,20 @@ export class SelectAllDirective<T extends SelectAllValue>
   }
 
   private isAllSelected(selected: T[] | null | undefined): boolean {
-    if (!this.allValues || this.allValues.length === 0) return false;
-    const safeSelected = (selected || []).filter(
-      (s): s is T => s !== null && s !== undefined
+    const allIds = this.getAllIds();
+    if (allIds.length === 0) return false;
+    const selectedIds = new Set(
+      (selected || [])
+        .filter((s): s is T => s !== null && s !== undefined)
+        .map(item =>
+          typeof item === 'object' && item !== null && 'id' in item
+            ? (item as { id: string | number }).id
+            : (item as string | number)
+        )
     );
     return (
-      this.getAllIds().length > 0 &&
-      this.getAllIds().length === safeSelected.length
+      selectedIds.size === allIds.length &&
+      allIds.every(id => selectedIds.has(id))
     );
   }
 

--- a/src/app/shared/directives/select-all.directive.ts
+++ b/src/app/shared/directives/select-all.directive.ts
@@ -28,7 +28,9 @@ export class SelectAllDirective<T extends SelectAllValue>
     if (changes['allValues']) {
       const ctrl = this._matSelect.ngControl?.control;
       if (ctrl) {
-        this._updateState(ctrl.value);
+        setTimeout(() => {
+          this._updateState(ctrl.value);
+        });
       }
     }
   }


### PR DESCRIPTION
## Description

Now, 'Select All' remains checked by default when switching Evaluation Process, ensuring consistent behavior across Dynamic Charts, Summary Charts, and Polls Answered.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


