### PR TITLE
806 eras v2   reports create a tab component to select the desired report

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -20,6 +20,7 @@ import { SummaryChartsComponent } from '@modules/reports/components/summary-char
 import { evaluationProcessesResolver } from '@modules/reports/resolvers/evaluation-processes.resolver';
 import { StudentsListComponent } from '@modules/students/students-list/students-list.component';
 import { DynamicChartContainerComponent } from '@modules/reports/components/dynamic-charts-v2/dynamic-chart-container.component';
+import { ReportsComponent } from '@modules/reports/components/reports/reports.component';
 
 export const routes: Routes = [
   {
@@ -34,20 +35,31 @@ export const routes: Routes = [
       },
       { path: 'home', component: HomeComponent },
       {
-        path: 'reports/summary-charts',
-        component: SummaryChartsComponent,
-        data: { breadcrumb: 'Summary Charts' },
-      },
-      {
-        path: 'reports/polls-answered',
-        component: PollsAnsweredComponent,
-        data: { breadcrumb: 'Polls Answered' },
-      },
-      {
-        path: 'reports/dynamic-charts',
-        component: DynamicChartContainerComponent,
-        data: { breadcrumb: 'Dynamic Charts' },
-        resolve: { evaluations: evaluationProcessesResolver },
+        path: 'reports',
+        component: ReportsComponent,
+        children: [
+          {
+            path: '',
+            redirectTo: 'dynamic-charts',
+            pathMatch: 'full',
+          },
+          {
+            path: 'dynamic-charts',
+            component: DynamicChartContainerComponent,
+            data: { breadcrumb: 'Dynamic Charts' },
+            resolve: { evaluations: evaluationProcessesResolver },
+          },
+          {
+            path: 'summary-charts',
+            component: SummaryChartsComponent,
+            data: { breadcrumb: 'Summary Charts' },
+          },
+          {
+            path: 'polls-answered',
+            component: PollsAnsweredComponent,
+            data: { breadcrumb: 'Polls Answered' },
+          },
+        ],
       },
       {
         path: 'cosmic-latte',
@@ -116,7 +128,9 @@ export const routes: Routes = [
           {
             path: 'details/:id',
             loadComponent: () =>
-              import('@modules/supports-referrals/components/referral-detail/referral-detail.component'),
+              import(
+                '@modules/supports-referrals/components/referral-detail/referral-detail.component'
+              ),
             resolve: { referral: referralDetailsResolver },
             data: { breadcrumb: 'Referral Details' },
           },

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.html
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.html
@@ -1,0 +1,39 @@
+<!-- New design -->
+<mat-nav-list class="sidebar">
+  <div class="sidebar-logo">
+    <img
+      src="assets/logo/ERAS_Logo_Dark.svg"
+      alt="ERAS Logo"
+      class="logo-img"
+    />
+  </div>
+  <div class="sidebar-divider"></div>
+
+  <ng-container *ngFor="let item of menuItems()">
+    <mat-list-item
+      class="menu-item"
+      [matTooltip]="item.label"
+      [matTooltipPosition]="'after'"
+      [class.active-parent]="isParentActive(item)"
+      (click)="onMenuClick(item)"
+      [routerLink]="item.route || null"
+    >
+      <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
+      <span matListItemTitle>{{ item.label }}</span>
+    </mat-list-item>
+
+    <div
+      *ngIf="item.children && getExpandedMenu() === item.label"
+      class="submenu"
+    >
+      <mat-list-item
+        class="submenu-item"
+        *ngFor="let child of item.children"
+        [routerLink]="child.route"
+        routerLinkActive="active-submenu"
+      >
+        <span class="subtitle">{{ child.label }}</span>
+      </mat-list-item>
+    </div>
+  </ng-container>
+</mat-nav-list>

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.scss
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.scss
@@ -1,0 +1,96 @@
+$hover-bg: rgba(#135b5c, 0.5);
+$selected-bg: #144d4d;
+$text-color: #ffffff;
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 20px;
+  margin-bottom: -6px;
+  margin-top: -8px;
+
+  .logo-img {
+    width: 100%;
+    height: auto;
+    max-height: 100px;
+    object-fit: contain;
+    display: block;
+  }
+}
+
+.sidebar-divider {
+  height: 1px;
+  background-color: rgba($text-color, 0.25);
+  margin: 0 16px 12px;
+}
+
+.menu-item {
+  width: 95%;
+  margin: auto;
+  border-radius: 8px !important;
+  height: 56px !important;
+  cursor: pointer;
+
+  mat-icon {
+    font-family: 'Material Symbols Rounded' !important;
+    font-variation-settings:
+      'FILL' 0,
+      'wght' 400,
+      'GRAD' 0,
+      'opsz' 24 !important;
+    color: $text-color;
+    opacity: 0.9;
+    font-size: 24px;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  span {
+    color: $text-color;
+    font-family: 'Roboto', sans-serif;
+    font-size: 15px;
+    font-weight: 500;
+  }
+
+  &:hover {
+    background-color: $hover-bg;
+  }
+  &.active-parent {
+    background-color: $selected-bg;
+  }
+}
+
+.submenu {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  margin: auto;
+  overflow: hidden;
+  padding: 15px 0;
+  white-space: nowrap;
+  width: 95%;
+}
+
+.submenu-item {
+  text-decoration: none;
+
+  &:hover .subtitle {
+    color: $text-color;
+    opacity: 1;
+  }
+  &.active-submenu .subtitle {
+    color: $text-color;
+    font-weight: 500;
+  }
+}
+
+.subtitle {
+  color: rgba($text-color, 0.75);
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  margin-left: 56px;
+}

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.component-v2.ts
@@ -1,0 +1,47 @@
+import { Component, input } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { Menu } from '../sidebar.model';
+import { SidebarService } from '../sidebar.service';
+
+@Component({
+  selector: 'app-sidebar-v2',
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatListModule,
+    MatIconModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './sidebar.component-v2.html',
+  styleUrl: './sidebar.component-v2.scss',
+})
+export class SidebarV2Component {
+  menuItems = input<Menu[]>([]);
+
+  constructor(public sidebarService: SidebarService) {}
+
+  onMenuClick(item: Menu) {
+    if (!item.children) {
+      this.sidebarService.closeMenu();
+      return;
+    }
+    this.sidebarService.toggleMenu(item.label);
+  }
+
+  isParentActive(item: Menu): boolean {
+    if (item.route) return this.sidebarService.isRouteActive(item.route);
+    return !!item.children?.some(child =>
+      this.sidebarService.isRouteActive(child.route!)
+    );
+  }
+
+  getExpandedMenu(): string | null {
+    return this.sidebarService.expandedMenu();
+  }
+}

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
@@ -11,7 +11,7 @@ export const SIDEBAR_MENUS_NEW: Menu[] = [
         route: '/student-option',
         forProduction: false,
       },
-      { label: 'Students List', route: '/list-students-by-poll' },
+      { label: 'Students List', route: '/students' },
     ],
   },
   {

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
@@ -17,11 +17,7 @@ export const SIDEBAR_MENUS_NEW: Menu[] = [
   {
     label: 'Reports',
     icon: 'assessment',
-    children: [
-      { label: 'Dynamic Charts', route: '/reports/dynamic-charts' },
-      { label: 'Summary Charts', route: '/reports/summary-charts' },
-      { label: 'Polls Answered', route: '/reports/polls-answered' },
-    ],
+    route: '/reports',
   },
   {
     label: 'Assessments',

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
@@ -1,0 +1,39 @@
+import { Menu } from '../sidebar.model';
+
+export const SIDEBAR_MENUS_NEW: Menu[] = [
+  { label: 'Home', icon: 'home', route: '/home' },
+  {
+    label: 'Students',
+    icon: 'school',
+    children: [
+      {
+        label: 'Student Monitoring',
+        route: '/student-option',
+        forProduction: false,
+      },
+      { label: 'Students List', route: '/list-students-by-poll' },
+    ],
+  },
+  {
+    label: 'Reports',
+    icon: 'assessment',
+    children: [
+      { label: 'Dynamic Charts', route: '/reports/dynamic-charts' },
+      { label: 'Summary Charts', route: '/reports/summary-charts' },
+      { label: 'Polls Answered', route: '/reports/polls-answered' },
+    ],
+  },
+  {
+    label: 'Assessments',
+    icon: 'link',
+    children: [
+      { label: 'Evaluation Processes', route: '/evaluation-process' },
+      {
+        label: 'Supports and Referrals',
+        route: '/supports-referrals',
+        forProduction: false,
+      },
+      { label: 'Import Students', route: '/import-students' },
+    ],
+  },
+];

--- a/src/app/core/components/sidebar/sidebar.component.html
+++ b/src/app/core/components/sidebar/sidebar.component.html
@@ -1,45 +1,3 @@
-<!-- New design -->
-<div *ngIf="newSidebar()" class="new-sidebar-wrapper">
-  <mat-nav-list class="sidebar">
-    <div class="sidebar-logo">
-      <img
-        src="assets/logo/ERAS_Logo_Dark.svg"
-        alt="ERAS Logo"
-        class="logo-img"
-      />
-    </div>
-    <div class="sidebar-divider"></div>
-
-    <ng-container *ngFor="let item of menuItems()">
-      <mat-list-item
-        class="menu-item"
-        [matTooltip]="item.label"
-        [matTooltipPosition]="'after'"
-        [class.active-parent]="isParentActive(item)"
-        (click)="onMenuClick(item)"
-        [routerLink]="item.route || null"
-      >
-        <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
-        <span matListItemTitle>{{ item.label }}</span>
-      </mat-list-item>
-
-      <div
-        *ngIf="item.children && getExpandedMenu() === item.label"
-        class="submenu"
-      >
-        <mat-list-item
-          class="submenu-item"
-          *ngFor="let child of item.children"
-          [routerLink]="child.route"
-          routerLinkActive="active-submenu"
-        >
-          <span class="subtitle">{{ child.label }}</span>
-        </mat-list-item>
-      </div>
-    </ng-container>
-  </mat-nav-list>
-</div>
-
 <!-- Old design (Legacy) -->
 <div *ngIf="!newSidebar()" class="old-sidebar-wrapper">
   <mat-nav-list class="sidebar">
@@ -81,3 +39,5 @@
     </ng-container>
   </mat-nav-list>
 </div>
+
+<app-sidebar-v2 *ngIf="newSidebar()" [menuItems]="menuItems()" />

--- a/src/app/core/components/sidebar/sidebar.component.scss
+++ b/src/app/core/components/sidebar/sidebar.component.scss
@@ -1,110 +1,6 @@
+// OLD SIDEBAR (Legacy)
 @use 'index.scss' as main-styles;
 
-// NEW SIDEBAR
-.new-sidebar-wrapper {
-  $hover-bg: rgba(#135b5c, 0.5);
-  $selected-bg: #144d4d;
-  $text-color: #ffffff;
-
-  .sidebar-logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px 20px 24px;
-    margin-bottom: -6px;
-    margin-top: -8px;
-
-    .logo-img {
-      width: 100%;
-      height: auto;
-      max-height: 100px;
-      object-fit: contain;
-      display: block;
-    }
-  }
-
-  .sidebar-divider {
-    height: 1px;
-    background-color: rgba($text-color, 0.25);
-    margin: 0 16px 12px;
-  }
-
-  .menu-item {
-    width: 95%;
-    margin: auto;
-    border-radius: 8px !important;
-    height: 56px !important;
-    cursor: pointer;
-    position: relative;
-
-    mat-icon {
-      font-family: 'Material Symbols Rounded' !important;
-      font-variation-settings:
-        'FILL' 0,
-        'wght' 400,
-        'GRAD' 0,
-        'opsz' 24 !important;
-
-      color: $text-color;
-      opacity: 0.9;
-      font-size: 24px;
-      width: 24px;
-      height: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    span {
-      color: $text-color;
-      font-family: 'Roboto', sans-serif;
-      font-size: 15px;
-      font-weight: 500;
-    }
-
-    &:hover {
-      background-color: $hover-bg;
-    }
-
-    &.active-parent {
-      background-color: $selected-bg;
-    }
-  }
-
-  .submenu {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-    margin: auto;
-    overflow: hidden;
-    padding: 15px 0;
-    white-space: nowrap;
-    width: 95%;
-  }
-
-  .submenu-item {
-    text-decoration: none;
-
-    &:hover .subtitle {
-      color: $text-color;
-      opacity: 1;
-    }
-
-    &.active-submenu .subtitle {
-      color: $text-color;
-      font-weight: 500;
-    }
-  }
-
-  .subtitle {
-    color: rgba($text-color, 0.75);
-    font-family: 'Roboto', sans-serif;
-    font-size: 13px;
-    margin-left: 56px;
-  }
-}
-
-// OLD SIDEBAR (Legacy)
 .old-sidebar-wrapper {
   $neutral-color: main-styles.get-color('neutral', 70);
   $primary-bg: main-styles.get-color('primary', 50);
@@ -163,17 +59,12 @@
   .submenu-item {
     text-decoration: none;
 
-    &:hover {
-      .subtitle {
-        color: $primary-text;
-      }
+    &:hover .subtitle {
+      color: $primary-text;
     }
-
-    &.active-submenu {
-      .subtitle {
-        color: $primary-text;
-        font-weight: 500;
-      }
+    &.active-submenu .subtitle {
+      color: $primary-text;
+      font-weight: 500;
     }
   }
 

--- a/src/app/core/components/sidebar/sidebar.component.ts
+++ b/src/app/core/components/sidebar/sidebar.component.ts
@@ -8,8 +8,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { Menu } from './sidebar.model';
 import { SidebarService } from './sidebar.service';
-
-import { SIDEBAR_MENUS_NEW, SIDEBAR_MENUS_OLD } from './sidebar.model';
+import { SIDEBAR_MENUS_OLD } from './sidebar.model';
+import { SIDEBAR_MENUS_NEW } from './sidebar v2/sidebar.model-v2';
+import { SidebarV2Component } from './sidebar v2/sidebar.component-v2';
 
 @Component({
   selector: 'app-sidebar',
@@ -19,17 +20,19 @@ import { SIDEBAR_MENUS_NEW, SIDEBAR_MENUS_OLD } from './sidebar.model';
     MatListModule,
     MatIconModule,
     MatTooltipModule,
+    SidebarV2Component,
   ],
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.scss',
 })
 export class SidebarComponent {
   collapsed = model<boolean>();
-
   newSidebar = input<boolean>(false);
 
   menuItems = computed(() =>
-    this.newSidebar() ? SIDEBAR_MENUS_NEW : SIDEBAR_MENUS_OLD
+    this.newSidebar()
+      ? this.sidebarService.getMenus(SIDEBAR_MENUS_NEW)
+      : this.sidebarService.getMenus(SIDEBAR_MENUS_OLD)
   );
 
   constructor(public sidebarService: SidebarService) {
@@ -45,19 +48,14 @@ export class SidebarComponent {
       this.sidebarService.closeMenu();
       return;
     }
-
     if (this.collapsed()) {
       this.collapsed.set(false);
     }
-
     this.sidebarService.toggleMenu(item.label);
   }
 
   isParentActive(item: Menu): boolean {
-    if (item.route) {
-      return this.sidebarService.isRouteActive(item.route);
-    }
-
+    if (item.route) return this.sidebarService.isRouteActive(item.route);
     return !!item.children?.some(child =>
       this.sidebarService.isRouteActive(child.route!)
     );

--- a/src/app/core/components/sidebar/sidebar.model.ts
+++ b/src/app/core/components/sidebar/sidebar.model.ts
@@ -6,44 +6,6 @@ export interface Menu {
   forProduction?: boolean;
 }
 
-export const SIDEBAR_MENUS_NEW: Menu[] = [
-  { label: 'Home', icon: 'home', route: '/home' },
-  {
-    label: 'Students',
-    icon: 'school',
-    children: [
-      {
-        label: 'Student Monitoring',
-        route: '/student-option',
-        forProduction: false,
-      },
-      { label: 'Students List', route: '/list-students-by-poll' },
-    ],
-  },
-  {
-    label: 'Reports',
-    icon: 'assessment',
-    children: [
-      { label: 'Dynamic Charts', route: '/reports/dynamic-charts' },
-      { label: 'Summary Charts', route: '/reports/summary-charts' },
-      { label: 'Polls Answered', route: '/reports/polls-answered' },
-    ],
-  },
-  {
-    label: 'Assessments',
-    icon: 'link',
-    children: [
-      { label: 'Evaluation Processes', route: '/evaluation-process' },
-      {
-        label: 'Supports and Referrals',
-        route: '/supports-referrals',
-        forProduction: false,
-      },
-      { label: 'Import Students', route: '/import-students' },
-    ],
-  },
-];
-
 export const SIDEBAR_MENUS_OLD: Menu[] = [
   { label: 'Home', icon: 'home', route: '/home' },
   {

--- a/src/app/modules/reports/components/reports/reports.component.html
+++ b/src/app/modules/reports/components/reports/reports.component.html
@@ -1,0 +1,17 @@
+<div class="reports-wrapper">
+  <nav class="reports-tabs">
+    <ng-container *ngFor="let tab of tabs">
+      <a
+        class="tab-item"
+        [routerLink]="tab.route"
+        routerLinkActive="active-tab"
+      >
+        {{ tab.label }}
+      </a>
+    </ng-container>
+  </nav>
+
+  <div class="reports-content">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/src/app/modules/reports/components/reports/reports.component.scss
+++ b/src/app/modules/reports/components/reports/reports.component.scss
@@ -1,0 +1,42 @@
+.reports-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.reports-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 24px;
+  margin-bottom: 2px;
+}
+
+.tab-item {
+  text-decoration: none;
+  color: #757575;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 16px 16px;
+  border-bottom: 2px solid transparent;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    color: #117473;
+    border-bottom: 2px solid rgba(#117473, 0.4);
+  }
+
+  &.active-tab {
+    color: #117473;
+    font-weight: 600;
+    border-bottom: 3px solid #117473;
+  }
+}
+
+.reports-content {
+  flex: 1;
+}

--- a/src/app/modules/reports/components/reports/reports.component.ts
+++ b/src/app/modules/reports/components/reports/reports.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-reports',
+  imports: [CommonModule, RouterModule],
+  templateUrl: './reports.component.html',
+  styleUrl: './reports.component.scss',
+})
+export class ReportsComponent {
+  tabs = [
+    { label: 'Dynamic Charts', route: 'dynamic-charts' },
+    { label: 'Summary Charts', route: 'summary-charts' },
+    { label: 'Polls Answered', route: 'polls-answered' },
+  ];
+}


### PR DESCRIPTION
## Description

Created a ReportsComponent as a parent wrapper for the three report views 
(Dynamic Charts, Summary Charts, Polls Answered). Converted the three 
independent routes into children of /reports and adds a tab navigation 
UI to switch between them. Updated sidebar-v2 menu to navigate directly 
to /reports instead of expanding a submenu.


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


