### PR TITLE
Fix: chart maximized keep the component selected when another one is included in the filter

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
@@ -29,7 +29,7 @@
         [class.has-expanded-card]="isAnyCardExpanded"
       >
         <div
-          #contentToExport
+          #contentQuarter
           class="charts-grid"
           [style.height.px]="isAnyCardExpanded ? gridHeight : null"
         >

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -224,44 +224,14 @@ export class DynamicChartsV2Component implements AfterViewInit {
   }
 
   handleFilterSelect(filters: Filter) {
-    this.hasNoResults = false;
-    this.title = filters.title;
-    this.uuid = filters.uuid;
-    this.cohortIds = filters.cohortIds.join(',');
-    this.evaluationId = filters.evaluationId;
-
-    if (this.isAnyCardExpanded) {
-      const indexOfChartStorage = filters.selectedComponents.reduce(
-        (prev, value, index) =>
-          value == this.expandedComponent?.toLocaleLowerCase() ? index : prev,
-        -1
-      );
-      if (filters.selectedComponents.length > 1 && indexOfChartStorage === -1) {
-        this.isAnyCardExpanded = false;
-        this.handleFilterSelect(filters);
-      }
-      let firstIndex = 0;
-      if (indexOfChartStorage !== -1) {
-        firstIndex = indexOfChartStorage;
-      } else {
-        firstIndex = 0;
-        this.expandedComponent =
-          filters.selectedComponents[0].toLocaleLowerCase();
-      }
-      this.expandedIndex = firstIndex;
-      this.expandedId = firstIndex !== null ? `chart-${firstIndex}` : null;
-    }
-    this.gridHeight = 0;
-
-    if (!filters.cohortIds || filters.variableIds.length === 0) {
-      this.chartsOptions = [];
-      this.components.set(null);
-      this.uuid = null;
-      this.isAnyCardExpanded = false;
-      this.expandedId = null;
-      this.expandedIndex = null;
+    this.resetBaseState();
+    this.applyFilterMetadata(filters);
+    if (!this.isValidFilter(filters)) {
+      this.resetState();
       return;
     }
+    this.handleExpandedState(filters);
+    this.gridHeight = 0;
     this.generateHeatMap(filters.cohortIds, filters.variableIds);
   }
 
@@ -376,5 +346,48 @@ export class DynamicChartsV2Component implements AfterViewInit {
 
   onChartTypeChange(index: number, type: 'heatmap' | 'column'): void {
     this.chartTypeMap.set(index, type);
+  }
+
+  private resetBaseState() {
+    this.hasNoResults = false;
+  }
+
+  private applyFilterMetadata(filters: Filter) {
+    this.title = filters.title;
+    this.uuid = filters.uuid;
+    this.cohortIds = filters.cohortIds.join(',');
+    this.evaluationId = filters.evaluationId;
+  }
+
+  private isValidFilter(filters: Filter): boolean {
+    return !!filters.cohortIds && filters.variableIds.length > 0;
+  }
+
+  private resetState() {
+    this.chartsOptions = [];
+    this.components.set(null);
+    this.uuid = null;
+    this.isAnyCardExpanded = false;
+    this.expandedId = null;
+    this.expandedIndex = null;
+  }
+
+  private handleExpandedState(filters: Filter) {
+    if (!this.isAnyCardExpanded) return;
+
+    const selected = filters.selectedComponents;
+    const expanded = this.expandedComponent?.toLowerCase();
+
+    let index = selected.findIndex(c => c === expanded);
+    if (selected.length > 1 && index === -1) {
+      this.isAnyCardExpanded = false;
+      return;
+    }
+    if (index === -1) {
+      index = 0;
+      this.expandedComponent = selected[0].toLowerCase();
+    }
+    this.expandedIndex = index;
+    this.expandedId = `chart-${index}`;
   }
 }

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -84,13 +84,14 @@ export class DynamicChartsV2Component implements AfterViewInit {
   hasNoResults = false;
   isAnyCardExpanded = false;
   expandedIndex: number | null = null;
+  expandedComponent: string | null | undefined = null;
 
   gridHeight = 0;
   isExporting = signal(false);
   chartTypeMap = new Map<number, 'heatmap' | 'column'>();
   resizeTick = signal(0);
 
-  @ViewChild('contentToExport', { static: false }) contentToExport!: ElementRef;
+  @ViewChild('contentQuarter', { static: false }) contentQuarter!: ElementRef;
   @ViewChildren('chartsGrid') chartsGrid!: QueryList<ExpandableCardComponent>;
 
   private cardWidth = signal<number>(0);
@@ -139,7 +140,6 @@ export class DynamicChartsV2Component implements AfterViewInit {
 
   generateSeries(report: PollCountReport) {
     const totalWidth = this.cardWidth();
-
     const CARD_LAYOUT = {
       spacing: 16,
       columns: 2,
@@ -231,7 +231,23 @@ export class DynamicChartsV2Component implements AfterViewInit {
     this.evaluationId = filters.evaluationId;
 
     if (this.isAnyCardExpanded) {
-      const firstIndex = filters.selectedComponentIndex?.[0] ?? null;
+      const indexOfChartStorage = filters.selectedComponents.reduce(
+        (prev, value, index) =>
+          value == this.expandedComponent?.toLocaleLowerCase() ? index : prev,
+        -1
+      );
+      if (filters.selectedComponents.length > 1 && indexOfChartStorage === -1) {
+        this.isAnyCardExpanded = false;
+        this.handleFilterSelect(filters);
+      }
+      let firstIndex = 0;
+      if (indexOfChartStorage !== -1) {
+        firstIndex = indexOfChartStorage;
+      } else {
+        firstIndex = 0;
+        this.expandedComponent =
+          filters.selectedComponents[0].toLocaleLowerCase();
+      }
       this.expandedIndex = firstIndex;
       this.expandedId = firstIndex !== null ? `chart-${firstIndex}` : null;
     }
@@ -250,6 +266,9 @@ export class DynamicChartsV2Component implements AfterViewInit {
   }
 
   onToggle(id: string): void {
+    const index: string = id.at(-1) ?? '0';
+    this.expandedComponent =
+      this.components()?.components[parseInt(index)].description;
     this.expandedId = this.expandedId === id ? null : id;
     this.isAnyCardExpanded = this.expandedId !== null;
     this.expandedIndex = this.isAnyCardExpanded
@@ -257,7 +276,7 @@ export class DynamicChartsV2Component implements AfterViewInit {
       : null;
 
     if (this.expandedId === null) {
-      this.gridHeight = this.contentToExport.nativeElement.offsetHeight;
+      this.gridHeight = this.contentQuarter.nativeElement.offsetHeight;
     }
     this._updateCardWidth();
     const report = this.components();
@@ -347,7 +366,7 @@ export class DynamicChartsV2Component implements AfterViewInit {
   }
 
   private _updateCardWidth() {
-    const width = this.contentToExport?.nativeElement?.offsetWidth ?? 0;
+    const width = this.contentQuarter?.nativeElement?.offsetWidth ?? 0;
     this.cardWidth.set(width);
   }
 

--- a/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
+++ b/src/app/modules/reports/components/poll-filters/poll-filters.component.ts
@@ -424,6 +424,7 @@ export class PollFiltersComponent implements OnInit {
             : -1
         )
         .filter(i => i !== -1),
+      selectedComponents,
     });
   }
 

--- a/src/app/modules/reports/components/poll-filters/types/filters.ts
+++ b/src/app/modules/reports/components/poll-filters/types/filters.ts
@@ -6,6 +6,7 @@ export interface Filter {
   lastVersion: boolean;
   evaluationId?: number | string;
   selectedComponentIndex?: number[];
+  selectedComponents: string[];
 }
 
 export type FormKey =

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.ts
@@ -35,8 +35,7 @@ import { ModalStudentDetailComponent } from '../../../../shared/components/modal
 import { PollFiltersComponent } from '../../components/poll-filters/poll-filters.component';
 
 interface DynamicPollInstance
-  extends PollInstanceModel,
-    Record<string, unknown> {}
+  extends PollInstanceModel, Record<string, unknown> {}
 
 @Component({
   selector: 'app-polls-answered',


### PR DESCRIPTION
## Description

Add the component name to the 'filter-polls' filter as part of the 'sendFilters' function in order to compare the selected component when it is expanded. This ensures that if other components are added, the same component will be displayed.

If other components are selected and the maximized component is deselected, the cards will be minimized and at least one component will be maximized and only one is selected, the new one will be displayed.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#823 
