### PR TITLE
feat: add reportsV2 feature flag and separate v1/v2 report routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,12 +18,13 @@ import { StudentMonitoringPollsComponent } from '@modules/student-monitoring/stu
 import { SummaryChartsComponent } from '@modules/reports/components/summary-charts/summary-charts.component';
 import { evaluationProcessesResolver } from '@modules/reports/resolvers/evaluation-processes.resolver';
 import { StudentsListComponent } from '@modules/students/students-list/students-list.component';
-import { DynamicChartContainerComponent } from '@modules/reports/components/dynamic-charts-v2/dynamic-chart-container.component';
 import { ReportsComponent } from '@modules/reports/components/reports/reports.component';
 import { HomeContainerComponent } from '@modules/home-v2/home-container.component';
 import { AppRouteData } from '@core/models/route-data.model';
 import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
 import { featureFlagGuard } from '@core/components/feature-flags/feature-flag.guard';
+import { DynamicChartsComponent } from '@modules/reports/components/dynamic-charts/dynamic-charts.component';
+import { DynamicChartsV2Component } from '@modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component';
 
 export const routes: Routes = [
   {
@@ -49,7 +50,7 @@ export const routes: Routes = [
           { path: '', redirectTo: 'dynamic-charts', pathMatch: 'full' },
           {
             path: 'dynamic-charts',
-            component: DynamicChartContainerComponent,
+            component: DynamicChartsV2Component,
             resolve: { evaluations: evaluationProcessesResolver },
           },
           { path: 'summary-charts', component: SummaryChartsComponent },
@@ -62,7 +63,7 @@ export const routes: Routes = [
           { path: '', redirectTo: 'dynamic-charts', pathMatch: 'full' },
           {
             path: 'dynamic-charts',
-            component: DynamicChartContainerComponent,
+            component: DynamicChartsComponent,
             resolve: { evaluations: evaluationProcessesResolver },
           },
           { path: 'summary-charts', component: SummaryChartsComponent },
@@ -136,9 +137,7 @@ export const routes: Routes = [
           {
             path: 'details/:id',
             loadComponent: () =>
-              import(
-                '@modules/supports-referrals/components/referral-detail/referral-detail.component'
-              ),
+              import('@modules/supports-referrals/components/referral-detail/referral-detail.component'),
             resolve: { referral: referralDetailsResolver },
             data: { breadcrumb: 'Referral Details' },
           },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -22,6 +22,8 @@ import { DynamicChartContainerComponent } from '@modules/reports/components/dyna
 import { ReportsComponent } from '@modules/reports/components/reports/reports.component';
 import { HomeContainerComponent } from '@modules/home-v2/home-container.component';
 import { AppRouteData } from '@core/models/route-data.model';
+import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
+import { featureFlagGuard } from '@core/components/feature-flags/feature-flag.guard';
 
 export const routes: Routes = [
   {
@@ -41,29 +43,30 @@ export const routes: Routes = [
       },
       {
         path: 'reports',
+        canActivate: [featureFlagGuard(FEATURE_FLAGS.reportsV2)],
         component: ReportsComponent,
         children: [
-          {
-            path: '',
-            redirectTo: 'dynamic-charts',
-            pathMatch: 'full',
-          },
+          { path: '', redirectTo: 'dynamic-charts', pathMatch: 'full' },
           {
             path: 'dynamic-charts',
             component: DynamicChartContainerComponent,
-            data: { breadcrumb: 'Dynamic Charts' },
             resolve: { evaluations: evaluationProcessesResolver },
           },
+          { path: 'summary-charts', component: SummaryChartsComponent },
+          { path: 'polls-answered', component: PollsAnsweredComponent },
+        ],
+      },
+      {
+        path: 'reports-v1',
+        children: [
+          { path: '', redirectTo: 'dynamic-charts', pathMatch: 'full' },
           {
-            path: 'summary-charts',
-            component: SummaryChartsComponent,
-            data: { breadcrumb: 'Summary Charts' } satisfies AppRouteData,
+            path: 'dynamic-charts',
+            component: DynamicChartContainerComponent,
+            resolve: { evaluations: evaluationProcessesResolver },
           },
-          {
-            path: 'polls-answered',
-            component: PollsAnsweredComponent,
-            data: { breadcrumb: 'Polls Answered' },
-          },
+          { path: 'summary-charts', component: SummaryChartsComponent },
+          { path: 'polls-answered', component: PollsAnsweredComponent },
         ],
       },
       {

--- a/src/app/core/components/feature-flags/feature-flag.guard.ts
+++ b/src/app/core/components/feature-flags/feature-flag.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
+
+export function featureFlagGuard(flag: string): CanActivateFn {
+  return () => {
+    const featureFlagsService = inject(FeatureFlagsService);
+    const router = inject(Router);
+
+    if (featureFlagsService.isEnabled(flag)) {
+      return true;
+    }
+
+    return router.createUrlTree(['/home']);
+  };
+}

--- a/src/app/core/components/feature-flags/feature-flags.model.ts
+++ b/src/app/core/components/feature-flags/feature-flags.model.ts
@@ -1,4 +1,6 @@
 export interface FeatureFlags {
   dynamicCharts: string;
   home: string;
+  newSidebar: string;
+  reportsV2: string;
 }

--- a/src/app/core/components/feature-flags/feature-flags.service.ts
+++ b/src/app/core/components/feature-flags/feature-flags.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, computed, inject } from '@angular/core';
 import { environment } from 'src/environments/environment';
+import { Router } from '@angular/router';
 
 /**
  * Service responsible for evaluating feature flags based on URL query parameters.
@@ -12,15 +13,21 @@ import { environment } from 'src/environments/environment';
  * Example:
  *   ?newSection=true or ?newSection=false.
  */
+
 @Injectable({ providedIn: 'root' })
 export class FeatureFlagsService {
+  private router = inject(Router);
+  private queryParams = computed(() => {
+    return this.router.routerState.root.snapshot.queryParams;
+  });
+
   isEnabled(flag: string): boolean {
     if (environment.production) return false;
 
-    const params = new URLSearchParams(window.location.search);
+    const params = this.queryParams();
 
-    if (params.get('v2') === 'true') return true;
+    if (params['v2'] === 'true') return true;
 
-    return params.get(flag) === 'true';
+    return params[flag] === 'true';
   }
 }

--- a/src/app/core/components/feature-flags/feature-flags.service.ts
+++ b/src/app/core/components/feature-flags/feature-flags.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
 /**
@@ -15,17 +14,13 @@ import { environment } from 'src/environments/environment';
  */
 @Injectable({ providedIn: 'root' })
 export class FeatureFlagsService {
-  private readonly route = inject(ActivatedRoute);
-
   isEnabled(flag: string): boolean {
-    const param = this.route.snapshot.queryParamMap.get(flag);
+    if (environment.production) return false;
 
-    // PROD: Restricts use of feature flags on Production.
-    if (environment.production) {
-      return false;
-    }
+    const params = new URLSearchParams(window.location.search);
 
-    // NON-PROD: Works with query params, only available for testing mode.
-    return param === 'true';
+    if (params.get('v2') === 'true') return true;
+
+    return params.get(flag) === 'true';
   }
 }

--- a/src/app/core/components/feature-flags/feature-flags.ts
+++ b/src/app/core/components/feature-flags/feature-flags.ts
@@ -9,4 +9,6 @@ import { FeatureFlags } from '@core/components/feature-flags/feature-flags.model
 export const FEATURE_FLAGS: FeatureFlags = {
   dynamicCharts: 'dynamicChartsV2',
   home: 'homev2',
+  newSidebar: 'newSidebar',
+  reportsV2: 'reportsV2',
 };

--- a/src/app/core/components/feature-flags/home-redirect.guard.ts
+++ b/src/app/core/components/feature-flags/home-redirect.guard.ts
@@ -1,0 +1,13 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { FEATURE_FLAGS } from './feature-flags';
+import { FeatureFlagsService } from './feature-flags.service';
+import { inject } from '@angular/core';
+
+export const homeRedirectGuard: CanActivateFn = () => {
+  const featureFlags = inject(FeatureFlagsService);
+  const router = inject(Router);
+
+  const isV2 = featureFlags.isEnabled(FEATURE_FLAGS.home);
+
+  return router.createUrlTree([isV2 ? '/home' : '/home-v1']);
+};

--- a/src/app/core/components/layout/layout.component.ts
+++ b/src/app/core/components/layout/layout.component.ts
@@ -61,6 +61,8 @@ export class LayoutComponent implements OnInit {
   collapsed = model<boolean>(false);
   newSidebar = signal<boolean>(false);
   reportsV2 = signal<boolean>(false);
+  home = signal<boolean>(false);
+  dynamicCharts = signal<boolean>(false);
 
   sidenavWidth = computed(() => {
     if (this.newSidebar()) {
@@ -83,6 +85,10 @@ export class LayoutComponent implements OnInit {
     );
     this.reportsV2.set(
       this.featureFlagsService.isEnabled(FEATURE_FLAGS.reportsV2)
+    );
+    this.home.set(this.featureFlagsService.isEnabled(FEATURE_FLAGS.home));
+    this.dynamicCharts.set(
+      this.featureFlagsService.isEnabled(FEATURE_FLAGS.dynamicCharts)
     );
   }
 }

--- a/src/app/core/components/layout/layout.component.ts
+++ b/src/app/core/components/layout/layout.component.ts
@@ -6,7 +6,7 @@ import {
   model,
   signal,
 } from '@angular/core';
-import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
+import { RouterOutlet, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
@@ -22,10 +22,10 @@ import {
   BreakpointState,
   Breakpoints,
 } from '@angular/cdk/layout';
-import { filter } from 'rxjs';
-
 import { SidebarComponent } from '@core/components/sidebar/sidebar.component';
 import { HeaderContainerComponent } from './header/header-v2/header-container.component';
+import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
+import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
 
 enum Sidenav {
   shrink = '70px',
@@ -56,9 +56,11 @@ enum Sidenav {
 export class LayoutComponent implements OnInit {
   private breakpointObserver = inject(BreakpointObserver);
   private router = inject(Router);
+  private featureFlagsService = inject(FeatureFlagsService);
 
   collapsed = model<boolean>(false);
-  newSidebar = signal<boolean>(true);
+  newSidebar = signal<boolean>(false);
+  reportsV2 = signal<boolean>(false);
 
   sidenavWidth = computed(() => {
     if (this.newSidebar()) {
@@ -70,22 +72,17 @@ export class LayoutComponent implements OnInit {
   ngOnInit() {
     this.readSidebarFlag();
 
-    this.router.events
-      .pipe(filter(e => e instanceof NavigationEnd))
-      .subscribe(() => this.readSidebarFlag());
-
     this.breakpointObserver
       .observe([Breakpoints.Small, '(max-width: 1200px)'])
       .subscribe((state: BreakpointState) => this.collapsed.set(state.matches));
   }
 
   private readSidebarFlag(): void {
-    const params = new URLSearchParams(window.location.search);
-
-    if (params.has('newSidebar')) {
-      this.newSidebar.set(params.get('newSidebar') !== 'false');
-    } else {
-      this.newSidebar.set(true);
-    }
+    this.newSidebar.set(
+      this.featureFlagsService.isEnabled(FEATURE_FLAGS.newSidebar)
+    );
+    this.reportsV2.set(
+      this.featureFlagsService.isEnabled(FEATURE_FLAGS.reportsV2)
+    );
   }
 }

--- a/src/app/core/components/sidebar/sidebar.component.ts
+++ b/src/app/core/components/sidebar/sidebar.component.ts
@@ -28,12 +28,14 @@ import { SidebarV2Component } from './sidebar v2/sidebar.component-v2';
 export class SidebarComponent {
   collapsed = model<boolean>();
   newSidebar = input<boolean>(false);
+  reportsV2 = input<boolean>(false);
 
-  menuItems = computed(() =>
-    this.newSidebar()
-      ? this.sidebarService.getMenus(SIDEBAR_MENUS_NEW)
-      : this.sidebarService.getMenus(SIDEBAR_MENUS_OLD)
-  );
+  menuItems = computed(() => {
+    if (this.newSidebar()) {
+      return this.sidebarService.getMenus(SIDEBAR_MENUS_NEW);
+    }
+    return this.sidebarService.getMenus(SIDEBAR_MENUS_OLD);
+  });
 
   constructor(public sidebarService: SidebarService) {
     effect(() => {

--- a/src/app/core/components/sidebar/sidebar.model.ts
+++ b/src/app/core/components/sidebar/sidebar.model.ts
@@ -29,17 +29,17 @@ export const SIDEBAR_MENUS_OLD: Menu[] = [
       {
         label: 'Dynamic Charts',
         icon: 'description',
-        route: '/reports/dynamic-charts',
+        route: '/reports-v1/dynamic-charts',
       },
       {
         label: 'Summary Charts',
         icon: 'find_in_page',
-        route: '/reports/summary-charts',
+        route: '/reports-v1/summary-charts',
       },
       {
         label: 'Polls Answered',
         icon: 'poll',
-        route: '/reports/polls-answered',
+        route: '/reports-v1/polls-answered',
       },
     ],
   },

--- a/src/app/modules/home-v2/home-container.component.ts
+++ b/src/app/modules/home-v2/home-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
 import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
 import { HomeComponent } from '@modules/home/home.component';
@@ -8,7 +8,7 @@ import { HomeV2Component } from './home.component';
   selector: 'app-home-container',
   imports: [HomeComponent, HomeV2Component],
   template: `
-    @if (showV2) {
+    @if (showV2()) {
       <app-home-v2></app-home-v2>
     } @else {
       <app-home></app-home>
@@ -17,5 +17,5 @@ import { HomeV2Component } from './home.component';
 })
 export class HomeContainerComponent {
   private readonly featureFlags = inject(FeatureFlagsService);
-  showV2 = this.featureFlags.isEnabled(FEATURE_FLAGS.home);
+  showV2 = computed(() => this.featureFlags.isEnabled(FEATURE_FLAGS.home));
 }


### PR DESCRIPTION
## Description

Adds **reportsV2** to FeatureFlags model and service. 
Routes for v1 reports moved to **/reports-v1/** to avoid collision 
with the guarded **/reports** route (ReportsComponent with tabs). 
Sidebar menu selection now driven by feature flags instead of being 
hardcoded. 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


