### PR TITLE
fix: reset file input after rejection to allow re-uploading same file

### DIFF
--- a/src/app/core/services/csv-checker.service.ts
+++ b/src/app/core/services/csv-checker.service.ts
@@ -12,7 +12,7 @@ import {
   providedIn: 'root',
 })
 export class CsvCheckerService {
-  requiredHeaders: string[] = ['Name', 'Email', 'SISId', 'Id'];
+  requiredHeaders: string[] = ['Name', 'Email', 'SISId'];
   expectedHeaders: string[] = [
     ...this.requiredHeaders,
     'EnrolledCourses',
@@ -68,7 +68,7 @@ export class CsvCheckerService {
       Papa.parse(csv, {
         header: true,
         skipEmptyLines: true,
-        delimiter: ',',
+        delimiter: '',
         encoding: 'UTF-8',
         complete: result => {
           if (result.errors.length > 0) {

--- a/src/app/modules/imports/components/import-students/import-students.component.ts
+++ b/src/app/modules/imports/components/import-students/import-students.component.ts
@@ -116,6 +116,7 @@ export class ImportStudentsComponent {
   private rejectFile(msg: string): void {
     this.fileError = msg;
     this.selectedFile = null;
+    this.inputFile.nativeElement.value = '';
     this.openDialog(GENERAL_MESSAGES.DETAILS, false);
   }
 


### PR DESCRIPTION
## Description

Reset file input value after CSV validation failure so the browser 
triggers the change event when the same file is selected again.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


