### PR TITLE
fix(summary-charts): set dynamic chart height for heatmap and column …

### DIFF
--- a/src/app/core/utils/apex-chart/heat-map-config.ts
+++ b/src/app/core/utils/apex-chart/heat-map-config.ts
@@ -15,9 +15,17 @@ export function GetChartOptions(
   tooltipCustomFunction?: (x: number, y: number) => string,
   fixColors = true
 ): ApexOptions {
+  const ROW_HEIGHT = 50;
+  const LEGEND_OFFSET = 60;
+  const calculatedHeight = Math.max(
+    300,
+    series.length * ROW_HEIGHT + LEGEND_OFFSET
+  );
+
   const options: ApexOptions = {
     series: series,
     chart: {
+      height: calculatedHeight,
       zoom: {
         enabled: false,
       },

--- a/src/app/modules/reports/components/summary-charts/summary-column-charts/summary-column-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-column-charts/summary-column-charts.component.ts
@@ -75,7 +75,7 @@ export class SummaryColumnChartsComponent {
   ): Partial<ChartOptions> {
     return {
       title: ColumnChartUtils.createTitle(title),
-      chart: ColumnChartUtils.createChartBase(onSelect),
+      chart: ColumnChartUtils.createChartBase(onSelect, components.length),
       series: this._createSeries(components),
       plotOptions: ColumnChartUtils.createPlotOptions(),
       xaxis: ColumnChartUtils.createXAxis(

--- a/src/app/modules/reports/utils/column-chart.config.ts
+++ b/src/app/modules/reports/utils/column-chart.config.ts
@@ -19,11 +19,16 @@ export class ColumnChartUtils {
   }
 
   static createChartBase(
-    onSelect?: (x: number, y: number, series: ComponentRisk[]) => void
+    onSelect?: (x: number, y: number, series: ComponentRisk[]) => void,
+    componentCount = 5
   ): ApexChart {
+    const BAR_WIDTH = 20;
+    const MIN_HEIGHT = 580;
+    const calculatedHeight = Math.max(MIN_HEIGHT, componentCount * BAR_WIDTH);
+
     return {
       type: 'bar',
-      height: 650,
+      height: calculatedHeight,
       stacked: true,
       stackType: '100%',
       toolbar: { show: false },


### PR DESCRIPTION
## Description

This fix adjusts the heatmap chart size to prevent horizontal overflow in the Summary Charts view.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


