### PR TITLE
fix(details-panel): preserve pageSize when selecting risk from heatmap

### DIFF
--- a/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
+++ b/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
@@ -86,7 +86,11 @@ export class DetailsPanelComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['data'] && this.data()) {
-      this.pagination = { page: 0, pageSize: 10 };
+      this.pagination = {
+        page: 0,
+        pageSize: this.pagination.pageSize,
+      };
+
       this.studentList.set([]);
       this.loadComponentsAndVariables();
     }
@@ -172,7 +176,10 @@ export class DetailsPanelComponent implements OnChanges {
   }
 
   handleLoadCalled(event: EventLoad): void {
-    this.pagination = { page: event.page, pageSize: event.pageSize };
+    this.pagination = {
+      page: event.page,
+      pageSize: event.pageSize,
+    };
     this.loadComponentsAndVariables();
   }
 


### PR DESCRIPTION
## Description

- Keep user selected pageSize in pagination state on ngOnChanges
- Prevent reset to default pageSize=10 when filtering by risk level

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


