### PR TITLE
Fix status color-label recent alerts table

### DIFF
--- a/src/app/core/constants/StatusEvaluation.ts
+++ b/src/app/core/constants/StatusEvaluation.ts
@@ -2,8 +2,8 @@ export const STATUS_EVALUATIONS: Record<string, string> = {
   Pending: 'Pending',
   Ready: 'Ready',
   InProgress: 'In Progress',
-  Completed: 'Resolved',
-  Uncompleted: 'Unresolved',
+  Completed: 'Completed',
+  Uncompleted: 'Uncompleted',
   default: 'New',
 };
 
@@ -13,7 +13,7 @@ export const STATUS_COLORS: Record<string, string> = {
   InProgress: '#FEF9C3',
   Completed: '#DCFCE7',
   Uncompleted: '#FEE2E2',
-  default: '#DBEAFE',
+  default: '#F0EAEA',
 };
 
 export const STATUS_LABEL_COLORS: Record<string, string> = {
@@ -22,5 +22,5 @@ export const STATUS_LABEL_COLORS: Record<string, string> = {
   InProgress: '#854D0E',
   Completed: '#166534',
   Uncompleted: '#991B1B',
-  default: '#1E40AF',
+  default: '#63656A',
 };

--- a/src/app/core/constants/alertRiskLevel.ts
+++ b/src/app/core/constants/alertRiskLevel.ts
@@ -1,12 +1,12 @@
 export const ALERT_RISK_COLORS: Record<string, string> = {
-  Low: '#FEF9C3',
+  Low: '#DCFCE7',
   Medium: '#FFEDD5',
   High: '#FEE2E2',
   default: '#DBEAFE',
 };
 
 export const ALERT_RISK_LABEL_COLORS: Record<string, string> = {
-  Low: '#854D0E',
+  Low: '#166534',
   Medium: '#9A3412',
   High: '#991B1B',
   default: '#1E40AF',

--- a/src/app/shared/components/list/list.component.scss
+++ b/src/app/shared/components/list/list.component.scss
@@ -38,6 +38,21 @@ mat-paginator {
   );
 }
 
+::ng-deep .mat-mdc-paginator-page-size,
+mat-mdc-paginator-page-size {
+  display: flex;
+  align-items: center !important;
+}
+
+.mat-mdc-paginator-page-size {
+  justify-content: flex-start;
+}
+
+::ng-deep .mat-mdc-form-field-subscript-wrapper {
+  height: 2px !important;
+  overflow: hidden;
+}
+
 .export-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

Based on the agreement regarding the colours of the status column, the following fixes were implemented:

| Status from Back-end| Status label displayed | Color |
|-------|-----|----------|
| Pending| Pending| Orange |
| Ready| Ready| Blue |
| InProgress| In Progress| Yellow |
| Completed| Completed| Green |
| Uncompleted| Uncompleted | Red |
| By default _(not matching previous values)_| New | Gray|

Furthermore, the pagination selector is now vertically centred in every list displayed in the system.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#770 
