### PR TITLE
Fix the reports summary heatmap so that it exports all items in the list

### DIFF
--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
@@ -109,15 +109,16 @@
     <div class="report-card">
       <div class="report-card--students">
         <app-list
-          (actionCalled)="(null)"
           (loadCalled)="getStudentsByCohortAndPoll($event)"
+          (exportRequested)="onExportRequested($event)"
+          (exporting)="onExporting($event)"
           [items]="students"
           [totalItems]="totalStudents"
           [columns]="columns"
           [columnTemplates]="columnTemplates"
-          [actionDatas]="[]"
           [title]="'Student Answers'"
-          [showExportDropdown]="false"
+          [showExportDropdown]="true"
+          [allItems]="allStudents"
         >
           <ng-template #avgRiskLevel let-item>
             <span

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
@@ -5,6 +5,24 @@
   padding: 24px;
 }
 
+.export-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(149, 149, 149, 0.322);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 999;
+
+  &-label {
+    font-size: var(--font-size-large);
+    color: var(--color-neutral-700);
+  }
+}
+
 .report-card {
   background: #ffffff;
   border-radius: 8px;

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
@@ -37,7 +37,10 @@ import { ReportService } from '@core/services/api/report.service';
 import { StudentService } from '@core/services/api/student.service';
 
 import { EmptyDataComponent } from '@shared/components/empty-data/empty-data.component';
-import { ListComponent } from '@shared/components/list/list.component';
+import {
+  ListComponent,
+  TypeFile,
+} from '@shared/components/list/list.component';
 import {
   ModalQuestionDetailsComponent,
   SelectedHMData,
@@ -111,13 +114,16 @@ export class SummaryChartsV2Component {
   evaluationId?: number | string;
 
   students: StudentRiskAverage[] = [];
+  allStudents: StudentRiskAverage[] = [];
   totalStudents = 0;
 
   isLoading = false;
   isGeneratingPDF = false;
+  isExporting = signal<boolean>(false);
   title = '';
   components = signal<PollAvgReport | null>(null);
   heatmapChart = true;
+  private allStudentsLoaded = false;
 
   constructor(private snackBar: MatSnackBar) {}
 
@@ -293,6 +299,50 @@ export class SummaryChartsV2Component {
 
   toggleChart(chart: string) {
     this.heatmapChart = chart === 'heatmap';
+  }
+
+  loadAllStudents(): Promise<void> {
+    return new Promise(resolve => {
+      const batchPageSize = 100;
+      let page = 0;
+      let allItems: StudentRiskAverage[] = [];
+
+      const fetchPage = () => {
+        this.studentService
+          .getAllAverageByCohortsAndPoll({
+            page,
+            pageSize: batchPageSize,
+            cohortIds: this.cohortIds,
+            pollUuid: this.pollUuid,
+            lastVersion: this.lastVersion,
+            evaluationId: this.evaluationId,
+          })
+          .subscribe(response => {
+            allItems = [...allItems, ...response.items];
+            if (allItems.length < response.count) {
+              page++;
+              fetchPage();
+            } else {
+              this.allStudents = allItems;
+              resolve();
+            }
+          });
+      };
+
+      fetchPage();
+    });
+  }
+
+  async onExportRequested(event: TypeFile) {
+    void event;
+    if (!this.allStudentsLoaded) {
+      await this.loadAllStudents();
+      this.allStudentsLoaded = true;
+    }
+  }
+
+  async onExporting(processExport: boolean) {
+    this.isExporting.set(processExport);
   }
 
   get showEmpty(): boolean {

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.html
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.html
@@ -5,6 +5,12 @@
   (filters)="handleFilterSelect($event)"
 ></app-poll-filters>
 
+@if (isExporting()) {
+  <div class="export-overlay">
+    <mat-spinner diameter="48"></mat-spinner>
+    <p class="export-overlay__label">Generating PDF...</p>
+  </div>
+}
 @if (showEmpty) {
   <app-empty-data-message
     description="Please select the required fields to generate the charts."
@@ -75,6 +81,7 @@
       <app-list
         (actionCalled)="(null)"
         (loadCalled)="getStudentsByCohortAndPoll($event)"
+        (exporting)="onExporting($event)"
         [items]="students"
         [totalItems]="totalStudents"
         [columns]="columns"

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.html
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.html
@@ -79,13 +79,12 @@
     }
     <div id="table-container">
       <app-list
-        (actionCalled)="(null)"
         (loadCalled)="getStudentsByCohortAndPoll($event)"
+        (exportRequested)="onExportRequested($event)"
         (exporting)="onExporting($event)"
         [items]="students"
         [totalItems]="totalStudents"
         [columns]="columns"
-        [actionDatas]="[]"
         [title]="'Students Risk'"
         [showExportDropdown]="true"
         [allItems]="allStudents"

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.html
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.html
@@ -81,6 +81,7 @@
         [actionDatas]="[]"
         [title]="'Students Risk'"
         [showExportDropdown]="true"
+        [allItems]="allStudents"
       />
     </div>
   </div>

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.scss
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.scss
@@ -3,6 +3,24 @@
   gap: 1rem;
 }
 
+.export-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(149, 149, 149, 0.322);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  z-index: 999;
+
+  &-label {
+    font-size: var(--font-size-large);
+    color: var(--color-neutral-700);
+  }
+}
+
 .risk-badge {
   width: 32px;
   height: 32px;

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
@@ -45,6 +45,7 @@ import {
 import { PollFiltersComponent } from '../poll-filters/poll-filters.component';
 import { SummaryColumnChartsComponent } from '@modules/reports/components/summary-charts/summary-column-charts/summary-column-charts.component';
 import { TooltipChartComponent } from '../tooltip-chart/tooltip-chart.component';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-students-risk',
@@ -63,6 +64,7 @@ import { TooltipChartComponent } from '../tooltip-chart/tooltip-chart.component'
     PollFiltersComponent,
     MatMenuModule,
     SummaryColumnChartsComponent,
+    MatProgressSpinner,
   ],
   templateUrl: './summary-charts.component.html',
   styleUrl: './summary-charts.component.scss',
@@ -111,6 +113,7 @@ export class SummaryChartsComponent {
 
   isLoading = false;
   isGeneratingPDF = false;
+  isExporting = signal<boolean>(false);
   title = '';
   components = signal<PollAvgReport | null>(null);
   heatmapChart = true;
@@ -302,6 +305,10 @@ export class SummaryChartsComponent {
         });
     };
     fetchPage();
+  }
+
+  async onExporting(processExport: boolean) {
+    this.isExporting.set(processExport);
   }
 
   get showEmpty(): boolean {

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
@@ -106,6 +106,7 @@ export class SummaryChartsComponent {
   evaluationId?: number | string;
 
   students: StudentRiskAverage[] = [];
+  allStudents: StudentRiskAverage[] = [];
   totalStudents = 0;
 
   isLoading = false;
@@ -118,6 +119,7 @@ export class SummaryChartsComponent {
 
   getStudentsByCohortAndPoll(event: EventLoad) {
     this._loadStudents(event);
+    this.loadAllStudents();
   }
 
   getHeatMap() {
@@ -271,6 +273,35 @@ export class SummaryChartsComponent {
 
   toggleChart(chart: string) {
     this.heatmapChart = chart === 'heatmap';
+  }
+
+  loadAllStudents() {
+    const batchPageSize = 100;
+    let page = 0;
+    let allItems: StudentRiskAverage[] = [];
+
+    const fetchPage = () => {
+      this.studentService
+        .getAllAverageByCohortsAndPoll({
+          page,
+          pageSize: batchPageSize,
+          cohortIds: this.cohortIds,
+          pollUuid: this.pollUuid,
+          lastVersion: this.lastVersion,
+          evaluationId: this.evaluationId,
+        })
+        .subscribe(response => {
+          allItems = [...allItems, ...response.items];
+
+          if (allItems.length < response.count) {
+            page++;
+            fetchPage();
+          } else {
+            this.allStudents = allItems;
+          }
+        });
+    };
+    fetchPage();
   }
 
   get showEmpty(): boolean {

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.ts
@@ -37,7 +37,10 @@ import { ReportService } from '@core/services/api/report.service';
 import { StudentService } from '@core/services/api/student.service';
 
 import { EmptyDataComponent } from '@shared/components/empty-data/empty-data.component';
-import { ListComponent } from '@shared/components/list/list.component';
+import {
+  ListComponent,
+  TypeFile,
+} from '@shared/components/list/list.component';
 import {
   ModalQuestionDetailsComponent,
   SelectedHMData,
@@ -117,12 +120,12 @@ export class SummaryChartsComponent {
   title = '';
   components = signal<PollAvgReport | null>(null);
   heatmapChart = true;
+  private allStudentsLoaded = false;
 
   constructor(private snackBar: MatSnackBar) {}
 
   getStudentsByCohortAndPoll(event: EventLoad) {
     this._loadStudents(event);
-    this.loadAllStudents();
   }
 
   getHeatMap() {
@@ -278,33 +281,44 @@ export class SummaryChartsComponent {
     this.heatmapChart = chart === 'heatmap';
   }
 
-  loadAllStudents() {
-    const batchPageSize = 100;
-    let page = 0;
-    let allItems: StudentRiskAverage[] = [];
+  loadAllStudents(): Promise<void> {
+    return new Promise(resolve => {
+      const batchPageSize = 100;
+      let page = 0;
+      let allItems: StudentRiskAverage[] = [];
 
-    const fetchPage = () => {
-      this.studentService
-        .getAllAverageByCohortsAndPoll({
-          page,
-          pageSize: batchPageSize,
-          cohortIds: this.cohortIds,
-          pollUuid: this.pollUuid,
-          lastVersion: this.lastVersion,
-          evaluationId: this.evaluationId,
-        })
-        .subscribe(response => {
-          allItems = [...allItems, ...response.items];
+      const fetchPage = () => {
+        this.studentService
+          .getAllAverageByCohortsAndPoll({
+            page,
+            pageSize: batchPageSize,
+            cohortIds: this.cohortIds,
+            pollUuid: this.pollUuid,
+            lastVersion: this.lastVersion,
+            evaluationId: this.evaluationId,
+          })
+          .subscribe(response => {
+            allItems = [...allItems, ...response.items];
+            if (allItems.length < response.count) {
+              page++;
+              fetchPage();
+            } else {
+              this.allStudents = allItems;
+              resolve();
+            }
+          });
+      };
 
-          if (allItems.length < response.count) {
-            page++;
-            fetchPage();
-          } else {
-            this.allStudents = allItems;
-          }
-        });
-    };
-    fetchPage();
+      fetchPage();
+    });
+  }
+
+  async onExportRequested(event: TypeFile) {
+    void event;
+    if (!this.allStudentsLoaded) {
+      await this.loadAllStudents();
+      this.allStudentsLoaded = true;
+    }
   }
 
   async onExporting(processExport: boolean) {

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -11,6 +11,7 @@ import {
   TemplateRef,
   ViewChild,
   AfterContentInit,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
@@ -94,6 +95,7 @@ export class ListComponent<T extends object>
   @Input() columnTemplates: Column<T>[] = [];
   @ViewChild('contentToExport', { static: false }) contentToExport!: ElementRef;
   @Input() pageIndex = 0;
+  @Output() exporting = new EventEmitter<boolean>();
 
   templateMap = new Map<string, TemplateRef<unknown>>();
 
@@ -108,7 +110,11 @@ export class ListComponent<T extends object>
     }
   }
 
-  constructor(private snackBar: MatSnackBar) {}
+  constructor(
+    private snackBar: MatSnackBar,
+    private cdr: ChangeDetectorRef
+    //aqui private pdfHelper: PdfHelper,
+  ) {}
 
   ngOnInit(): void {
     this.load();
@@ -216,13 +222,19 @@ export class ListComponent<T extends object>
     if (this.isGenerating) return;
 
     this.isGenerating = true;
-    await this.pdfHelper.exportToPdf({
-      fileName: 'report_detail',
-      container: this.contentToExport,
-      snackBar: this.snackBar,
-      preProcess: 'list',
-    });
-    this.isGenerating = false;
+    this.exporting.emit(true);
+    try {
+      if (!this.allItems?.length) {
+        const ready = await this.waitForAllItems();
+        if (!ready) {
+          console.warn('allItems not available, exporting current page only');
+        }
+      }
+      await this.exportWithAllItems();
+    } finally {
+      this.isGenerating = false;
+      this.exporting.emit(false);
+    }
   }
 
   private getItemsToExport(): T[] {
@@ -236,5 +248,40 @@ export class ListComponent<T extends object>
     }
 
     return selectedItems;
+  }
+
+  private waitForAllItems(timeoutMs = 30000): Promise<boolean> {
+    return new Promise(resolve => {
+      const start = Date.now();
+      const interval = setInterval(() => {
+        if (this.allItems?.length) {
+          clearInterval(interval);
+          resolve(true);
+        } else if (Date.now() - start > timeoutMs) {
+          clearInterval(interval);
+          resolve(false);
+        }
+      }, 200);
+    });
+  }
+
+  private async exportWithAllItems() {
+    const originalItems = this.items;
+    const itemsToExport = this.allItems?.length ? this.allItems : this.items;
+
+    this.items = itemsToExport;
+    this.cdr.detectChanges();
+    await new Promise(r => requestAnimationFrame(() => setTimeout(r, 150)));
+
+    await this.pdfHelper.exportToPdf({
+      fileName: 'report_detail',
+      container: this.contentToExport,
+      snackBar: this.snackBar,
+      preProcess: 'list',
+    });
+
+    this.items = originalItems;
+    this.showPaginator = true;
+    this.cdr.detectChanges();
   }
 }

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -85,6 +85,7 @@ export class ListComponent<T extends object>
   @Input() showPaginator = true;
   @Input() columnOrder: Column<T>[] = [];
   @Input() isItemDisabled?: (item: T) => boolean;
+  @Input() allItems: T[] = [];
 
   @Output() loadCalled = new EventEmitter<EventLoad>();
   @Output() actionCalled = new EventEmitter<EventAction>();
@@ -195,7 +196,7 @@ export class ListComponent<T extends object>
     this.isGenerating = true;
     const itemsToExport = this.itemsAreSelectable
       ? this.getItemsToExport()
-      : this.items;
+      : (this.allItems ?? this.items);
     const columnsToExport = [
       ...new Set([...this.columns, ...this.exportColumns]),
     ];

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -12,6 +12,8 @@ import {
   ViewChild,
   AfterContentInit,
   ChangeDetectorRef,
+  SimpleChanges,
+  OnChanges,
 } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
@@ -39,6 +41,8 @@ import { FormsModule } from '@angular/forms';
 import { MapClass } from './types/class';
 import { EmptyDataComponent } from '../empty-data/empty-data.component';
 
+export type TypeFile = 'csv' | 'pdf' | '';
+
 @Component({
   selector: 'app-list',
   imports: [
@@ -59,7 +63,7 @@ import { EmptyDataComponent } from '../empty-data/empty-data.component';
   styleUrl: './list.component.scss',
 })
 export class ListComponent<T extends object>
-  implements OnInit, AfterContentInit
+  implements OnInit, AfterContentInit, OnChanges
 {
   csvService = inject(CsvService);
   pdfHelper = inject(PdfHelper);
@@ -96,10 +100,12 @@ export class ListComponent<T extends object>
   @ViewChild('contentToExport', { static: false }) contentToExport!: ElementRef;
   @Input() pageIndex = 0;
   @Output() exporting = new EventEmitter<boolean>();
+  @Output() exportRequested = new EventEmitter<TypeFile>();
+  private pendingExportResolve: (() => void) | null = null;
 
   templateMap = new Map<string, TemplateRef<unknown>>();
 
-  selectedExportFormat: 'csv' | 'pdf' | '' = '';
+  selectedExportFormat: TypeFile = '';
 
   exportTable() {
     if (!this.selectedExportFormat) return;
@@ -113,7 +119,6 @@ export class ListComponent<T extends object>
   constructor(
     private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef
-    //aqui private pdfHelper: PdfHelper,
   ) {}
 
   ngOnInit(): void {
@@ -129,6 +134,18 @@ export class ListComponent<T extends object>
         this.templateMap.set(name, tpl);
       }
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (
+      changes['allItems'] &&
+      this.allItems?.length &&
+      this.pendingExportResolve
+    ) {
+      const resolve = this.pendingExportResolve;
+      this.pendingExportResolve = null;
+      resolve();
+    }
   }
 
   onPageChange(pagination: PageEvent): void {
@@ -199,23 +216,15 @@ export class ListComponent<T extends object>
 
   exportToCSV() {
     if (this.isGenerating) return;
-    this.isGenerating = true;
-    const itemsToExport = this.itemsAreSelectable
-      ? this.getItemsToExport()
-      : (this.allItems ?? this.items);
-    const columnsToExport = [
-      ...new Set([...this.columns, ...this.exportColumns]),
-    ];
-    const columnKeys = columnsToExport.map(c => c.key);
-    const columnLabels = columnsToExport.map(c => c.label);
-
-    this.csvService.exportToCSV(
-      itemsToExport,
-      columnKeys as string[],
-      columnLabels
-    );
-
-    this.isGenerating = false;
+    if (!this.allItems?.length) {
+      const waitForItems = new Promise<void>(resolve => {
+        this.pendingExportResolve = resolve;
+      });
+      this.exportRequested.emit('csv');
+      waitForItems.then(() => this._exportItemsToCsv());
+      return;
+    }
+    this._exportItemsToCsv();
   }
 
   async exportToPdf() {
@@ -225,10 +234,10 @@ export class ListComponent<T extends object>
     this.exporting.emit(true);
     try {
       if (!this.allItems?.length) {
-        const ready = await this.waitForAllItems();
-        if (!ready) {
-          console.warn('allItems not available, exporting current page only');
-        }
+        await new Promise<void>(resolve => {
+          this.pendingExportResolve = resolve;
+          this.exportRequested.emit('pdf');
+        });
       }
       await this.exportWithAllItems();
     } finally {
@@ -283,5 +292,25 @@ export class ListComponent<T extends object>
     this.items = originalItems;
     this.showPaginator = true;
     this.cdr.detectChanges();
+  }
+  private _exportItemsToCsv() {
+    if (this.isGenerating) return;
+    this.isGenerating = true;
+    const itemsToExport = this.itemsAreSelectable
+      ? this.getItemsToExport()
+      : (this.allItems ?? this.items);
+    const columnsToExport = [
+      ...new Set([...this.columns, ...this.exportColumns]),
+    ];
+    const columnKeys = columnsToExport.map(c => c.key);
+    const columnLabels = columnsToExport.map(c => c.label);
+
+    this.csvService.exportToCSV(
+      itemsToExport,
+      columnKeys as string[],
+      columnLabels
+    );
+
+    this.isGenerating = false;
   }
 }


### PR DESCRIPTION
## Description

Based on the requirements, only the paginated items were exported to the CSV or PDF file in the summary charts section.
Now, all items relating to the Student Risk table are exported to CSV and PDF files.
A blur effect will be displayed while exporting.

NOTE: Ensure you test selecting an 'Evaluation Process' with a large amount of data to see if the resulting CSV or PDF shows all the data.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [X] Have the requirements been met?
- [X] Is the code easy to read?
- [X] Do unit tests pass?
- [X] Is the code formatted correctly?

## Angular Checklist

- [X] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [X] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [X] Are all dependencies necessary and up-to-date?

## Design Checklist
- [X] Most important content is be visible on all screen sizes
- [X] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#249 
