### PR TITLE
fix: use form date instead of current date

### DIFF
--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
@@ -12,7 +12,10 @@ describe('NewAssessmentModalComponent', () => {
     await TestBed.configureTestingModule({
       imports: [NewAssessmentModalComponent],
       providers: [
-        { provide: MAT_DIALOG_DATA, useValue: {} },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { profiles: [{ label: 'Admin', value: 'admin' }] },
+        },
         {
           provide: MatDialogRef,
           useValue: { close: jasmine.createSpy('close') },

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -107,7 +107,7 @@ export class NewAssessmentModalComponent implements FormCreation {
   submitAssessment() {
     if (this.form.valid) {
       const newAssessment: AssessmentModel = {
-        createdAtUtc: new Date().toISOString(),
+        createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
         service: this.form.value.service,
         assignedProfessional: this.form.value.professional,

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -66,6 +66,7 @@ export class NewAssessmentModalComponent implements FormCreation {
         options: this.data.profiles,
         validators: [Validators.required],
         floatingLabel: 'always',
+        value: this.data.profiles[0].value ?? undefined,
       },
       {
         type: 'select',


### PR DESCRIPTION
## Description

Use date selected in form instead of current date when creating a new assessment.


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


