### PR TITLE
fix: Add attribute to export risk levels in Csv in summary charts section

### DIFF
--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
@@ -6,6 +6,12 @@
     ></app-poll-filters>
   </div>
 
+  @if (isExporting()) {
+    <div class="export-overlay">
+      <mat-spinner diameter="48"></mat-spinner>
+      <p class="export-overlay__label">Generating PDF...</p>
+    </div>
+  }
   @if (showEmpty) {
     <app-empty-data-message
       description="Please select the required fields to generate the charts."
@@ -119,6 +125,7 @@
           [title]="'Student Answers'"
           [showExportDropdown]="true"
           [allItems]="allStudents"
+          [areExportedAllItems]="true"
         >
           <ng-template #avgRiskLevel let-item>
             <span

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
@@ -50,6 +50,7 @@ import { SummaryColumnChartsComponent } from '@modules/reports/components/summar
 import { TooltipChartComponent } from '../tooltip-chart/tooltip-chart.component';
 import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
 import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-students-risk',
@@ -68,6 +69,7 @@ import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
     PollFiltersComponent,
     MatMenuModule,
     SummaryColumnChartsComponent,
+    MatProgressSpinner,
   ],
   templateUrl: './summary-charts-v2.component.html',
   styleUrl: './summary-charts-v2.component.scss',

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -300,7 +300,11 @@ export class ListComponent<T extends object>
       ? this.getItemsToExport()
       : (this.allItems ?? this.items);
     const columnsToExport = [
-      ...new Set([...this.columns, ...this.exportColumns]),
+      ...new Set([
+        ...this.columns,
+        ...this.exportColumns,
+        ...this.columnTemplates,
+      ]),
     ];
     const columnKeys = columnsToExport.map(c => c.key);
     const columnLabels = columnsToExport.map(c => c.label);

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -91,6 +91,7 @@ export class ListComponent<T extends object>
   @Input() columnOrder: Column<T>[] = [];
   @Input() isItemDisabled?: (item: T) => boolean;
   @Input() allItems: T[] = [];
+  @Input() areExportedAllItems = false;
 
   @Output() loadCalled = new EventEmitter<EventLoad>();
   @Output() actionCalled = new EventEmitter<EventAction>();
@@ -216,7 +217,7 @@ export class ListComponent<T extends object>
 
   exportToCSV() {
     if (this.isGenerating) return;
-    if (!this.allItems?.length) {
+    if (this.areExportedAllItems) {
       const waitForItems = new Promise<void>(resolve => {
         this.pendingExportResolve = resolve;
       });
@@ -233,7 +234,7 @@ export class ListComponent<T extends object>
     this.isGenerating = true;
     this.exporting.emit(true);
     try {
-      if (!this.allItems?.length) {
+      if (this.areExportedAllItems) {
         await new Promise<void>(resolve => {
           this.pendingExportResolve = resolve;
           this.exportRequested.emit('pdf');
@@ -257,21 +258,6 @@ export class ListComponent<T extends object>
     }
 
     return selectedItems;
-  }
-
-  private waitForAllItems(timeoutMs = 30000): Promise<boolean> {
-    return new Promise(resolve => {
-      const start = Date.now();
-      const interval = setInterval(() => {
-        if (this.allItems?.length) {
-          clearInterval(interval);
-          resolve(true);
-        } else if (Date.now() - start > timeoutMs) {
-          clearInterval(interval);
-          resolve(false);
-        }
-      }, 200);
-    });
   }
 
   private async exportWithAllItems() {


### PR DESCRIPTION
## Description

Added the respective column to export all data (included risk levels) in csv for **summary charts** section

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#249 
