### PR TITLE
fix: add evaluationId in loadStudentList in RiskLevels-modal

### DIFF
--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.html
@@ -101,6 +101,7 @@
             [pollUuid]="pollUuid"
             [cohortsIds]="cohortIds"
             [data]="title"
+            [evaluationId]="evaluationId"
           ></app-summary-column-charts>
         }
       </div>

--- a/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
+++ b/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.ts
@@ -117,7 +117,9 @@ export default class RiskDetailsComponent {
         this.data.data.cohorts,
         [this.variableId],
         this.pagination.pageSize,
-        this.pagination.page
+        this.pagination.page,
+        undefined,
+        this.data.data.evaluationId
       )
       .subscribe(data => {
         const items = (data?.items ?? []).sort((a, b) => {

--- a/src/app/modules/reports/components/summary-charts/summary-charts.component.html
+++ b/src/app/modules/reports/components/summary-charts/summary-charts.component.html
@@ -75,6 +75,7 @@
         [pollUuid]="pollUuid"
         [cohortsIds]="cohortIds"
         [data]="title"
+        [evaluationId]="evaluationId"
       ></app-summary-column-charts>
     }
     <div id="table-container">

--- a/src/app/modules/reports/components/summary-charts/summary-column-charts/summary-column-charts.component.ts
+++ b/src/app/modules/reports/components/summary-charts/summary-column-charts/summary-column-charts.component.ts
@@ -32,6 +32,7 @@ export class SummaryColumnChartsComponent {
   pollUuid = input<string>();
   cohortsIds = input<number[]>();
   data = input();
+  evaluationId = input<number | string>();
 
   private injector = inject(EnvironmentInjector);
   private erasModalService = inject(ErasModalService);
@@ -61,6 +62,7 @@ export class SummaryColumnChartsComponent {
         pollUuid: this.pollUuid(),
         cohorts: this.cohortsIds(),
         componentName,
+        evaluationId: this.evaluationId(),
       },
       title: `${componentName}: ${series[y].name} Details`,
     };


### PR DESCRIPTION
## Description

In summary-charts it was added evaluationId in the modal when the chart type : 'column-chart' is selected
Because the reason of bug was the not found attribute: evaluationId for StudentByFilters endpoint

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#855 