### PR TITLE
Fix failed cases by importing students new user interface

### DIFF
--- a/src/app/core/utils/helpers/parsers.ts
+++ b/src/app/core/utils/helpers/parsers.ts
@@ -43,3 +43,10 @@ export function parseJsonRows(rows: Record<string, string>[]) {
     return filteredRow;
   });
 }
+
+export function parseFloatDistinct(value: string | undefined | null): number {
+  if (value == null) return NaN;
+  const decimal = value.replace(',', '.');
+  const parsed = parseFloat(decimal);
+  return isNaN(parsed) ? NaN : Math.round(parsed * 100) / 100;
+}

--- a/src/app/modules/imports/components/import-modal/import-modal.component.ts
+++ b/src/app/modules/imports/components/import-modal/import-modal.component.ts
@@ -113,4 +113,9 @@ export class ImportModalComponent {
     this.selectedFile = null;
     this.fileError = null;
   }
+
+  preloadFile(file: File): void {
+    this.fileError = null;
+    this.selectedFile = file;
+  }
 }

--- a/src/app/modules/imports/components/import-preview-students/import-preview-students.component.html
+++ b/src/app/modules/imports/components/import-preview-students/import-preview-students.component.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="Close dialog"
       [disabled]="isLoading"
-      (click)="onCancel()"
+      (click)="onExit()"
     >
       <mat-icon>close</mat-icon>
     </button>

--- a/src/app/modules/imports/components/import-preview-students/import-preview-students.component.ts
+++ b/src/app/modules/imports/components/import-preview-students/import-preview-students.component.ts
@@ -53,6 +53,9 @@ export class ImportPreviewStudentsComponent implements OnInit {
   previewDataRows: PreviewDataRow[] = [];
 
   ngOnInit(): void {
+    if (this.rows.length === 0) {
+      this.errorsInHeaders.unshift('Failed to parse CSV file.');
+    }
     this.loadRows();
   }
 

--- a/src/app/modules/imports/components/import-preview-students/import-preview-students.component.ts
+++ b/src/app/modules/imports/components/import-preview-students/import-preview-students.component.ts
@@ -47,6 +47,7 @@ export class ImportPreviewStudentsComponent implements OnInit {
 
   @Output() confirmed = new EventEmitter<ImportPreviewConfirm>();
   @Output() cancelled = new EventEmitter<void>();
+  @Output() cancelledExit = new EventEmitter<void>();
 
   statusColumn: Column<StudentModelPreview>[] = [{ key: 'status', label: '' }];
   previewDataRows: PreviewDataRow[] = [];
@@ -114,6 +115,11 @@ export class ImportPreviewStudentsComponent implements OnInit {
 
   onCancel(): void {
     this.cancelled.emit();
+    this.dialogRef?.close();
+  }
+
+  onExit(): void {
+    this.cancelledExit.emit();
     this.dialogRef?.close();
   }
 }

--- a/src/app/modules/students/students-list/students-list.component.ts
+++ b/src/app/modules/students/students-list/students-list.component.ts
@@ -32,6 +32,7 @@ import {
 } from '@shared/components/list/types/preview';
 import {
   getHeadersErrors,
+  parseFloatDistinct,
   parseJsonRows,
   parseRowErrors,
 } from '@core/utils/helpers/parsers';
@@ -226,7 +227,7 @@ export class StudentsListComponent implements OnInit {
     }));
   }
 
-  openImportModal(): void {
+  openImportModal(restoredFile?: File): void {
     const dialogRef: MatDialogRef<ImportModalComponent> = this.dialog.open(
       ImportModalComponent,
       {
@@ -238,6 +239,10 @@ export class StudentsListComponent implements OnInit {
     const instance = dialogRef.componentInstance;
     instance.config = CSV_IMPORT_CONFIG;
     instance.dialogRef = dialogRef;
+
+    if (restoredFile) {
+      instance.preloadFile(restoredFile);
+    }
 
     instance.fileSelected.subscribe((file: File) => {
       instance.isLoading = true;
@@ -257,18 +262,25 @@ export class StudentsListComponent implements OnInit {
       return;
     }
     const csvErrors = this.csvCheckerService.getErrors();
-
-    if (csvErrors.some(e => /Row NaN:/i.test(e))) {
+    if (
+      csvErrors.some(e => /Row NaN:|Too few fields|Too many fields/i.test(e))
+    ) {
       instance.isLoading = false;
       dialogRef.close();
 
       const previewRef = this.prepareDialog();
       const preview = previewRef.componentInstance;
+      const errorsInHeaders = getHeadersErrors(csvErrors);
       preview.rows = [];
-      preview.errorsInHeaders = getHeadersErrors(csvErrors);
+      preview.errorsInHeaders =
+        errorsInHeaders.length > 0 ? errorsInHeaders : csvErrors;
       preview.columns = [...MandatoryColumns];
       preview.dialogRef = previewRef;
-      preview.cancelled.subscribe(() => this.openImportModal());
+      preview.cancelled.subscribe(() => this.openImportModal(file));
+      preview.cancelledExit.subscribe(() => {
+        preview.dialogRef?.close();
+        dialogRef.close();
+      });
       return;
     }
 
@@ -289,6 +301,7 @@ export class StudentsListComponent implements OnInit {
       data: this.convertToModel(row),
       errors: rowErrorMap.get(i) ?? [],
     }));
+
     instance.isLoading = false;
     dialogRef.close();
 
@@ -299,7 +312,11 @@ export class StudentsListComponent implements OnInit {
     preview.errorsInHeaders = errorsInHeaders;
     preview.columns = [...MandatoryColumns, ...detectedOptionalColumns];
     preview.dialogRef = previewRef;
-    preview.cancelled.subscribe(() => this.openImportModal());
+    preview.cancelled.subscribe(() => this.openImportModal(file));
+    preview.cancelledExit.subscribe(() => {
+      preview.dialogRef?.close();
+      dialogRef.close();
+    });
 
     const jsonData = parseJsonRows(rawRows);
     preview.confirmed.subscribe((result: ImportPreviewConfirm) => {
@@ -361,7 +378,7 @@ export class StudentsListComponent implements OnInit {
       enrolledCourses: parseInt(row['EnrolledCourses']),
       gradedCourses: parseInt(row['GradedCourses']),
       timeDeliveryRate: parseFloat(row['TimelySubmissions']),
-      avgScore: parseFloat(row['AverageScore']),
+      avgScore: parseFloatDistinct(row['AverageScore']),
       coursesUnderAvg: parseFloat(row['CoursesBelowAverage']),
       pureScoreDiff: parseFloat(row['RawScoreDifference']),
       standardScoreDiff: parseFloat(row['StandardScoreDifference']),


### PR DESCRIPTION
## Description

- Failed cases like 8,9, 11, 14 and 15 were solved
- If we click on "Back" button in the preview import (second modal), then the imported file remains in the first modal.
- The X button closes all modals
- Remaining data is not displayed when uploading a file with errors after uploading a file without errors. 
- If there is not parsed csv data, a message appears as part of alerts.

If you want to test the cases without data parsing, this file could be helpful:
[ImportCSV_RequiredFieldsMissing (2).csv](https://github.com/user-attachments/files/27808584/ImportCSV_RequiredFieldsMissing.2.csv)

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#804 