### PR TITLE
fix: fix scope of styles + increase margin of fields

### DIFF
--- a/src/app/shared/components/list/list.component.scss
+++ b/src/app/shared/components/list/list.component.scss
@@ -37,7 +37,7 @@ mat-paginator {
   );
 }
 
-::ng-deep .mat-mdc-paginator-page-size,
+:host ::ng-deep .mat-mdc-paginator-page-size,
 mat-mdc-paginator-page-size {
   display: flex;
   align-items: center !important;
@@ -47,7 +47,7 @@ mat-mdc-paginator-page-size {
   justify-content: flex-start;
 }
 
-::ng-deep .mat-mdc-form-field-subscript-wrapper {
+:host ::ng-deep .mat-mdc-form-field-subscript-wrapper {
   height: 2px !important;
   overflow: hidden;
 }

--- a/src/styles/utils/_forms.scss
+++ b/src/styles/utils/_forms.scss
@@ -4,7 +4,7 @@
 
 // Generic forms styles
 mat-form-field {
-  margin-bottom: 5px;
+  margin-bottom: 8px;
 }
 
 mat-option[appselectall] {


### PR DESCRIPTION
## Description
Added :host pseudo-class to classes using ::ng-deep that caused material form fields to behave unexpectedly. Also, increased the margin bottom of mat-form-field for a better UI/UX.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


