### PR TITLE
fix: answer details list displayed when selecting the same cell in summary charts (column charts).

### DIFF
--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, DatePipe, NgClass } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import {
   Component,
   EventEmitter,

--- a/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.html
+++ b/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.html
@@ -23,28 +23,20 @@
           </section>
 
           <section class="answer-details">
-            <mat-expansion-panel>
-              <mat-expansion-panel-header>
-                Answer Details
-              </mat-expansion-panel-header>
-              <ng-template matExpansionPanelContent>
-                <app-list
-                  (loadCalled)="handleLoadCalled($event, risk)"
-                  (actionCalled)="handleActionCalled($event)"
-                  [columns]="columns"
-                  [columnTemplates]="columnTemplates"
-                  [items]="riskStudentData().get(risk.position)?.items ?? []"
-                  [totalItems]="
-                    riskStudentData().get(risk.position)?.total ?? 0
-                  "
-                  [actionDatas]="actionDatas"
-                >
-                  <ng-template #riskLevel let-item>
-                    <app-badge-risk-level [riskLevel]="item.riskLevel" />
-                  </ng-template>
-                </app-list>
+            <h3 class="risk-title">Answer Details</h3>
+            <app-list
+              (loadCalled)="handleLoadCalled($event, risk)"
+              (actionCalled)="handleActionCalled($event)"
+              [columns]="columns"
+              [columnTemplates]="columnTemplates"
+              [items]="riskStudentData().get(risk.position)?.items ?? []"
+              [totalItems]="riskStudentData().get(risk.position)?.total ?? 0"
+              [actionDatas]="actionDatas"
+            >
+              <ng-template #riskLevel let-item>
+                <app-badge-risk-level [riskLevel]="item.riskLevel" />
               </ng-template>
-            </mat-expansion-panel>
+            </app-list>
           </section>
         </div>
       }

--- a/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.html
+++ b/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.html
@@ -32,6 +32,7 @@
               [items]="riskStudentData().get(risk.position)?.items ?? []"
               [totalItems]="riskStudentData().get(risk.position)?.total ?? 0"
               [actionDatas]="actionDatas"
+              [emptyTemplate]="loadingTemplate"
             >
               <ng-template #riskLevel let-item>
                 <app-badge-risk-level [riskLevel]="item.riskLevel" />
@@ -43,3 +44,6 @@
     </div>
   }
 </div>
+<ng-template #loadingTemplate>
+  <mat-spinner diameter="32"></mat-spinner>
+</ng-template>

--- a/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.ts
@@ -6,6 +6,7 @@ import {
   inject,
   OnChanges,
   SimpleChanges,
+  effect,
 } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -88,12 +89,33 @@ export class ColumnRiskPanelComponent implements OnChanges {
       tooltip: 'View details',
     },
   ];
+  variablesCacheReady = signal(false);
+
+  constructor() {
+    effect(() => {
+      if (this.variablesCacheReady()) {
+        const panelData = this.data();
+        if (!panelData) return;
+
+        panelData.questions.forEach(risk => {
+          const variableId = this.variablesCache.get(
+            `${risk.question}__${risk.position}`
+          );
+          if (variableId !== undefined) {
+            this.loadStudentList(risk, variableId);
+          }
+        });
+      }
+    });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['data'] && this.data()) {
       this.riskStudentData.set(new Map());
       this.pagination = { page: 0, pageSize: 10 };
       this.variablesCache = new Map();
+      this.variablesCacheReady.set(false);
+
       this._preloadVariables();
     }
   }
@@ -116,11 +138,15 @@ export class ColumnRiskPanelComponent implements OnChanges {
         response.forEach(v => {
           this.variablesCache.set(`${v.name}__${v.position}`, v.id);
         });
+        this.variablesCacheReady.set(true);
       });
   }
 
   handleLoadCalled(event: EventLoad, risk: PollAvgQuestion): void {
     this.pagination = { page: event.page, pageSize: event.pageSize };
+    if (!this.variablesCacheReady()) {
+      return;
+    }
     const variableId = this.variablesCache.get(
       `${risk.question}__${risk.position}`
     );

--- a/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.ts
@@ -32,6 +32,7 @@ import { ListComponent } from '@shared/components/list/list.component';
 import { BadgeRiskComponent } from '@shared/components/badge-risk-level/badge-risk-level.component';
 import { ModalStudentDetailComponent } from '@shared/components/modals/modal-student-detail/modal-student-detail.component';
 import { ModalStudentDetailV2Component } from '@shared/components/modals/modal-student-detail/v2/modal-student-detail-v2.component';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 export interface ColumnRiskPanelData {
   cohortIds: number[];
@@ -52,6 +53,7 @@ export interface ColumnRiskPanelData {
     MatExpansionModule,
     ListComponent,
     BadgeRiskComponent,
+    MatProgressSpinner,
   ],
   templateUrl: './column-risk-panel.component.html',
   styleUrl: './column-risk-panel.component.scss',

--- a/src/app/shared/components/list-details/list-details.component.html
+++ b/src/app/shared/components/list-details/list-details.component.html
@@ -12,7 +12,11 @@
 <div class="container-table-button" #contentToExport>
   <div>
     @if (!items.length) {
-      <app-empty-data-message />
+      @if (emptyTemplate) {
+        <ng-container [ngTemplateOutlet]="emptyTemplate" />
+      } @else {
+        <app-empty-data-message />
+      }
     } @else {
       <app-mat-card-details
         [mapClass]="mapClass?.table ? mapClass : undefined"

--- a/src/app/shared/components/list-details/list-details.component.ts
+++ b/src/app/shared/components/list-details/list-details.component.ts
@@ -38,6 +38,7 @@ import { Column, ComponentColumn } from '../list/types/column';
 import { ActionDatas } from '../list/types/action';
 import { MapClass } from '../list/types/class';
 import { MatCardDetailsComponent } from '../mat-card-details/mat-card-details.component';
+import { NgTemplateOutlet } from '@angular/common';
 
 @Component({
   selector: 'app-list-details',
@@ -54,6 +55,7 @@ import { MatCardDetailsComponent } from '../mat-card-details/mat-card-details.co
     MatMenuModule,
     EmptyDataComponent,
     MatCardDetailsComponent,
+    NgTemplateOutlet,
   ],
   templateUrl: './list-details.component.html',
   styleUrl: './list-details.component.scss',
@@ -82,6 +84,7 @@ export class ListDetailsComponent<T extends object>
   @Input() showExportDropdown = false;
   @Input() itemsAreSelectable = false;
   @Input() externalExport = false;
+  @Input() emptyTemplate?: TemplateRef<T>;
 
   @Output() loadCalled = new EventEmitter<EventLoad>();
   @Output() actionCalled = new EventEmitter<EventAction>();

--- a/src/app/shared/components/list/list.component.html
+++ b/src/app/shared/components/list/list.component.html
@@ -43,7 +43,11 @@
 <div class="container-table-button" #contentToExport>
   <div>
     @if (!items.length) {
-      <app-empty-data-message />
+      @if (emptyTemplate) {
+        <ng-container [ngTemplateOutlet]="emptyTemplate" />
+      } @else {
+        <app-empty-data-message />
+      }
     } @else {
       <app-table-with-actions
         [mapClass]="mapClass?.table ? mapClass : undefined"

--- a/src/app/shared/components/list/list.component.ts
+++ b/src/app/shared/components/list/list.component.ts
@@ -40,6 +40,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { FormsModule } from '@angular/forms';
 import { MapClass } from './types/class';
 import { EmptyDataComponent } from '../empty-data/empty-data.component';
+import { NgTemplateOutlet } from '@angular/common';
 
 export type TypeFile = 'csv' | 'pdf' | '';
 
@@ -58,6 +59,7 @@ export type TypeFile = 'csv' | 'pdf' | '';
     MatTooltipModule,
     MatMenuModule,
     EmptyDataComponent,
+    NgTemplateOutlet,
   ],
   templateUrl: './list.component.html',
   styleUrl: './list.component.scss',
@@ -92,6 +94,7 @@ export class ListComponent<T extends object>
   @Input() isItemDisabled?: (item: T) => boolean;
   @Input() allItems: T[] = [];
   @Input() areExportedAllItems = false;
+  @Input() emptyTemplate?: TemplateRef<T>;
 
   @Output() loadCalled = new EventEmitter<EventLoad>();
   @Output() actionCalled = new EventEmitter<EventAction>();

--- a/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
+++ b/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
@@ -19,7 +19,6 @@ import { Column } from '@shared/components/list/types/column';
 import { ActionDatas } from '@shared/components/list/types/action';
 import { EventAction, EventLoad } from '@core/models/load';
 import { Pagination } from '@core/services/interfaces/server.type';
-import { ListComponent } from '@shared/components/list/list.component';
 import { BadgeRiskComponent } from '@shared/components/badge-risk-level/badge-risk-level.component';
 import { ModalStudentDetailComponent } from '@shared/components/modals/modal-student-detail/modal-student-detail.component';
 import { MatDialog } from '@angular/material/dialog';
@@ -45,7 +44,6 @@ export interface DetailsPanelData {
   imports: [
     MatIconModule,
     MatButtonModule,
-    ListComponent,
     BadgeRiskComponent,
     ListDetailsComponent,
   ],


### PR DESCRIPTION
## Description

In Summary charts, by changing the type of chart: Column chart, due to lazy loading in collapsible-extendable component:
- Added effect to load variablesCache in constructor of column risk
- Remove the component that wraps the list (as part of the third requirement in ticket)
- Remove unused imports in assessment-list and details-panel

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#855 