### PR TITLE
fix: charts are not displayed when they are extended and a few variables are selected for the extended chart.

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
@@ -34,11 +34,16 @@
         @for (chartOption of chartsOptions; track $index) {
           <app-expandable-card
             #chartsGrid
-            [cardId]="'chart-' + $index"
-            [expanded]="expandedId === 'chart-' + $index && isAnyCardExpanded"
+            [cardId]="'chart-' + getComponentOfChart(chartOption.title?.text)"
+            [expanded]="
+              expandedId ===
+                'chart-' + getComponentOfChart(chartOption.title?.text) &&
+              isAnyCardExpanded
+            "
             [dimmed]="
               expandedId !== null &&
-              expandedId !== 'chart-' + $index &&
+              expandedId !==
+                'chart-' + getComponentOfChart(chartOption.title?.text) &&
               isAnyCardExpanded
             "
             [transitioning]="isPanelTransitioning()"

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -76,7 +76,6 @@ export class DynamicChartsV2Component implements AfterViewInit {
   isPanelOpen = signal(false);
   hasNoResults = false;
   isAnyCardExpanded = false;
-  expandedIndex: number | null = null;
   expandedComponent: string | null | undefined = null;
 
   gridHeight = 0;
@@ -226,15 +225,9 @@ export class DynamicChartsV2Component implements AfterViewInit {
   }
 
   onToggle(id: string): void {
-    const index: string = id.at(-1) ?? '0';
-    this.expandedComponent =
-      this.components()?.components[parseInt(index)].description;
+    this.expandedComponent = id.replace('chart-', '');
     this.expandedId = this.expandedId === id ? null : id;
     this.isAnyCardExpanded = this.expandedId !== null;
-    this.expandedIndex = this.isAnyCardExpanded
-      ? parseInt(id.replace('chart-', ''))
-      : null;
-
     if (this.expandedId === null) {
       this.gridHeight = this.contentQuarter.nativeElement.offsetHeight;
     }
@@ -347,6 +340,10 @@ export class DynamicChartsV2Component implements AfterViewInit {
     this.chartTypeMap.set(componentLabel, type);
   }
 
+  getComponentOfChart(titleChart: string | undefined) {
+    return titleChart?.replace('Reporte: ', '').toLocaleLowerCase();
+  }
+
   private resetBaseState() {
     this.hasNoResults = false;
   }
@@ -369,7 +366,6 @@ export class DynamicChartsV2Component implements AfterViewInit {
     this.uuid = null;
     this.isAnyCardExpanded = false;
     this.expandedId = null;
-    this.expandedIndex = null;
   }
 
   private handleExpandedState(filters: Filter) {
@@ -387,7 +383,6 @@ export class DynamicChartsV2Component implements AfterViewInit {
       index = 0;
       this.expandedComponent = selected[0].toLowerCase();
     }
-    this.expandedIndex = index;
-    this.expandedId = `chart-${index}`;
+    this.expandedId = `chart-${this.expandedComponent}`;
   }
 }


### PR DESCRIPTION
## Description
**Bug Reproduction**

The issue occurred under the following conditions:

- Filters were set to the default value: "Select All".
- A chart was expanded. For example: Individual 
- In the expanded chart, specific variables were selected, for example:
Components: "Select All"
Variable: "Estado civil"

This scenario caused the chart to stop rendering.

**Fix Implemented**

The chart rendering logic was updated to use extendedComponent as the primary comparator instead of the chart+id => depends on index iterated by for loop of chartsOptions. As part of this refactor, unused variables such as expandedIndex were removed.

Additionally, extendedComponent is now used as the main reference for applying the expanded view and its filters. This prevents charts from disappearing when the number of rendered charts is insufficient or when filters are applied to specific variables.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


