### PR TITLE
fix: remove import-students on V2 sidebar adding a container to change the view follow v2

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,7 +7,6 @@ import { referralsResolver } from '@modules/supports-referrals/resolvers/referra
 import { CosmicLatteComponent } from '@modules/settings/cosmic-latte.component';
 import { EvaluationProcessListComponent } from '@modules/lists/components/evaluacion-process/evaluation-process-list.component';
 import { ImportPreviewComponent } from '@modules/imports/components/import-preview/import-preview.component';
-import { ImportStudentsComponent } from '@modules/imports/components/import-students/import-students.component';
 import { LayoutComponent } from '@core/components/layout/layout.component';
 import { ListStudentsByPollComponent } from '@modules/lists/components/list-students-by-poll/list-students-by-poll.component';
 import { PollsAnsweredComponent } from '@modules/reports/components/polls-answered/polls-answered.component';
@@ -17,7 +16,6 @@ import { StudentMonitoringDetailsComponent } from '@modules/student-monitoring/s
 import { StudentMonitoringPollsComponent } from '@modules/student-monitoring/student-monitoring-polls/student-monitoring-polls.component';
 import { SummaryChartsComponent } from '@modules/reports/components/summary-charts/summary-charts.component';
 import { evaluationProcessesResolver } from '@modules/reports/resolvers/evaluation-processes.resolver';
-import { StudentsListComponent } from '@modules/students/students-list/students-list.component';
 import { ReportsComponent } from '@modules/reports/components/reports/reports.component';
 import { HomeContainerComponent } from '@modules/home-v2/home-container.component';
 import { AppRouteData } from '@core/models/route-data.model';
@@ -29,6 +27,7 @@ import { AssessmentsComponent } from '@modules/assessments/components/assessment
 import { RecentAlertsListComponent } from '@modules/lists/components/recent-alerts-list/recent-alerts-list.component';
 import { SummaryChartsV2Component } from '@modules/reports/components/summary-charts-v2/summary-charts-v2.component';
 import { AssessmentsContainerComponent } from '@modules/assessments/components/assesment-container/assessments-container.component';
+import { StudentsContainerComponent } from '@modules/students/students-container.component';
 
 export const routes: Routes = [
   {
@@ -105,18 +104,13 @@ export const routes: Routes = [
         ],
       },
       {
-        path: 'import-students',
-        component: ImportStudentsComponent,
-        data: { breadcrumb: 'Import Students' },
-      },
-      {
         path: 'list-students-by-poll',
         component: ListStudentsByPollComponent,
         data: { breadcrumb: 'Students List By Poll' },
       },
       {
         path: 'students',
-        component: StudentsListComponent,
+        component: StudentsContainerComponent,
         data: {
           breadcrumb: 'Students List',
           headerTitle: 'Students',
@@ -172,9 +166,7 @@ export const routes: Routes = [
           {
             path: 'details/:id',
             loadComponent: () =>
-              import(
-                '@modules/supports-referrals/components/referral-detail/referral-detail.component'
-              ),
+              import('@modules/supports-referrals/components/referral-detail/referral-detail.component'),
             resolve: { referral: referralDetailsResolver },
             data: { breadcrumb: 'Referral Details' },
           },

--- a/src/app/core/components/feature-flags/feature-flags.model.ts
+++ b/src/app/core/components/feature-flags/feature-flags.model.ts
@@ -4,4 +4,5 @@ export interface FeatureFlags {
   newSidebar: string;
   reportsV2: string;
   studentDetails: string;
+  studentList: string;
 }

--- a/src/app/core/components/feature-flags/feature-flags.ts
+++ b/src/app/core/components/feature-flags/feature-flags.ts
@@ -12,4 +12,5 @@ export const FEATURE_FLAGS: FeatureFlags = {
   newSidebar: 'newSidebar',
   reportsV2: 'reportsV2',
   studentDetails: 'studentDetailsV2',
+  studentList: 'studentList',
 };

--- a/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
@@ -12,7 +12,6 @@ export const SIDEBAR_MENUS_NEW: Menu[] = [
         forProduction: false,
       },
       { label: 'Evaluation Processes', route: '/evaluation-process' },
-      { label: 'Import Students', route: '/import-students' },
       { label: 'Students List', route: '/students' },
     ],
   },

--- a/src/app/core/components/sidebar/sidebar.model.ts
+++ b/src/app/core/components/sidebar/sidebar.model.ts
@@ -66,7 +66,7 @@ export const SIDEBAR_MENUS_OLD: Menu[] = [
       {
         label: 'Import Students',
         icon: 'person_add',
-        route: '/import-students',
+        route: '/students',
       },
     ],
   },

--- a/src/app/modules/students/students-container.component.ts
+++ b/src/app/modules/students/students-container.component.ts
@@ -1,0 +1,23 @@
+import { Component, computed, inject } from '@angular/core';
+import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
+import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
+import { ImportStudentsComponent } from '@modules/imports/components/import-students/import-students.component';
+import { StudentsListComponent } from './students-list/students-list.component';
+
+@Component({
+  selector: 'app-students',
+  imports: [ImportStudentsComponent, StudentsListComponent],
+  template: `
+    @if (showV2()) {
+      <app-students-list></app-students-list>
+    } @else {
+      <app-import-students></app-import-students>
+    }
+  `,
+})
+export class StudentsContainerComponent {
+  private readonly featureFlags = inject(FeatureFlagsService);
+  showV2 = computed(() =>
+    this.featureFlags.isEnabled(FEATURE_FLAGS.studentList)
+  );
+}


### PR DESCRIPTION

## Description

A container was added to verify which version is selected and to display Import Students in V1 and Students List in V2.
The sidebar for V2 was also removed to avoid misunderstandings.
The sidebar for V1 keeps the student list and import students separate.

V2 route: http://localhost:4200/students?v2=true
V2 route: http://localhost:4200/students

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#876 
