### PR TITLE
Fix summary column chart answer details table when a column segment is selected

### DIFF
--- a/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.scss
+++ b/src/app/modules/reports/components/summary-charts-v2/column-risk-panel/column-risk-panel.component.scss
@@ -64,3 +64,9 @@
     font-size: 13px;
   }
 }
+
+:host ::ng-deep .mat-mdc-table {
+  color: black;
+  width: 100%;
+  table-layout: fixed;
+}

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 24px;
+  padding: 24px 4px;
 }
 
 .export-overlay {

--- a/src/app/shared/components/badge-risk-level/badge-risk-level.component.scss
+++ b/src/app/shared/components/badge-risk-level/badge-risk-level.component.scss
@@ -1,3 +1,8 @@
+:host {
+  justify-content: center;
+  display: flex;
+}
+
 .risk-badge {
   padding: 2px 8px;
   border-radius: 4px;

--- a/src/app/shared/components/list/list.component.scss
+++ b/src/app/shared/components/list/list.component.scss
@@ -29,6 +29,12 @@
   margin-left: auto;
 }
 
+app-table-with-actions {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
 app-table-with-actions,
 mat-paginator {
   color: var(

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.html
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.html
@@ -119,7 +119,13 @@
         </th>
         <td
           mat-cell
+          #cellText
           [class]="mapClass?.table?.cell ?? ''"
+          [matTooltip]="
+            cellText.scrollWidth > cellText.clientWidth
+              ? showElement(element, column)
+              : null
+          "
           *matCellDef="let element"
         >
           {{ showElement(element, column) }}

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.scss
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.scss
@@ -2,6 +2,12 @@ $row-height: 48px;
 $table-border-radius: 8px;
 $border-color: #e3e2e2;
 
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
 table {
   text-align: left;
   width: 100%;
@@ -59,7 +65,6 @@ mat-card-actions {
 
 .mat-mdc-cell {
   border-bottom: 1px solid $border-color;
-  text-transform: capitalize;
 }
 
 .row-mobile {


### PR DESCRIPTION
## Description

- The fix introduces a change that displays text in cells for tables with ellipses and tooltips in cases where the text overflows.
- The summary charts view also has different padding to achieve 24px for the content.
- The table avoids overflow if the table layout has a fixed value.
- The badge risk component is centered.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#871 