### PR TITLE
Feature: list of assessments student column should follow the new UI design for more than 1 selected students

### DIFF
--- a/src/app/core/models/assessement.model.ts
+++ b/src/app/core/models/assessement.model.ts
@@ -1,3 +1,5 @@
+import { StudentProfileData } from '@modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component';
+
 export interface AssessmentModel {
   id?: number;
 
@@ -8,6 +10,7 @@ export interface AssessmentModel {
   assignedProfessional?: string | null;
   studentIds: string[];
   studentNames?: string[];
+  students?: StudentProfileData[];
 
   diagnosis?: string | null;
   objective?: string | null;

--- a/src/app/core/models/assessement.model.ts
+++ b/src/app/core/models/assessement.model.ts
@@ -73,6 +73,7 @@ export enum AssessmentStatus {
   OnHold = 'OnHold',
   Remitted = 'Remitted',
   Resolved = 'Resolved',
+  Rejected = 'Rejected',
 }
 
 export enum InterventionStatus {

--- a/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.html
+++ b/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.html
@@ -14,8 +14,14 @@
 
 <div class="dialog-content">
   <div class="field-group">
-    <span class="field-label">Student:</span>
-    <span class="field-value">{{ data.studentDisplay }}</span>
+    <span class="field-label">Student(s):</span>
+    <app-list-with-removal
+      [columns]="columns"
+      [items]="data.students ?? []"
+      [totalItems]="data.students ? data.students.length : 0"
+      [title]="'Answer Details'"
+      [actionDatas]="actionDatas"
+    />
   </div>
 
   <div class="field-group">

--- a/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.html
+++ b/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.html
@@ -15,13 +15,15 @@
 <div class="dialog-content">
   <div class="field-group">
     <span class="field-label">Student(s):</span>
-    <app-list-with-removal
-      [columns]="columns"
-      [items]="data.students ?? []"
-      [totalItems]="data.students ? data.students.length : 0"
-      [title]="'Answer Details'"
-      [actionDatas]="actionDatas"
-    />
+    <div class="list-of-student">
+      <app-list-with-removal
+        [columns]="columns"
+        [items]="data.students ?? []"
+        [totalItems]="data.students ? data.students.length : 0"
+        [title]="'Answer Details'"
+        [actionDatas]="actionDatas"
+      />
+    </div>
   </div>
 
   <div class="field-group">

--- a/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.scss
+++ b/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.scss
@@ -122,3 +122,9 @@ mat-divider {
     background-color: darken($primary, 6%);
   }
 }
+
+.list-of-student {
+  width: 100%;
+  max-height: 282px;
+  overflow-y: auto;
+}

--- a/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.ts
+++ b/src/app/modules/assessments/components/assessment-detail/assessment-detail-dialog.component.ts
@@ -5,6 +5,10 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { AssessmentStatusBadgeComponent } from '../assessment-list/assessment-status-badge/assessment-status-badge.component';
 import { AssessmentRowViewModel } from '../assessment-list/assessment-list.component';
+import { ListWithRemovalComponent } from '@modules/lists/components/list-with-removal/list-with-removal.component';
+import { Column } from '@shared/components/list/types/column';
+import { StudentProfileData } from '../assessment-list/assessment-student-data/assessment-student-data.component';
+import { ActionDatas } from '@shared/components/list/types/action';
 
 @Component({
   selector: 'app-assessment-detail-dialog',
@@ -15,6 +19,7 @@ import { AssessmentRowViewModel } from '../assessment-list/assessment-list.compo
     MatDividerModule,
     MatIconModule,
     AssessmentStatusBadgeComponent,
+    ListWithRemovalComponent,
   ],
   templateUrl: './assessment-detail-dialog.component.html',
   styleUrl: './assessment-detail-dialog.component.scss',
@@ -24,6 +29,26 @@ export class AssessmentDetailDialogComponent {
 
   @Output() close = new EventEmitter<void>();
   @Output() createIntervention = new EventEmitter<AssessmentRowViewModel>();
+
+  columns: Column<StudentProfileData>[] = [
+    { key: 'name', label: 'Name', showLabel: false },
+    { key: 'email', label: 'Email', showLabel: false },
+  ];
+
+  actionDatas: ActionDatas = [
+    {
+      columnId: 'action_open',
+      id: 'openStudentDetails',
+      label: 'ActionOpen',
+      ngIconName: 'open_in_new',
+    },
+    {
+      columnId: 'action_close',
+      id: 'removeStudent',
+      label: 'ActionClose',
+      ngIconName: 'close',
+    },
+  ];
 
   onClose(): void {
     this.close.emit();

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
@@ -60,7 +60,9 @@
           <ng-container matColumnDef="student">
             <th mat-header-cell *matHeaderCellDef>Student</th>
             <td mat-cell *matCellDef="let item">
-              <app-assessment-student-data [studentData]="item.students" />
+              <div class="container-student-data">
+                <app-assessment-student-data [studentData]="item.students" />
+              </div>
             </td>
           </ng-container>
 

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
@@ -59,13 +59,8 @@
 
           <ng-container matColumnDef="student">
             <th mat-header-cell *matHeaderCellDef>Student</th>
-            <td
-              mat-cell
-              *matCellDef="let item"
-              [matTooltip]="item.studentDisplay"
-            >
-              <!-- <span class="truncate-text">{{ item.studentDisplay }}</span> -->
-              <app-assessment-student-data [studentData]="item.studentNames" />
+            <td mat-cell *matCellDef="let item">
+              <app-assessment-student-data [studentData]="item.students" />
             </td>
           </ng-container>
 

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
@@ -64,7 +64,8 @@
               *matCellDef="let item"
               [matTooltip]="item.studentDisplay"
             >
-              <span class="truncate-text">{{ item.studentDisplay }}</span>
+              <!-- <span class="truncate-text">{{ item.studentDisplay }}</span> -->
+              <app-assessment-student-data [studentData]="item.studentNames" />
             </td>
           </ng-container>
 

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.spec.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.spec.ts
@@ -17,6 +17,13 @@ describe('AssessmentListComponent', () => {
       service: 'Student Services',
       assignedProfessional: 'Master',
       studentIds: ['Jane Doe'],
+      students: [
+        {
+          id: 12,
+          name: 'Jane Doe',
+          email: 'jane@mail.com',
+        },
+      ],
       comments: 'Some comment for preview testing',
       status: AssessmentStatus.Created,
       interventions: [],

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
@@ -118,7 +118,6 @@ export class AssessmentListComponent implements OnInit {
   protected onViewClick(item: AssessmentRowViewModel): void {
     this.viewClicked.emit(item);
     this.selectedAssessment.set(item);
-    console.log('item', item);
   }
 
   protected closeDetailPanel(): void {

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
@@ -33,6 +33,7 @@ import { ModalDeleteConfirmationService } from '@shared/components/modals/modal-
 import { HttpErrorResponse } from '@angular/common/http';
 import { ToastNotificationData } from '@core/models/toast-notification.model';
 import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { AssessmentStudentDataComponent } from './assessment-student-data/assessment-student-data.component';
 
 export interface AssessmentRowViewModel extends AssessmentModel {
   studentDisplay: string;
@@ -57,6 +58,7 @@ export interface AssessmentRowViewModel extends AssessmentModel {
     MatTooltipModule,
     AssessmentStatusBadgeComponent,
     AssessmentDetailDialogComponent,
+    AssessmentStudentDataComponent,
   ],
   templateUrl: './assessment-list.component.html',
   styleUrl: './assessment-list.component.scss',
@@ -116,6 +118,7 @@ export class AssessmentListComponent implements OnInit {
   protected onViewClick(item: AssessmentRowViewModel): void {
     this.viewClicked.emit(item);
     this.selectedAssessment.set(item);
+    console.log('item', item);
   }
 
   protected closeDetailPanel(): void {

--- a/src/app/modules/assessments/components/assessment-list/assessment-status-badge/assessment-status-badge.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-status-badge/assessment-status-badge.component.ts
@@ -26,6 +26,7 @@ export class AssessmentStatusBadgeComponent {
     [AssessmentStatus.OnHold]: 'On Hold',
     [AssessmentStatus.Remitted]: 'Remitted',
     [AssessmentStatus.Resolved]: 'Resolved',
+    [AssessmentStatus.Rejected]: 'Rejected',
   };
 
   private readonly statusClassMap: Record<AssessmentStatus, string> = {
@@ -34,5 +35,6 @@ export class AssessmentStatusBadgeComponent {
     [AssessmentStatus.OnHold]: 'status-on-hold',
     [AssessmentStatus.Remitted]: 'status-remitted',
     [AssessmentStatus.Resolved]: 'status-resolved',
+    [AssessmentStatus.Rejected]: 'status-rejected',
   };
 }

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
@@ -9,13 +9,21 @@
       (mouseenter)="openPopover()"
       (mouseleave)="closePopover()"
     >
-      <span class="badge-number-student" #badgeRef>
+      <span
+        class="badge-number-student"
+        #badgeRef
+        (click)="togglePin()"
+        (keydown.enter)="togglePin()"
+        (keydown.space)="togglePin()"
+        tabindex="0"
+      >
         +{{ studentData.length - 1 }}
       </span>
 
       <div
         class="students-popover"
         [class.visible]="show"
+        [class.pinned]="pinned"
         [ngStyle]="popoverStyle"
         (mouseenter)="show = true"
         (mouseleave)="closePopover()"

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
@@ -1,6 +1,41 @@
-<span class="text-student">
-  {{ studentData[0] }}
+<div class="assessment-data-student">
+  <span class="text-student">
+    {{ studentData[0].name }}
+  </span>
+
   @if (studentData.length > 1) {
-    <span class="badge-number-student">+{{ studentData.length - 1 }}</span>
+    <div
+      class="popover-wrapper"
+      (mouseenter)="openPopover()"
+      (mouseleave)="closePopover()"
+    >
+      <span class="badge-number-student" #badgeRef>
+        +{{ studentData.length - 1 }}
+      </span>
+
+      <div
+        class="students-popover"
+        [class.visible]="show"
+        [ngStyle]="popoverStyle"
+        (mouseenter)="show = true"
+        (mouseleave)="closePopover()"
+      >
+        @for (student of studentData.slice(1); track student.id) {
+          <div class="student-item">
+            <div class="student-avatar">
+              <img
+                src="assets/icons/avatarPlaceholder.svg"
+                alt="imageForStudent"
+                class="avatar"
+              />
+            </div>
+            <div class="student-info">
+              <div class="student-name">{{ student.name }}</div>
+              <div class="student-email">{{ student.email }}</div>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
   }
-</span>
+</div>

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
@@ -1,0 +1,6 @@
+<span class="text-student">
+  {{ studentData[0] }}
+  @if (studentData.length > 1) {
+    <span class="badge-number-student">+{{ studentData.length - 1 }}</span>
+  }
+</span>

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
@@ -1,13 +1,24 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+$inter: 'Inter', sans-serif;
 $neutral-surface: var(--color-neutral-200);
 $font-text-sm: var(--font-size-small);
 
-.text-student {
-  max-width: 100%;
-  white-space: nowrap;
+$color-background: #f0f0f0;
+$color-accent: #5c9e8f;
+$color-accent-hover: #4a8a7c;
+$color-stroke: #e5e5e5;
+
+.assessment-data-student {
   display: flex;
   align-items: center;
   justify-content: flex-start;
   gap: 8px;
+  font-weight: inherit;
+}
+
+.text-student {
+  max-width: 100%;
+  white-space: nowrap;
 }
 
 .badge-number-student {
@@ -20,4 +31,75 @@ $font-text-sm: var(--font-size-small);
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.student-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  min-width: 240px;
+}
+
+.student-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $color-accent-hover;
+}
+
+.avatar {
+  object-fit: cover;
+  width: 28px;
+}
+
+.student-info {
+  display: flex;
+  flex-direction: column;
+  font-family: $inter;
+}
+
+.student-name {
+  font-weight: 600;
+  font-family: $inter;
+  line-height: 21px;
+  letter-spacing: 0.29%;
+  color: var(--color-neutral-800);
+}
+
+.student-email {
+  font-size: $font-text-sm;
+  font-family: $inter;
+  color: var(--color-neutral-500);
+}
+
+.popover-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.students-popover {
+  position: fixed;
+  z-index: 1000;
+  background: $color-background;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  min-width: 280px;
+  border: 1px solid $color-stroke;
+
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease;
+
+  &.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
 }

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
@@ -1,0 +1,23 @@
+$neutral-surface: var(--color-neutral-200);
+$font-text-sm: var(--font-size-small);
+
+.text-student {
+  max-width: 100%;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+.badge-number-student {
+  padding: 1.5px 10px;
+  background-color: $neutral-surface;
+  border-radius: 17px;
+  font-size: $font-text-sm;
+  line-height: 16px;
+  font-weight: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
@@ -89,6 +89,8 @@ $color-stroke: #e5e5e5;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   min-width: 280px;
   border: 1px solid $color-stroke;
+  max-height: calc(5 * 72px);
+  overflow-y: auto;
 
   opacity: 0;
   pointer-events: none;

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -38,9 +38,15 @@ export class AssessmentStudentDataComponent {
 
   openPopover() {
     const rect = this.badgeRef.nativeElement.getBoundingClientRect();
+    const popoverHeight = 360;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const showAbove = spaceBelow < popoverHeight;
+
     this.popoverStyle = {
-      top: `${rect.bottom + 6}px`,
       left: `${rect.left}px`,
+      ...(showAbove
+        ? { bottom: `${window.innerHeight - rect.top + 6}px` }
+        : { top: `${rect.bottom + 6}px` }),
     };
     this.show = true;
     setTimeout(() => {

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -1,4 +1,10 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  ViewChild,
+} from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
 
@@ -19,7 +25,16 @@ export class AssessmentStudentDataComponent {
   @ViewChild('badgeRef') badgeRef!: ElementRef;
 
   show = false;
+  pinned = false;
   popoverStyle: Record<string, string> = {};
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent) {
+    const clickedInside = this.badgeRef?.nativeElement.contains(event.target);
+    if (!clickedInside) {
+      this.pinned = false;
+      this.show = false;
+    }
+  }
 
   openPopover() {
     const rect = this.badgeRef.nativeElement.getBoundingClientRect();
@@ -28,9 +43,18 @@ export class AssessmentStudentDataComponent {
       left: `${rect.left}px`,
     };
     this.show = true;
+    setTimeout(() => {
+      const panel = document.querySelector('.students-popover');
+      if (panel) panel.scrollTop = 0;
+    });
   }
 
   closePopover() {
-    this.show = false;
+    if (!this.pinned) this.show = false;
+  }
+
+  togglePin() {
+    this.pinned = !this.pinned;
+    if (!this.pinned) this.show = false;
   }
 }

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-assessment-student-data',
+  imports: [],
+  templateUrl: './assessment-student-data.component.html',
+  styleUrl: './assessment-student-data.component.scss',
+})
+export class AssessmentStudentDataComponent {
+  @Input({ required: true }) studentData!: string[];
+}

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -1,11 +1,36 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { MatMenuModule } from '@angular/material/menu';
+import { CommonModule } from '@angular/common';
+
+export interface StudentProfileData {
+  id: number;
+  name: string;
+  email: string;
+}
 
 @Component({
   selector: 'app-assessment-student-data',
-  imports: [],
+  imports: [MatMenuModule, CommonModule],
   templateUrl: './assessment-student-data.component.html',
   styleUrl: './assessment-student-data.component.scss',
 })
 export class AssessmentStudentDataComponent {
-  @Input({ required: true }) studentData!: string[];
+  @Input({ required: true }) studentData!: StudentProfileData[];
+  @ViewChild('badgeRef') badgeRef!: ElementRef;
+
+  show = false;
+  popoverStyle: Record<string, string> = {};
+
+  openPopover() {
+    const rect = this.badgeRef.nativeElement.getBoundingClientRect();
+    this.popoverStyle = {
+      top: `${rect.bottom + 6}px`,
+      left: `${rect.left}px`,
+    };
+    this.show = true;
+  }
+
+  closePopover() {
+    this.show = false;
+  }
 }

--- a/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.html
@@ -44,7 +44,7 @@
 
   <div class="field-group">
     <span class="field-label">Student(s):</span>
-    <span class="field-value">{{ data.studentDisplay }}</span>
+    <span class="field-value">{{ displayStudents() }}</span>
   </div>
 
   @if (data.area) {

--- a/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.ts
@@ -25,6 +25,13 @@ export class InterventionDetailComponent {
 
   @Output() close = new EventEmitter<void>();
 
+  displayStudents(): string {
+    if (Array.isArray(this.data.studentDisplay)) {
+      return this.data.studentDisplay.map(m => m.name).join(', ');
+    }
+    return this.data.studentDisplay;
+  }
+
   onClose(): void {
     this.close.emit();
   }

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -83,12 +83,10 @@
 
           <ng-container matColumnDef="student">
             <th mat-header-cell *matHeaderCellDef>Student</th>
-            <td
-              mat-cell
-              *matCellDef="let item"
-              [matTooltip]="item.studentDisplay"
-            >
-              <span class="truncate-text">{{ item.studentDisplay }}</span>
+            <td mat-cell *matCellDef="let item">
+              <app-assessment-student-data
+                [studentData]="item.studentDisplay"
+              />
             </td>
           </ng-container>
 

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -21,9 +21,13 @@ import { InterventionPillBadgeComponent } from './intervention-status-badge/inte
 import { InterventionDetailComponent } from '../interventions-detail/intervention-detail.component';
 import { InterventionModel } from '@core/models/assessement.model';
 import { InterventionService } from '@core/services/api/intervention.service';
+import {
+  StudentProfileData,
+  AssessmentStudentDataComponent,
+} from '../../assessment-list/assessment-student-data/assessment-student-data.component';
 
 export interface InterventionRowViewModel extends InterventionModel {
-  studentDisplay: string;
+  studentDisplay: StudentProfileData[] | string;
   commentPreview: string;
 }
 
@@ -43,6 +47,7 @@ export interface InterventionRowViewModel extends InterventionModel {
     MatTooltipModule,
     InterventionPillBadgeComponent,
     InterventionDetailComponent,
+    AssessmentStudentDataComponent,
   ],
   templateUrl: './intervention-list.component.html',
   styleUrl: './intervention-list.component.scss',
@@ -52,10 +57,10 @@ export class InterventionListComponent {
 
   @Input() pageSize = 10;
 
-  @Input() set studentNamesLookup(value: Record<string, string>) {
+  @Input() set studentNamesLookup(value: Record<string, StudentProfileData>) {
     this._studentNamesLookup = value;
   }
-  private _studentNamesLookup: Record<string, string> = {};
+  private _studentNamesLookup: Record<string, StudentProfileData> = {};
 
   readonly assessmentId = signal<number | null>(null);
   @Input() set assessmentIdInput(value: number | null) {
@@ -147,11 +152,11 @@ export class InterventionListComponent {
     };
   }
 
-  private buildStudentDisplay(item: InterventionModel): string {
+  private buildStudentDisplay(
+    item: InterventionModel
+  ): StudentProfileData[] | string {
     if (item.studentIds?.length) {
-      return item.studentIds
-        .map(id => this._studentNamesLookup[id] ?? id)
-        .join(', ');
+      return item.studentIds.map(id => this._studentNamesLookup[id]);
     }
     return 'No student assigned';
   }

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -69,6 +69,7 @@ export class InterventionsComponent implements OnInit {
     [AssessmentStatus.OnHold]: 'On Hold',
     [AssessmentStatus.Remitted]: 'Remitted',
     [AssessmentStatus.Resolved]: 'Resolved',
+    [AssessmentStatus.Rejected]: 'Rejected',
   };
 
   @ViewChild('interventionList') interventionList!: InterventionListComponent;

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -23,6 +23,7 @@ import {
 } from '@core/models/assessement.model';
 import { InterventionListComponent } from './interventions-list/intervention-list.component';
 import { NewInterventionModalComponent } from './new-intervention-modal/new-intervention-modal.component';
+import { StudentProfileData } from '../assessment-list/assessment-student-data/assessment-student-data.component';
 
 interface AssessmentOption {
   value: number;
@@ -57,9 +58,9 @@ export class InterventionsComponent implements OnInit {
     []
   );
 
-  readonly studentNamesLookup: WritableSignal<Record<string, string>> = signal(
-    {}
-  );
+  readonly studentNamesLookup: WritableSignal<
+    Record<string, StudentProfileData>
+  > = signal({});
 
   readonly selectedAssessmentId: WritableSignal<number | null> = signal(null);
 
@@ -90,10 +91,14 @@ export class InterventionsComponent implements OnInit {
           this.assessmentOptions.set(assessments.map(a => this.mapToOption(a)));
           this.isLoadingAssessments.set(false);
 
-          const lookup: Record<string, string> = {};
+          const lookup: Record<string, StudentProfileData> = {};
           assessments.forEach(a => {
             a.studentIds.forEach((id, index) => {
-              lookup[id] = a.studentNames?.[index] ?? id;
+              lookup[id] = a.students?.[index] ?? {
+                id: 0,
+                name: '',
+                email: '',
+              };
             });
           });
           this.studentNamesLookup.set(lookup);
@@ -133,7 +138,7 @@ export class InterventionsComponent implements OnInit {
 
     const students = assessment.studentIds.map((id, index) => ({
       value: id,
-      label: assessment.studentNames?.[index] ?? id,
+      label: assessment.students?.[index].name ?? id,
     }));
 
     this.matDialog

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -66,7 +66,7 @@ export class NewAssessmentModalComponent implements FormCreation {
         options: this.data.profiles,
         validators: [Validators.required],
         floatingLabel: 'always',
-        value: this.data.profiles[0].value ?? undefined,
+        value: this.data.profiles?.[0]?.value ?? null,
       },
       {
         type: 'select',

--- a/src/app/modules/lists/components/list-with-removal/list-with-removal.component.html
+++ b/src/app/modules/lists/components/list-with-removal/list-with-removal.component.html
@@ -1,0 +1,14 @@
+<div class="list-with-removal">
+  @if (!items.length && emptyTemplate) {
+    <ng-container [ngTemplateOutlet]="emptyTemplate" />
+  } @else {
+    <app-mat-card-details
+      [mapClass]="mapClass?.table ? mapClass : undefined"
+      [columns]="columns"
+      [items]="items"
+      [columnTemplates]="columnTemplates"
+      [actionDatas]="actionDatas"
+      (actionCalled)="handleAction($event)"
+    />
+  }
+</div>

--- a/src/app/modules/lists/components/list-with-removal/list-with-removal.component.scss
+++ b/src/app/modules/lists/components/list-with-removal/list-with-removal.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: flex;
+  width: 100%;
+}
+
+:host ::ng-deep .Email-label {
+  line-height: 16px;
+  font-size: 12px !important;
+  color: #6b7280;
+}
+
+.list-with-removal {
+  width: 100%;
+}

--- a/src/app/modules/lists/components/list-with-removal/list-with-removal.component.ts
+++ b/src/app/modules/lists/components/list-with-removal/list-with-removal.component.ts
@@ -1,0 +1,36 @@
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+} from '@angular/core';
+import { EventAction, EventLoad, EventUpdate } from '@core/models/load';
+import { ActionDatas } from '@shared/components/list/types/action';
+import { MapClass } from '@shared/components/list/types/class';
+import { Column } from '@shared/components/list/types/column';
+import { MatCardDetailsComponent } from '@shared/components/mat-card-details/mat-card-details.component';
+
+@Component({
+  selector: 'app-list-with-removal',
+  imports: [NgTemplateOutlet, MatCardDetailsComponent],
+  templateUrl: './list-with-removal.component.html',
+  styleUrl: './list-with-removal.component.scss',
+})
+export class ListWithRemovalComponent<T extends object> {
+  @Input() items: T[] = [];
+  @Input() totalItems = 0;
+  @Input() columns: Column<T>[] = [] as Column<T>[];
+  @Input() columnTemplates: Column<T>[] = [];
+  @Input() actionDatas: ActionDatas = [];
+  @Input() mapClass?: MapClass;
+  @Input() emptyTemplate?: TemplateRef<T>;
+
+  @Output() loadCalled = new EventEmitter<EventLoad>();
+  @Output() actionCalled = new EventEmitter<EventAction>();
+
+  handleAction(event: EventUpdate) {
+    this.actionCalled.emit(event);
+  }
+}

--- a/src/app/shared/components/list/types/column.ts
+++ b/src/app/shared/components/list/types/column.ts
@@ -7,6 +7,7 @@ export interface Column<T> {
   pipeKey?: keyof T;
   pipeArgs?: unknown[];
   isTemplate?: boolean;
+  showLabel?: boolean;
 }
 
 export interface ComponentColumn {

--- a/src/app/shared/components/mat-card-details/mat-card-details.component.html
+++ b/src/app/shared/components/mat-card-details/mat-card-details.component.html
@@ -15,13 +15,16 @@
     >
       <mat-card-content [class]="mapClass?.card?.content ?? ''">
         <div class="row-info" *ngFor="let column of columns">
-          @if (column.key !== 'name') {
+          @if (column.showLabel !== false) {
             <span class="field">{{ column.label }}:</span>
-            <span class="information-secondary">
+            <span
+              class="information-secondary"
+              [ngClass]="column.label + '-label'"
+            >
               {{ item[column.key] }}
             </span>
           } @else {
-            <span class="information">
+            <span class="information" [ngClass]="column.label + '-label'">
               {{ item[column.key] }}
             </span>
           }

--- a/src/app/shared/components/mat-card-details/mat-card-details.component.ts
+++ b/src/app/shared/components/mat-card-details/mat-card-details.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, NgClass } from '@angular/common';
 import {
   Component,
   Input,
@@ -41,6 +41,7 @@ import { ActionButtonComponent } from '../buttons/action-button/action-button.co
     MatProgressSpinnerModule,
     MatTableModule,
     MatMenuModule,
+    NgClass,
   ],
   templateUrl: './mat-card-details.component.html',
   styleUrls: ['./mat-card-details.component.scss'],

--- a/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
+++ b/src/app/shared/components/panels/details-panel-v2/details-panel.component.ts
@@ -66,7 +66,7 @@ export class DetailsPanelComponent implements OnChanges {
   pagination: Pagination = { page: 0, pageSize: 10 };
 
   columns: Column<EvaluationDetailsStudentResponse>[] = [
-    { key: 'name', label: 'Name' },
+    { key: 'name', label: 'Name', showLabel: false },
     { key: 'answerText', label: 'Answer' },
   ];
   columnTemplates: Column<EvaluationDetailsStudentResponse>[] = [


### PR DESCRIPTION
## Description

- Added a new component to display the number of students who participated in the assessment as a badge with the first student for column Student in table of assessment. 
- The new component has a pop-up with an image and email address (image of each student by default). 
- The student details show a different list in the "Student(s)" label.
- The interventions section also implemented the same component.

As a note, we can set the zoom to 80% to see the table. This will give us a view similar to the mockup on Figma.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [X] Others: Enhancement

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#880 
