### PR TITLE
Enhancement: tooltips for v2 are updated in summary charts and dynamic charts

### DIFF
--- a/src/app/core/models/summary.model.ts
+++ b/src/app/core/models/summary.model.ts
@@ -70,6 +70,7 @@ export interface AnswerDetail {
   answerText: string;
   answerPercentage: number;
   studentsEmails: string[];
+  riskLevel?: number;
 }
 
 export interface GetQueryResponse<T> {

--- a/src/app/core/utils/apex-chart/customTooltip-v2.ts
+++ b/src/app/core/utils/apex-chart/customTooltip-v2.ts
@@ -2,15 +2,19 @@ import { RISK_COLORS } from '@core/constants/riskLevel';
 import { PollCountAnswer } from '@core/models/summary.model';
 
 export function customTooltip(
+  xValue: string,
   yValue: string,
   formattedZValue: string,
   color: string
 ): string {
   return `
   <div>
-    <div class="apexcharts-tooltip-y item-tooltip" >
+    <div class="apexcharts-tooltip-y item-tooltip">
+      <div class="apexcharts-tooltip-x" style="font-size: 16px; letter-spacing: 0.15px; font-weight: 500;">
+      ${xValue}
+      </div>
       ${_formatStudentItem(color)}
-      <span>${yValue} Students</span>
+      <span class="badge-value-students">${yValue} Students</span>
     </div>
     <div class="apexcharts-tooltip-z">
       ${_formatEmailsList(formattedZValue)}

--- a/src/app/core/utils/apex-chart/heat-map-config-v2.ts
+++ b/src/app/core/utils/apex-chart/heat-map-config-v2.ts
@@ -138,11 +138,12 @@ export function GetChartOptions(
           } else {
             const dataPoint = w.config.series[seriesIndex].data[dataPointIndex];
             const color = w.globals.colors[seriesIndex];
+            const xValue = dataPoint.x;
             const yValue = dataPoint.y;
             const zValue = dataPoint.z;
             const formattedZValue = zValue;
 
-            return customTooltip(yValue, formattedZValue, color);
+            return customTooltip(xValue, yValue, formattedZValue, color);
           }
         };
         const wrap = (content: string) => {

--- a/src/app/core/utils/apex-chart/heat-map-config.ts
+++ b/src/app/core/utils/apex-chart/heat-map-config.ts
@@ -5,7 +5,7 @@ import {
   RISK_TEXT_COLORS,
   getRiskGroup,
 } from '@core/constants/riskLevel';
-import { customTooltip } from './customTooltip-v2';
+import { customTooltip } from './customTooltip';
 
 export function GetChartOptions(
   title: string,

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.scss
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.scss
@@ -93,7 +93,7 @@
 }
 
 ::ng-deep .item-tooltip {
-  padding: 8px 8px;
+  padding: 16px 16px 8px;
 }
 
 ::ng-deep .mail-list {
@@ -120,8 +120,11 @@
   width: 10px;
   height: 10px;
   margin-right: 8px;
-  margin-left: 8px;
   border-radius: 5px;
+}
+
+::ng-deep .point-tooltip-color-0 {
+  background-color: #868686;
 }
 
 ::ng-deep .point-tooltip-color-1 {
@@ -151,4 +154,13 @@
 
 ::ng-deep .apexcharts-yaxis {
   width: 30%;
+}
+
+::ng-deep .badge-value-students {
+  padding: 1.5px 10px;
+  background-color: var(--color-neutral-200);
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+  border-radius: 17px;
 }

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -199,7 +199,10 @@ export class DynamicChartsV2Component implements AfterViewInit {
             x: number;
           };
           const color = RISK_COLORS[regroupSeries[x]?.data[y].x];
+          const question = component.questions[x];
+
           return customTooltip(
+            question?.question ?? '',
             `${groupedAnswer?.count ?? 0}`,
             dataAtPoint.z,
             color
@@ -299,7 +302,6 @@ export class DynamicChartsV2Component implements AfterViewInit {
       const series =
         this.reportService.getHMSeriesFromCountComponent(component);
       const regroupSeries = this.reportService.regroupDynamicByColor(series);
-
       const groupedQuestion = series[seriesIndex];
       const dataAtPoint = regroupSeries[seriesIndex]?.data[dataPointIndex];
 
@@ -308,8 +310,10 @@ export class DynamicChartsV2Component implements AfterViewInit {
         groupedQuestion?.data[dataPointIndex - totalFillers];
 
       const color = RISK_COLORS[dataPointIndex];
+      const question = component.questions[seriesIndex];
 
       return customTooltip(
+        question?.question ?? '',
         `${groupedAnswer?.count ?? 0}`,
         dataAtPoint?.z ?? '',
         color

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
@@ -42,7 +42,6 @@ import {
   TypeFile,
 } from '@shared/components/list/list.component';
 import { PollFiltersComponent } from '../poll-filters/poll-filters.component';
-import { TooltipChartComponent } from '../tooltip-chart/tooltip-chart.component';
 import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
 import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
@@ -55,6 +54,7 @@ import {
   ColumnRiskPanelData,
 } from './column-risk-panel/column-risk-panel.component';
 import { SummaryColumnChartsV2Component } from '@modules/reports/components/summary-charts-v2/summary-column-charts-v2/summary-column-charts-v2.component';
+import { TooltipChartV2Component } from '../tooltip-chart-v2/tooltip-chart-v2.component';
 
 @Component({
   selector: 'app-students-risk',
@@ -184,6 +184,7 @@ export class SummaryChartsV2Component {
             response.body
           );
           const series = this.reportService.regroupSummaryByColor(reportSeries);
+          console.log('series', series);
 
           this.chartOptions = GetChartOptions(
             '',
@@ -208,11 +209,12 @@ export class SummaryChartsV2Component {
             },
             { legend: { show: false } },
             (x, y) => {
-              const category = `Q: ${series[x].data[y].x}`;
-              const value = `Answer: ${series[x].data[y].y}`;
+              const category = `${series[x].data[y].x}`;
+              const value = `Total answers: ${this.components()?.pollCount}`;
               const answers = series[x].data[y].z;
+              console.log('answers', series[x].data);
 
-              const compRef = createComponent(TooltipChartComponent, {
+              const compRef = createComponent(TooltipChartV2Component, {
                 environmentInjector: this.injector,
               });
 

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
@@ -184,7 +184,6 @@ export class SummaryChartsV2Component {
             response.body
           );
           const series = this.reportService.regroupSummaryByColor(reportSeries);
-          console.log('series', series);
 
           this.chartOptions = GetChartOptions(
             '',
@@ -212,7 +211,6 @@ export class SummaryChartsV2Component {
               const category = `${series[x].data[y].x}`;
               const value = `Total answers: ${this.components()?.pollCount}`;
               const answers = series[x].data[y].z;
-              console.log('answers', series[x].data);
 
               const compRef = createComponent(TooltipChartV2Component, {
                 environmentInjector: this.injector,

--- a/src/app/modules/reports/components/summary-charts-v2/summary-column-charts-v2/summary-column-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-column-charts-v2/summary-column-charts-v2.component.ts
@@ -19,9 +19,9 @@ import {
 import { RISK_COLORS, RISK_LABELS } from '@core/constants/riskLevel';
 
 import { ColumnChartUtils } from '@modules/reports/utils/column-chart.config';
-import { TooltipChartComponent } from '../../tooltip-chart/tooltip-chart.component';
 import { ColumnRiskPanelData } from '../column-risk-panel/column-risk-panel.component';
 import { ComponentValueType } from '@core/models/types/risk-students-detail.type';
+import { TooltipChartV2Component } from '../../tooltip-chart-v2/tooltip-chart-v2.component';
 
 @Component({
   selector: 'app-summary-column-charts-v2',
@@ -139,7 +139,7 @@ export class SummaryColumnChartsV2Component {
         const category = w.globals.labels[dataPointIndex];
         const emails = w.config.series[seriesIndex].data[dataPointIndex].meta;
 
-        const compRef = createComponent(TooltipChartComponent, {
+        const compRef = createComponent(TooltipChartV2Component, {
           environmentInjector: this.injector,
         });
 

--- a/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.html
+++ b/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.html
@@ -6,12 +6,12 @@
   <div class="summary-chart-tooltip-divider"></div>
   <div class="summary-chart-tooltip-container">
     @if (emails) {
-      <ul class="custom-markers">
+      <ul class="summary-chart-tooltip-mail-list">
         @for (email of emails; track $index) {
-          <li><span class="cct-icon">&#10003;</span> {{ email }}</li>
+          <li>{{ email }}</li>
         }
       </ul>
-    } @else if (answersWithColor) {
+    } @else if (answersWithColor.length > 0) {
       @for (answer of answersWithColor; track $index) {
         <div class="summary-chart-tooltip-percentage-answer">
           <span class="summary-chart-tooltip-answer">

--- a/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.html
+++ b/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.html
@@ -1,0 +1,46 @@
+<div class="summary-chart-tooltip">
+  <div class="summary-chart-tooltip-header">
+    <div class="summary-chart-tooltip-title">{{ category }}</div>
+    <div class="summary-chart-tooltip-total-badge" [innerHTML]="value"></div>
+  </div>
+  <div class="summary-chart-tooltip-divider"></div>
+  <div class="summary-chart-tooltip-container">
+    @if (emails) {
+      <ul class="custom-markers">
+        @for (email of emails; track $index) {
+          <li><span class="cct-icon">&#10003;</span> {{ email }}</li>
+        }
+      </ul>
+    } @else if (answersWithColor) {
+      @for (answer of answersWithColor; track $index) {
+        <div class="summary-chart-tooltip-percentage-answer">
+          <span class="summary-chart-tooltip-answer">
+            <div
+              class="point-tooltip-color"
+              [style.--progress-color]="answer.riskColor"
+            ></div>
+            {{ answer.answerText }}
+          </span>
+          <span
+            class="summary-chart-tooltip-percentage"
+            [style.--progress-color]="answer.riskColor"
+            >{{ answer.answerPercentage }} %</span
+          >
+        </div>
+        <progress
+          class="summary-chart-tooltip-progress"
+          [value]="answer.answerPercentage"
+          max="100"
+          [style.--progress-color]="answer.riskColor"
+        >
+          {{ answer.answerPercentage }}%
+        </progress>
+        <ul class="summary-chart-tooltip-mail-list">
+          @for (email of answer.studentsEmails; track $index) {
+            <li>{{ email }}</li>
+          }
+        </ul>
+      }
+    }
+  </div>
+</div>

--- a/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.ts
+++ b/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+import { RISK_COLORS } from '@core/constants/riskLevel';
+import { AnswerDetail } from '@core/models/summary.model';
+
+export type AnswerDetailWithColor = AnswerDetail & {
+  riskColor: string;
+};
+
+@Component({
+  selector: 'app-tooltip-chart-v2',
+  imports: [CommonModule],
+  templateUrl: './tooltip-chart-v2.component.html',
+})
+export class TooltipChartV2Component implements OnInit {
+  @Input() value!: string;
+  @Input() category!: string;
+  @Input() emails!: string[];
+  @Input() answers!: AnswerDetail[];
+  answersWithColor: AnswerDetailWithColor[] = [];
+
+  ngOnInit() {
+    this.answersWithColor = this.answers.map(answer => ({
+      ...answer,
+      riskColor: RISK_COLORS[answer.riskLevel ?? 0],
+    }));
+  }
+}

--- a/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.ts
+++ b/src/app/modules/reports/components/tooltip-chart-v2/tooltip-chart-v2.component.ts
@@ -15,14 +15,15 @@ export type AnswerDetailWithColor = AnswerDetail & {
 export class TooltipChartV2Component implements OnInit {
   @Input() value!: string;
   @Input() category!: string;
-  @Input() emails!: string[];
-  @Input() answers!: AnswerDetail[];
+  @Input() emails?: string[];
+  @Input() answers?: AnswerDetail[];
   answersWithColor: AnswerDetailWithColor[] = [];
 
   ngOnInit() {
-    this.answersWithColor = this.answers.map(answer => ({
-      ...answer,
-      riskColor: RISK_COLORS[answer.riskLevel ?? 0],
-    }));
+    this.answersWithColor =
+      this.answers?.map(answer => ({
+        ...answer,
+        riskColor: RISK_COLORS[answer.riskLevel ?? 0],
+      })) ?? [];
   }
 }

--- a/src/app/shared/components/apex-tooltip/apex-tooltip.component.scss
+++ b/src/app/shared/components/apex-tooltip/apex-tooltip.component.scss
@@ -9,29 +9,32 @@
   border-radius: 4px;
   box-shadow: 0 8px 8px rgba(0, 0, 0, 0.5);
   min-width: 282px;
+  max-width: 402px;
   font-size: var(--font-size-medium);
-  color: var(----color-neutral-800);
+  color: var(--color-neutral-800);
   overflow: hidden;
 
   ::ng-deep .apexcharts-tooltip-x {
-    font-size: var(--font-size-medium);
+    font-size: var(--font-size-large);
+    font-weight: 500;
+    line-height: 24px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    margin-bottom: 0;
+    margin-bottom: 8px;
   }
 
   ::ng-deep .apexcharts-tooltip-y {
     font-size: var(--font-size-medium);
-    color: var(----color-neutral-800);
+    color: var(--color-neutral-800);
     margin-bottom: 0;
   }
 
   ::ng-deep .apexcharts-tooltip-z {
     padding: 0 14px;
     font-size: var(--font-size-medium);
-    color: var(----color-neutral-800);
+    color: var(--color-neutral-800);
   }
 
-  ::ng-deep [style*='padding: 10px'] {
+  ::ng-deep [style*='padding: 16px'] {
     padding: 0 !important;
   }
 

--- a/src/app/shared/components/apex-tooltip/apex-tooltip.directive.ts
+++ b/src/app/shared/components/apex-tooltip/apex-tooltip.directive.ts
@@ -152,14 +152,33 @@ export class ApexTooltipDirective implements OnDestroy {
 
   private updatePosition(event: MouseEvent): void {
     if (!this.overlayRef) return;
-
     const offsetX = 16;
     const offsetY = -8;
+    const tooltipEl = this.overlayRef.overlayElement
+      .firstElementChild as HTMLElement;
+
+    const tooltipWidth = tooltipEl?.offsetWidth ?? 402;
+    const tooltipHeight = tooltipEl?.offsetHeight ?? 400;
+
+    const spaceOnRight = window.innerWidth - event.clientX;
+    const spaceOnBottom = window.innerHeight - event.clientY;
+
+    const showOnLeft = spaceOnRight < tooltipWidth + offsetX;
+    const showOnTop = spaceOnBottom < tooltipHeight + offsetY;
+
+    const left = showOnLeft
+      ? event.clientX - tooltipWidth - offsetX
+      : event.clientX + offsetX;
+
+    const top = showOnTop
+      ? event.clientY - tooltipHeight - offsetY
+      : event.clientY + offsetY;
+
     const strategy = this.overlay
       .position()
       .global()
-      .left(`${event.clientX + offsetX}px`)
-      .top(`${event.clientY + offsetY}px`);
+      .left(`${left}px`)
+      .top(`${top}px`);
 
     this.overlayRef.updatePositionStrategy(strategy);
     this.overlayRef.updatePosition();

--- a/src/styles/utils/_apex-charts.scss
+++ b/src/styles/utils/_apex-charts.scss
@@ -121,6 +121,7 @@ ul.custom-markers {
     width: 100% !important;
     display: flex;
     justify-content: space-between;
+    gap: 12px;
   }
 
   &-answer {
@@ -130,6 +131,7 @@ ul.custom-markers {
   &-percentage {
     font-weight: 500;
     color: var(--progress-color);
+    white-space: nowrap;
   }
 
   &-progress {

--- a/src/styles/utils/_apex-charts.scss
+++ b/src/styles/utils/_apex-charts.scss
@@ -70,3 +70,108 @@ ul.custom-markers {
   font-size: 16px !important;
   font-weight: 600;
 }
+
+.summary-chart-tooltip {
+  background-color: #f0f0f0;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  max-width: 402px;
+  padding: 16px;
+  white-space: normal;
+  word-wrap: break-word;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &-header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &-title {
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 500;
+  }
+
+  &-container {
+    width: 100%;
+    display: flex;
+    gap: 6px;
+    flex-direction: column;
+  }
+
+  &-divider {
+    border-top: 1px solid var(--color-neutral-200);
+  }
+
+  &-total-badge {
+    padding: 1.5px 10px;
+    background-color: var(--color-neutral-200);
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 500;
+    border-radius: 17px;
+    width: fit-content;
+  }
+
+  &-percentage-answer {
+    width: 100% !important;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &-answer {
+    font-weight: 500;
+  }
+
+  &-percentage {
+    font-weight: 500;
+    color: var(--progress-color);
+  }
+
+  &-progress {
+    width: inherit;
+    height: 4px;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  &-progress::-webkit-progress-bar {
+    background-color: #fff;
+    border-radius: 4px;
+  }
+
+  &-progress::-webkit-progress-value {
+    background-color: var(--progress-color);
+    border-radius: 4px;
+  }
+
+  &-progress::-moz-progress-bar {
+    background-color: var(--progress-color);
+    border-radius: 4px;
+  }
+}
+
+.summary-chart-tooltip-mail-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 2px 0 0 20px;
+
+  li {
+    position: relative;
+    color: #6b7280;
+  }
+}
+
+.point-tooltip-color {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: 8px;
+  border-radius: 5px;
+  background-color: var(--progress-color);
+}


### PR DESCRIPTION
## Description

The tooltips for dynamic-charts-v2 and summary-charts-v2 are updated regarding the styles presented in:
https://www.figma.com/design/7dsEWYFuwkoPQy4MUzcnVD/ERAS?node-id=3852-37681&t=OyCp4SEIoTmKcwwL-0

In order to avoid the tooltip is cut off, the tooltip is displayed mirroring in case of the right side is not enough, and is going off the bottom of the screen in case of bottom side is not enough.

When the evaluation has a large data (students answers) the tooltip is cut off in the two cases, but it will be worked in: https://github.com/JU-DEV-Bootcamps/ERAS-FE/issues/857

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [X] Others: Enhancement

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#873 