### PR TITLE
fix: clear typeMap and close panel when evaluation changes as a filter

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -349,6 +349,10 @@ export class DynamicChartsV2Component implements AfterViewInit {
   }
 
   private applyFilterMetadata(filters: Filter) {
+    if (this.evaluationId !== filters.evaluationId) {
+      this.chartTypeMap.clear();
+      this.closePanel();
+    }
     this.title = filters.title;
     this.uuid = filters.uuid;
     this.cohortIds = filters.cohortIds.join(',');


### PR DESCRIPTION
## Description

- The change is verified if the previous evaluation is changed, so the map that stores the chart types is cleaned and close panel previously opened.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#895 