### PR TITLE
fix: avoid mutation reference in components signal with getColumnData

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
@@ -55,7 +55,7 @@
             @if (getChartType($index) === 'column') {
               <div [appApexTooltip]="getTooltipFn($index)">
                 <app-dynamic-column-chart-v2
-                  [componentData]="components()!.components[$index]"
+                  [componentData]="getColumnData($index)"
                   [identifier]="uuid!"
                   [cohortsIds]="cohortIds"
                   [evaluationId]="evaluationId"

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -348,6 +348,14 @@ export class DynamicChartsV2Component implements AfterViewInit {
     return titleChart?.replace('Reporte: ', '').toLocaleLowerCase();
   }
 
+  getColumnData(index: number) {
+    const source = this.components()!.components[index];
+    return {
+      ...source,
+      questions: [...source.questions],
+    };
+  }
+
   private resetBaseState() {
     this.hasNoResults = false;
   }

--- a/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
+++ b/src/app/shared/components/form-field-virtual-scroll/select-multiple-virtual-scroll/select-multiple-virtual-scroll.component.html
@@ -22,6 +22,7 @@
       <input
         #searchInput
         matInput
+        placeholder="Search..."
         (input)="onSearch($event)"
         (keydown.space)="$event.stopPropagation()"
         (keydown)="$event.stopPropagation()"


### PR DESCRIPTION
## Description

Previously, if we displayed a chart as a "column chart" and didn't change the "Evaluations" filter or any other filters, and then clicked the "Apply" button, the order of the variables/questions would change due to a mutation of the signal components' reference.

Now, this behavior is avoided by making a shallow copy of the components variable inside getColumnData.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#894 