### PR TITLE
Refactor: add internal vertical scrolling to answer details sidebar panel when content exceeds visible height

### DIFF
--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.scss
@@ -295,13 +295,11 @@
   }
 
   .details-aside {
-    width: 420px;
+    width: 440px;
     flex-shrink: 0;
     position: sticky;
     top: 16px;
-
-    &--scroll {
-      position: static;
-    }
+    max-height: 100vh;
+    overflow-y: auto;
   }
 }

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.html
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.html
@@ -121,14 +121,17 @@
           mat-cell
           #cellText
           [class]="mapClass?.table?.cell ?? ''"
-          [matTooltip]="
-            cellText.scrollWidth > cellText.clientWidth
-              ? showElement(element, column)
-              : null
-          "
           *matCellDef="let element"
         >
-          {{ showElement(element, column) }}
+          <span
+            appOverflowTooltip
+            [tooltipText]="
+              displayCache.get(element)?.[column.key.toString()] ?? ''
+            "
+            class="cell-text"
+          >
+            {{ displayCache.get(element)?.[column.key.toString()] }}
+          </span>
         </td>
       </ng-container>
 

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.scss
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.scss
@@ -90,3 +90,10 @@ mat-card-actions {
   display: flex;
   align-items: anchor-center;
 }
+
+.cell-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/app/shared/components/table-with-actions/table-with-actions.component.ts
+++ b/src/app/shared/components/table-with-actions/table-with-actions.component.ts
@@ -35,6 +35,7 @@ import { MapClass } from '../list/types/class';
 import { ActionButtonComponent } from '../buttons/action-button/action-button.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SelectedCheckboxComponent } from '@modules/students/students-list/selected-checkbox/selected-checkbox.component';
+import { OverflowTooltipDirective } from '@shared/directives/overflow-tooltip.directive';
 
 @Component({
   selector: 'app-table-with-actions',
@@ -54,6 +55,7 @@ import { SelectedCheckboxComponent } from '@modules/students/students-list/selec
     MatMenuModule,
     MatCheckboxModule,
     SelectedCheckboxComponent,
+    OverflowTooltipDirective,
   ],
   templateUrl: './table-with-actions.component.html',
   styleUrls: ['./table-with-actions.component.scss'],
@@ -82,6 +84,7 @@ export class TableWithActionsComponent<T extends object>
   actionColumns = ['Actions'];
   displayedColumns: string[] = [];
   allItemsSelected: WritableSignal<boolean> = signal<boolean>(false);
+  displayCache = new Map<T, Record<string, string>>();
 
   @HostListener('window:resize', ['$event'])
   onResize(event: UIEvent): void {
@@ -90,7 +93,12 @@ export class TableWithActionsComponent<T extends object>
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['items']) this.allItemsSelected.set(this.areAllItemsSelected());
+    if (changes['items']) {
+      this.buildDisplayCache();
+      Promise.resolve().then(() => {
+        this.allItemsSelected.set(this.areAllItemsSelected());
+      });
+    }
   }
 
   ngOnInit() {
@@ -108,25 +116,6 @@ export class TableWithActionsComponent<T extends object>
       return column.key.toString();
     });
   }
-  // getAllColumns() {
-  //   let columnKeys = [] as (keyof T)[];
-
-  //   if (this.itemsAreSelectable) {
-  //     columnKeys = columnKeys.concat(['isSelected'] as (keyof T)[]);
-  //   }
-
-  //   columnKeys = columnKeys.concat(this.getColumnKeys());
-
-  //   if (this.getTotalTemplateColumns() > 0) {
-  //     columnKeys = columnKeys.concat(this.columnTemplates.map(ct => ct.key));
-  //   }
-
-  //   if (this.actionDatas().length > 0) {
-  //     columnKeys = columnKeys.concat(this.actionColumns);
-  //   }
-
-  //   return columnKeys;
-  // }
 
   getTotalTemplateColumns() {
     return this.columnTemplates.length;
@@ -219,5 +208,16 @@ export class TableWithActionsComponent<T extends object>
     this.allItemsSelected()
       ? this.toggleItemsSelection(false)
       : this.toggleItemsSelection(true);
+  }
+
+  private buildDisplayCache(): void {
+    this.displayCache.clear();
+    for (const item of this.items ?? []) {
+      const row: Record<string, string> = {};
+      for (const col of this.columns ?? []) {
+        row[col.key.toString()] = this.showElement(item, col);
+      }
+      this.displayCache.set(item, row);
+    }
   }
 }

--- a/src/app/shared/directives/overflow-tooltip.directive.ts
+++ b/src/app/shared/directives/overflow-tooltip.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+
+@Directive({
+  selector: '[appOverflowTooltip]',
+  standalone: true,
+  hostDirectives: [MatTooltip],
+})
+export class OverflowTooltipDirective {
+  @Input() tooltipText = '';
+
+  constructor(
+    private el: ElementRef<HTMLElement>,
+    private tooltip: MatTooltip
+  ) {}
+
+  @HostListener('mouseenter')
+  onMouseEnter() {
+    const el = this.el.nativeElement;
+    this.tooltip.message =
+      el.scrollWidth > el.clientWidth ? this.tooltipText : null;
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave() {
+    this.tooltip.hide();
+  }
+}


### PR DESCRIPTION
## Description

Now, in Summary charts-v2 in right details panel for column chart, the overflow in y axis was added, and due to some console logs in summary-charts v2 (column charts) with null values on ShowElement function, I replace that with a cache. The tooltip was replaced also with a directive instead of tooltip by default.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#889 
