### PR TITLE
fix: deselect elements and fix panel width

### DIFF
--- a/src/app/core/factories/forms/searchable-select/searchable-select.component.html
+++ b/src/app/core/factories/forms/searchable-select/searchable-select.component.html
@@ -4,5 +4,5 @@
   [label]="field().label"
   [floatLabelSetup]="field().floatingLabel ?? 'auto'"
   [placeholder]="field().placeholder ?? 'Select...'"
-  [autoSelect]="field().value === undefined"
+  [autoSelect]="false"
 ></app-select-multiple-virtual-scroll>

--- a/src/styles/utils/_forms.scss
+++ b/src/styles/utils/_forms.scss
@@ -16,7 +16,6 @@ mat-option[appselectall] {
   .mat-mdc-option,
   .mdc-list-item {
     min-height: 36px !important;
-    height: 36px !important;
   }
 
   .mat-mdc-option .mdc-list-item__primary-text {

--- a/src/styles/utils/index.scss
+++ b/src/styles/utils/index.scss
@@ -55,10 +55,6 @@ mat-icon {
   background-color: white !important;
 }
 
-.cdk-overlay-pane:has(.compact-select-panel) {
-  min-width: 540px !important;
-}
-
 // Rewrite apexcharts styles
 .apexcharts-canvas .apexcharts-heatmap-rect[val='-1'],
 .apexcharts-canvas


### PR DESCRIPTION
## Description

- Fixed issue with options panel width so now it fits the field width
- Disabled autoselect as default for searchable dropdowns inside form factory

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [x] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


