### PR TITLE
fix(reports): close answer details panel on filter change

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -363,8 +363,8 @@ export class DynamicChartsV2Component implements AfterViewInit {
   private applyFilterMetadata(filters: Filter) {
     if (this.evaluationId !== filters.evaluationId) {
       this.chartTypeMap.clear();
-      this.closePanel();
     }
+    this.closePanel();
     this.title = filters.title;
     this.uuid = filters.uuid;
     this.cohortIds = filters.cohortIds.join(',');

--- a/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
+++ b/src/app/modules/reports/components/summary-charts-v2/summary-charts-v2.component.ts
@@ -313,6 +313,7 @@ export class SummaryChartsV2Component {
   }
 
   handleFilterSelect(filters: Filter) {
+    this.closePanel();
     this.hasNoResults = false;
     this.cohortIds = filters.cohortIds;
     this.title = filters.title;


### PR DESCRIPTION
## Description

Answer details panel should be reset in any case that filters are applied

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


