### PR TITLE
fix: enforce required date range on evaluation edit and import flows

### DIFF
--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-form/evaluation-process-form.component.html
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-form/evaluation-process-form.component.html
@@ -180,9 +180,9 @@
         class="modalMainButton"
         type="submit"
         [ngClass]="{
-          disabledButton: (form.invalid && !pollDataSelected) || form.pristine,
+          disabledButton: form.invalid || form.pristine,
         }"
-        [disabled]="(form.invalid && !pollDataSelected) || form.pristine"
+        [disabled]="form.invalid || form.pristine"
       >
         {{ buttonText }}
       </button>

--- a/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.html
+++ b/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.html
@@ -56,7 +56,7 @@
         <div class="row">
           <mat-form-field class="input">
             <mat-label>Enter a date range</mat-label>
-            <mat-date-range-input [rangePicker]="picker">
+            <mat-date-range-input [rangePicker]="picker" [required]="true">
               <input
                 matStartDate
                 placeholder="Start date"
@@ -69,7 +69,14 @@
               [for]="picker"
             ></mat-datepicker-toggle>
             <mat-date-range-picker #picker></mat-date-range-picker>
-            <mat-hint>Not required</mat-hint>
+            @if (
+              form.get('start')?.hasError('required') ||
+              form.get('end')?.hasError('required')
+            ) {
+              <mat-error>Required</mat-error>
+            } @else {
+              <mat-hint>Required</mat-hint>
+            }
           </mat-form-field>
         </div>
         <div class="row">

--- a/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.ts
+++ b/src/app/modules/lists/components/modal-import-answers-form/modal-import-answers-form.component.ts
@@ -95,8 +95,8 @@ export class ModalImportAnswersFormComponent implements OnInit {
         },
         [Validators.pattern(/^(?!\s*$).+/)]
       ),
-      start: this.preselectedPollState?.startDate ?? '',
-      end: this.preselectedPollState?.endDate ?? '',
+      start: [this.preselectedPollState?.startDate ?? '', Validators.required],
+      end: [this.preselectedPollState?.endDate ?? '', Validators.required],
     });
   }
 


### PR DESCRIPTION
## Description

Start and end dates are now mandatory across Create, Edit, and Import.
Open-ended (single-boundary) filtering is no longer a supported state.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


