### PR TITLE
fix: add messages detailed for errors of type 400

### DIFF
--- a/src/app/core/constants/messages.ts
+++ b/src/app/core/constants/messages.ts
@@ -33,6 +33,9 @@ export const GENERAL_MESSAGES = {
   SUCCESS_IMPORT_TITLE: 'Successful import',
   WARNING_TITLE: 'Warning',
   DETAILS: 'Details:',
+  ERROR_400: 'Bad Request',
+  INVALID_TYPE_ERROR_400: (attribute: string) =>
+    `The property ${attribute} cannot be converted to the required type.`,
 };
 
 export const TYPE_ICON: Record<DialogType, string> = {

--- a/src/app/modules/students/students-list/students-list.component.ts
+++ b/src/app/modules/students/students-list/students-list.component.ts
@@ -351,11 +351,24 @@ export class StudentsListComponent implements OnInit {
       error: error => {
         this.isLoading = false;
         previewRef.close();
-        if (error.status == 500) {
+        if (error.status === 500) {
           openDialogWithStatus(
             GENERAL_MESSAGES.ERROR_500,
             false,
             [],
+            fileErrors,
+            this.dialog
+          );
+        } else if (error.status === 400) {
+          const keys = Object.keys(error.error.errors);
+          const errors = keys.slice(1).map(key => {
+            const attribute: string = key.split('.').pop() ?? '';
+            return GENERAL_MESSAGES.INVALID_TYPE_ERROR_400(attribute);
+          });
+          openDialogWithStatus(
+            GENERAL_MESSAGES.ERROR_400,
+            false,
+            errors,
             fileErrors,
             this.dialog
           );


### PR DESCRIPTION
## Description

In order to show the message with more information when the error is about type of data, the modal to show errors is updated to add information from BE response.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

