### PR TITLE
Fix: interventions creating an intervention under assessments assessment details doesnt display the students names

### DIFF
--- a/src/app/core/factories/forms/upload-input/upload-input.component.html
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.html
@@ -8,7 +8,7 @@
     <mat-label>{{ field().label }}</mat-label>
     <mat-chip-grid #chipGrid>
       @for (item of selectedFiles(); track $index) {
-        <mat-chip-row (removed)="removeFile($index)">
+        <mat-chip-row (removed)="removeFile($index)" class="selected-chip">
           {{ item.name }}
           <button matChipRemove>
             <mat-icon>cancel</mat-icon>

--- a/src/app/core/factories/forms/upload-input/upload-input.component.scss
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.scss
@@ -68,3 +68,34 @@ $color-accent-hover: #4a8a7c;
     top: 24%;
   }
 }
+
+.selected-chip {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border: 1px solid $color-accent-hover;
+  &:hover {
+    background-color: #deeae8;
+  }
+}
+
+:host ::ng-deep .mdc-evolution-chip__action--primary {
+  overflow: hidden !important;
+  min-width: 0;
+}
+
+.mat-mdc-standard-chip,
+.mdc-evolution-chip__cell--primary,
+.mat-mdc-standard-chip,
+.mdc-evolution-chip__action--primary,
+.mat-mdc-standard-chip,
+.mat-mdc-chip-action-label {
+  max-width: 320px;
+}
+
+:host ::ng-deep .mdc-evolution-chip__text-label,
+.mat-mdc-chip-action-label {
+  max-width: 260px;
+  display: block;
+  overflow: hidden !important;
+  text-overflow: ellipsis;
+}

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.ts
@@ -162,9 +162,9 @@ export class AssessmentListComponent implements OnInit {
   }
 
   protected onCreateIntervention(assessment: AssessmentRowViewModel): void {
-    const students = assessment.studentIds.map((id, index) => ({
-      value: String(id),
-      label: assessment.studentNames?.[index] ?? String(id),
+    const students = assessment.students?.map(student => ({
+      value: student.id,
+      label: student.name,
     }));
 
     this.matDialog.open(NewInterventionModalComponent, {


### PR DESCRIPTION
## Description

This PR contains:
- Fix to show student names in labels instead of ids.
- A fix to avoid the overflow of file names in upload-input with the button to choose field, an ellipsis is applied in text of chips.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


