### PR TITLE
Fix/fe 918/enhancement view list of interventions with some updates

### DIFF
--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.html
@@ -1,9 +1,9 @@
 <div class="assessment-data-student">
-  <span class="text-student">
-    {{ studentData[0].name }}
-  </span>
+  <div class="set-names">
+    {{ studentNames }}
+  </div>
 
-  @if (studentData.length > 1) {
+  @if (studentData.length > numberOfStudent) {
     <div
       class="popover-wrapper"
       (mouseenter)="openPopover()"
@@ -17,7 +17,7 @@
         (keydown.space)="togglePin()"
         tabindex="0"
       >
-        +{{ studentData.length - 1 }}
+        +{{ studentData.length - numberOfStudent }}
       </span>
 
       <div
@@ -28,7 +28,7 @@
         (mouseenter)="show = true"
         (mouseleave)="closePopover()"
       >
-        @for (student of studentData.slice(1); track student.id) {
+        @for (student of studentData.slice(numberOfStudent); track student.id) {
           <div class="student-item">
             <div class="student-avatar">
               <img

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.scss
@@ -33,6 +33,10 @@ $color-stroke: #e5e5e5;
   justify-content: center;
 }
 
+.set-names {
+  max-width: 170px;
+}
+
 .student-item {
   display: flex;
   align-items: center;

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -4,6 +4,7 @@ import {
   HostListener,
   Input,
   ViewChild,
+  OnInit,
 } from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
@@ -20,13 +21,16 @@ export interface StudentProfileData {
   templateUrl: './assessment-student-data.component.html',
   styleUrl: './assessment-student-data.component.scss',
 })
-export class AssessmentStudentDataComponent {
+export class AssessmentStudentDataComponent implements OnInit {
   @Input({ required: true }) studentData!: StudentProfileData[];
+  @Input({ required: false }) numberOfStudent = 1;
   @ViewChild('badgeRef') badgeRef!: ElementRef;
 
   show = false;
   pinned = false;
   popoverStyle: Record<string, string> = {};
+  studentNames = '';
+
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent) {
     const clickedInside = this.badgeRef?.nativeElement.contains(event.target);
@@ -34,6 +38,14 @@ export class AssessmentStudentDataComponent {
       this.pinned = false;
       this.show = false;
     }
+  }
+
+  ngOnInit() {
+    this.studentNames = this.studentData
+      .slice(0, this.numberOfStudent)
+      .map(st => st.name)
+      .join(', ');
+    console.log(this.studentNames);
   }
 
   openPopover() {

--- a/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
+++ b/src/app/modules/assessments/components/assessment-list/assessment-student-data/assessment-student-data.component.ts
@@ -4,7 +4,7 @@ import {
   HostListener,
   Input,
   ViewChild,
-  OnInit,
+  OnChanges,
 } from '@angular/core';
 import { MatMenuModule } from '@angular/material/menu';
 import { CommonModule } from '@angular/common';
@@ -21,7 +21,7 @@ export interface StudentProfileData {
   templateUrl: './assessment-student-data.component.html',
   styleUrl: './assessment-student-data.component.scss',
 })
-export class AssessmentStudentDataComponent implements OnInit {
+export class AssessmentStudentDataComponent implements OnChanges {
   @Input({ required: true }) studentData!: StudentProfileData[];
   @Input({ required: false }) numberOfStudent = 1;
   @ViewChild('badgeRef') badgeRef!: ElementRef;
@@ -40,12 +40,11 @@ export class AssessmentStudentDataComponent implements OnInit {
     }
   }
 
-  ngOnInit() {
+  ngOnChanges() {
     this.studentNames = this.studentData
       .slice(0, this.numberOfStudent)
       .map(st => st.name)
       .join(', ');
-    console.log(this.studentNames);
   }
 
   openPopover() {

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -18,10 +18,13 @@
   <div class="empty-state">
     <div class="empty-state-content">
       <div class="empty-icon">
-        <mat-icon>psychology</mat-icon>
+        <mat-icon>assignment</mat-icon>
       </div>
       <h3>No Interventions yet</h3>
-      <p>Create the first intervention for this assessment</p>
+      <p>
+        Get Started by creating your first <br />
+        intervention record
+      </p>
       <button mat-flat-button type="button" (click)="onCreateClick()">
         Create Intervention
       </button>
@@ -86,6 +89,7 @@
             <td mat-cell *matCellDef="let item">
               <app-assessment-student-data
                 [studentData]="item.studentDisplay"
+                [numberOfStudent]="2"
               />
             </td>
           </ng-container>

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.scss
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.scss
@@ -32,21 +32,23 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 18px;
   text-align: center;
   max-width: 400px;
 
   h3 {
     margin: 0;
     font-size: 18px;
-    font-weight: 600;
+    font-weight: 700;
     color: #0f172a;
+    font-family: 'Inter', sans-serif;
   }
 
   p {
     margin: 0;
     font-size: 14px;
     color: #64748b;
+    font-family: 'Inter', sans-serif;
   }
 }
 

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
@@ -489,10 +489,14 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
         this.attendedStudentIds().includes(String(student.value));
     });
 
+    const kindIntervention = this.formFields.find(
+      field => field.name === 'type'
+    )?.value;
+
     return {
       assessmentId: this.data.assessmentId,
       intervention: {
-        kind: v.type,
+        kind: v.type ?? kindIntervention,
         dateUtc: new Date(v.date).toISOString(),
         activity: v.activity,
         mode: v.mode,


### PR DESCRIPTION
## Description

This PR implements the following points:

- The Students for Interventions section now shows two students instead of one, and the remaining students are in the popover. Through a new input optional to handle the number of students in badge
- The style, which resembles the mockup, is controlled by a max-width of 170px. 
- The subtitle and icon in the empty list of interventions are updated to match the mockup.
- The bug that appeared when creating an intervention from an assessment with only one student has been fixed.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#918 
