### PR TITLE
feat: add V2 feature flag toggle for admin users

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -13,6 +13,8 @@ import { environment } from '../environments/environment';
 import { keycloakHttpInterceptor } from '@core/interceptors/keycloak-interceptor';
 import { AuthService } from '@core/services/access/access.service';
 import Keycloak from 'keycloak-js';
+import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
+import { firstValueFrom } from 'rxjs';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -22,7 +24,10 @@ export const appConfig: ApplicationConfig = {
     },
     provideAppInitializer(async () => {
       const authService = inject(AuthService);
-      return await authService.init();
+      const featureFlags = inject(FeatureFlagsService);
+
+      await authService.init();
+      await firstValueFrom(featureFlags.loadFlags());
     }),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),

--- a/src/app/core/components/feature-flags/feature-flags.service.ts
+++ b/src/app/core/components/feature-flags/feature-flags.service.ts
@@ -1,6 +1,15 @@
-import { Injectable, computed, inject } from '@angular/core';
-import { environment } from 'src/environments/environment';
+import { Injectable, signal, computed, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map, tap, Observable, catchError, of } from 'rxjs';
 import { Router } from '@angular/router';
+import { FEATURE_FLAGS } from './feature-flags';
+import { environment } from 'src/environments/environment';
+
+interface FeatureFlag {
+  id: number;
+  name: string;
+  isEnabled: boolean;
+}
 
 /**
  * Service responsible for evaluating feature flags based on URL query parameters.
@@ -16,18 +25,72 @@ import { Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class FeatureFlagsService {
-  private router = inject(Router);
-  private queryParams = computed(() => {
-    return this.router.routerState.root.snapshot.queryParams;
-  });
+  private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly baseUrl = environment.apiUrl + '/api/v1/feature-flags';
+
+  private _flags = signal<Record<string, boolean>>({});
+  flags = computed(() => this._flags());
+
+  private _flagMeta = signal<FeatureFlag[]>([]);
+
+  loadFlags(): Observable<void> {
+    return this.http.get<FeatureFlag[]>(this.baseUrl).pipe(
+      tap(flags => {
+        console.log('flags from API:', flags);
+        this._flagMeta.set(flags);
+
+        const v2Flag = flags.find(f => f.name === 'v2');
+        const v2Enabled = v2Flag?.isEnabled ?? false;
+
+        const mapped = Object.fromEntries(
+          Object.values(FEATURE_FLAGS).map(f => [f, v2Enabled])
+        );
+        this._flags.set(mapped);
+      }),
+      map(() => void 0),
+      catchError(err => {
+        console.error('loadFlags failed:', err);
+        return of(void 0);
+      })
+    );
+  }
 
   isEnabled(flag: string): boolean {
-    if (environment.production) return false;
+    return this._flags()[flag] ?? false;
+  }
 
-    const params = this.queryParams();
+  toggle(flagName: string, enabled: boolean): Observable<void> {
+    const flag = this._flagMeta().find(f => f.name === flagName);
+    if (!flag) {
+      console.warn(
+        `Flag '${flagName}' not found in meta. Meta:`,
+        this._flagMeta()
+      );
+      return of(void 0);
+    }
 
-    if (params['v2'] === 'true') return true;
+    return this.http
+      .put<void>(`${this.baseUrl}/${flag.id}`, { ...flag, isEnabled: enabled })
+      .pipe(
+        tap(() => {
+          const mapped = Object.fromEntries(
+            Object.values(FEATURE_FLAGS).map(f => [f, enabled])
+          );
+          this._flags.set(mapped);
+        }),
+        catchError(err => {
+          console.error('Toggle failed:', err);
+          return of(void 0);
+        })
+      );
+  }
 
-    return params[flag] === 'true';
+  enableLocal(flag: string): void {
+    this._flags.update(f => ({ ...f, [flag]: true }));
+  }
+
+  disableLocal(flag: string): void {
+    this._flags.update(f => ({ ...f, [flag]: false }));
   }
 }

--- a/src/app/core/components/feature-flags/feature-flags.service.ts
+++ b/src/app/core/components/feature-flags/feature-flags.service.ts
@@ -37,7 +37,6 @@ export class FeatureFlagsService {
   loadFlags(): Observable<void> {
     return this.http.get<FeatureFlag[]>(this.baseUrl).pipe(
       tap(flags => {
-        console.log('flags from API:', flags);
         this._flagMeta.set(flags);
 
         const v2Flag = flags.find(f => f.name === 'v2');

--- a/src/app/core/components/layout/layout.component.ts
+++ b/src/app/core/components/layout/layout.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  computed,
-  inject,
-  OnInit,
-  model,
-  signal,
-} from '@angular/core';
+import { Component, computed, inject, OnInit, model } from '@angular/core';
 import { RouterOutlet, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -61,10 +54,16 @@ export class LayoutComponent implements OnInit {
   private featureFlagsService = inject(FeatureFlagsService);
 
   collapsed = model<boolean>(false);
-  newSidebar = signal<boolean>(false);
-  reportsV2 = signal<boolean>(false);
-  home = signal<boolean>(false);
-  dynamicCharts = signal<boolean>(false);
+  newSidebar = computed(() =>
+    this.featureFlagsService.isEnabled(FEATURE_FLAGS.newSidebar)
+  );
+  reportsV2 = computed(() =>
+    this.featureFlagsService.isEnabled(FEATURE_FLAGS.reportsV2)
+  );
+  home = computed(() => this.featureFlagsService.isEnabled(FEATURE_FLAGS.home));
+  dynamicCharts = computed(() =>
+    this.featureFlagsService.isEnabled(FEATURE_FLAGS.dynamicCharts)
+  );
 
   sidenavWidth = computed(() => {
     if (this.newSidebar()) {
@@ -74,23 +73,8 @@ export class LayoutComponent implements OnInit {
   });
 
   ngOnInit() {
-    this.readSidebarFlag();
-
     this.breakpointObserver
       .observe([Breakpoints.Small, '(max-width: 1200px)'])
       .subscribe((state: BreakpointState) => this.collapsed.set(state.matches));
-  }
-
-  private readSidebarFlag(): void {
-    this.newSidebar.set(
-      this.featureFlagsService.isEnabled(FEATURE_FLAGS.newSidebar)
-    );
-    this.reportsV2.set(
-      this.featureFlagsService.isEnabled(FEATURE_FLAGS.reportsV2)
-    );
-    this.home.set(this.featureFlagsService.isEnabled(FEATURE_FLAGS.home));
-    this.dynamicCharts.set(
-      this.featureFlagsService.isEnabled(FEATURE_FLAGS.dynamicCharts)
-    );
   }
 }

--- a/src/app/core/components/layout/user-menu/user-menu.component.html
+++ b/src/app/core/components/layout/user-menu/user-menu.component.html
@@ -5,7 +5,12 @@
   </button>
 </div>
 
-<mat-menu #beforeMenu="matMenu" xPosition="before" hasBackdrop="false">
+<mat-menu
+  #beforeMenu="matMenu"
+  xPosition="before"
+  hasBackdrop="true"
+  class="user-menu-panel"
+>
   <div class="user-info-container">
     <!-- TODO: Add component/img for profile picture -->
     <mat-icon class="profile-picture">account_circle</mat-icon>
@@ -28,6 +33,22 @@
       <mat-icon>settings</mat-icon>
       Platform Settings
     </button>
+    @if (isAdmin()) {
+      <button
+        class="menu-button version-toggle-item"
+        (click)="$event.stopPropagation()"
+      >
+        <span class="toggle-label-text">Turn on V2</span>
+        <label class="simple-toggle">
+          <input
+            type="checkbox"
+            [checked]="v2Enabled()"
+            (change)="onV2Toggle($event)"
+          />
+          <span class="slider"></span>
+        </label>
+      </button>
+    }
   </div>
   <hr />
   <div class="logout-container">

--- a/src/app/core/components/layout/user-menu/user-menu.component.scss
+++ b/src/app/core/components/layout/user-menu/user-menu.component.scss
@@ -35,6 +35,70 @@
   }
 }
 
+.version-toggle-item {
+  cursor: default;
+  gap: 8px;
+  color: main-styles.get-color('neutral', 10);
+  box-sizing: border-box;
+  overflow: hidden;
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+
+  &:hover {
+    background-color: main-styles.get-color('neutral', 90);
+  }
+
+  .toggle-label-text {
+    flex: 1;
+    font-size: main-styles.get-font-size(label, large);
+    white-space: nowrap;
+  }
+}
+
+.simple-toggle {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  cursor: pointer;
+
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .slider {
+    position: absolute;
+    inset: 0;
+    background-color: main-styles.get-color('neutral', 70);
+    border-radius: 20px;
+    transition: background-color 200ms ease;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 14px;
+      height: 14px;
+      left: 3px;
+      top: 3px;
+      background-color: white;
+      border-radius: 50%;
+      transition: transform 200ms ease;
+    }
+  }
+
+  input:checked + .slider {
+    background-color: var(--primary-700);
+
+    &::before {
+      transform: translateX(16px);
+    }
+  }
+}
+
 .user-info-container {
   cursor: default;
   display: flex;

--- a/src/app/core/components/layout/user-menu/user-menu.component.ts
+++ b/src/app/core/components/layout/user-menu/user-menu.component.ts
@@ -1,24 +1,38 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, computed } from '@angular/core';
 
 import { MatIcon } from '@angular/material/icon';
-import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
+import { MatMenu, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { UserDataService } from '@core/services/access/user-data.service';
 import { AuthService } from '@core/services/access/access.service';
+import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
+import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-user-menu',
   templateUrl: './user-menu.component.html',
   styleUrls: ['./user-menu.component.scss'],
-  imports: [MatMenu, MatIcon, MatMenuTrigger],
+  imports: [
+    MatMenu,
+    MatMenuModule,
+    MatIcon,
+    MatMenuTrigger,
+    MatSlideToggleModule,
+    MatTooltipModule,
+  ],
 })
 export class UserMenuComponent {
   private readonly authService = inject(AuthService);
   private readonly userData = inject(UserDataService);
+  private readonly featureFlags = inject(FeatureFlagsService);
   private readonly router = inject(Router);
 
   user = this.userData.user;
+  isAdmin = computed(() => this.user()?.role === 'Eras Admin');
+  v2Enabled = computed(() => this.featureFlags.isEnabled(FEATURE_FLAGS.home));
 
   logout() {
     this.userData.clear();
@@ -27,5 +41,10 @@ export class UserMenuComponent {
 
   redirectToSettings() {
     this.router.navigate(['cosmic-latte']);
+  }
+
+  onV2Toggle(event: Event): void {
+    const enabled = (event.target as HTMLInputElement).checked;
+    this.featureFlags.toggle('v2', enabled).subscribe();
   }
 }

--- a/src/app/shared/components/modals/modal-question-details/modal-question-details.component.spec.ts
+++ b/src/app/shared/components/modals/modal-question-details/modal-question-details.component.spec.ts
@@ -13,6 +13,7 @@ import { PollService } from '@core/services/api/poll.service';
 import { ActivatedRoute } from '@angular/router';
 import { ComponentValueType } from '@core/models/types/risk-students-detail.type';
 import { EvaluationDetailsService } from '@core/services/api/evaluation-details.service';
+import { provideHttpClient } from '@angular/common/http';
 
 describe('ModalQuestionDetailsComponent', () => {
   let component: ModalQuestionDetailsComponent;
@@ -73,6 +74,7 @@ describe('ModalQuestionDetailsComponent', () => {
         NoopAnimationsModule,
       ],
       providers: [
+        provideHttpClient(),
         {
           provide: MAT_DIALOG_DATA,
           useValue: mockDialogData,


### PR DESCRIPTION
## Description

- Add V2 toggle in user menu, visible only for `Eras Admin` role
- Toggle enables/disables all `FEATURE_FLAGS` simultaneously via a single `v2` backend flag
- `FeatureFlagsService` loads flag state from `GET /api/v1/feature-flags` on app init (`provideAppInitializer`)
- Flag state persisted via `PUT /api/v1/feature-flags/{id}` — survives page reloads
- Remove `localStorage` and query param logic from `FeatureFlagsService`
- Fix `FeatureFlagsService` HTTP calls to use `environment.apiUrl` base URL instead of relative paths (was returning Angular's `index.html` in dev)
- Fix `ModalQuestionDetailsComponent` spec: add `provideHttpClient()` to satisfy `FeatureFlagsService` injection in tests

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


