### PR TITLE
fix: use highest chart height as reference for dynamic charts

### DIFF
--- a/src/app/core/utils/apex-chart/heat-map-config-v2.ts
+++ b/src/app/core/utils/apex-chart/heat-map-config-v2.ts
@@ -15,7 +15,8 @@ export function GetChartOptions(
   tooltipCustomFunction?: (x: number, y: number) => string,
   availableWidth = 1500,
   isExpanded = false,
-  fixColors = true
+  fixColors = true,
+  highestRowCount = 0
 ): ApexOptions {
   const CARD_HEADER_WIDTH = 96;
   const MIN_CHART_HEIGHT = 230;
@@ -27,7 +28,7 @@ export function GetChartOptions(
   const CELL_HEIGHT = chartValues.cellHeight;
   const percentageToView = chartValues.labelPercent;
   const questionSection = percentageToView * availableWidth;
-  const rowCount = series.length;
+  const rowCount = Math.max(series.length, highestRowCount);
   const chartHeight = Math.max(
     MIN_CHART_HEIGHT,
     rowCount * CELL_HEIGHT + CARD_HEADER_WIDTH

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
@@ -61,6 +61,9 @@
                   [evaluationId]="evaluationId"
                   [tooltipFn]="getTooltipFn($index)"
                   [resizeTrigger]="resizeTick()"
+                  [maxChartHeight]="
+                    isAnyCardExpanded ? undefined : chartOption.chart?.height
+                  "
                   (selectPoint)="
                     openDetailsModal(
                       uuid!,

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.ts
@@ -146,6 +146,11 @@ export class DynamicChartsV2Component implements AfterViewInit {
     const hmSeries = report.components.map(c =>
       this.reportService.getHMSeriesFromCountComponent(c)
     );
+
+    const highestRowCount = this.isAnyCardExpanded
+      ? 0
+      : Math.max(...hmSeries.map(series => series.length));
+
     this.chartsOptions = hmSeries.map((series, index) => {
       const regroupSeries = this.reportService.regroupDynamicByColor(series);
       const component = report.components[index];
@@ -209,7 +214,9 @@ export class DynamicChartsV2Component implements AfterViewInit {
           );
         },
         cardWidth,
-        this.isAnyCardExpanded
+        this.isAnyCardExpanded,
+        true,
+        highestRowCount
       );
     });
     this.cdr.detectChanges();

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-column-chart-v2/dynamic-column-chart-v2.component.ts
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-column-chart-v2/dynamic-column-chart-v2.component.ts
@@ -66,6 +66,7 @@ export class DynamicColumnChartV2Component {
   evaluationId = input<number | string | undefined>();
   tooltipFn = input<(seriesIndex: number, dataPointIndex: number) => string>();
   resizeTrigger = input<number>(0);
+  maxChartHeight = input<number | string | undefined>();
 
   selectPoint = output<SelectPointEvent>();
   private injector = inject(EnvironmentInjector);
@@ -97,9 +98,19 @@ export class DynamicColumnChartV2Component {
     questions: PollCountQuestion[],
     onSelect?: (x: number, y: number) => void
   ): Partial<ChartOptions> {
+    let chartHeight = 0;
+    const value = this.maxChartHeight();
+    if (value) {
+      chartHeight = typeof value == 'string' ? parseInt(value) : value;
+    }
+
     return {
       title: ColumnChartUtils.createTitle(title),
-      chart: ColumnChartUtils.createChartBase((x, s) => onSelect?.(x, s)),
+      chart: ColumnChartUtils.createChartBase(
+        (x, s) => onSelect?.(x, s),
+        questions.length,
+        chartHeight
+      ),
       series: this._createSeries(questions),
       plotOptions: ColumnChartUtils.createPlotOptions(),
       xaxis: ColumnChartUtils.createXAxis(questions.map(q => q.question)),

--- a/src/app/modules/reports/utils/column-chart.config.ts
+++ b/src/app/modules/reports/utils/column-chart.config.ts
@@ -20,11 +20,16 @@ export class ColumnChartUtils {
 
   static createChartBase(
     onSelect?: (x: number, y: number, series: ComponentRisk[]) => void,
-    componentCount = 5
+    componentCount = 5,
+    containerHeight?: number
   ): ApexChart {
     const BAR_WIDTH = 20;
     const MIN_HEIGHT = 580;
-    const calculatedHeight = Math.max(MIN_HEIGHT, componentCount * BAR_WIDTH);
+    const calculatedHeight = Math.max(
+      MIN_HEIGHT,
+      componentCount * BAR_WIDTH,
+      containerHeight ?? 0
+    );
 
     return {
       type: 'bar',


### PR DESCRIPTION
## Description

- Adjusted logic to calculate chart height to match the highest chart height available.
- Added exception for expanded cards to avoid oversizing the charts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


