### PR TITLE
fix: adjust styles to center smaller charts

### DIFF
--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.html
@@ -53,7 +53,10 @@
             (changeChart)="onChartTypeChange($index, $event)"
           >
             @if (getChartType($index) === 'column') {
-              <div [appApexTooltip]="getTooltipFn($index)">
+              <div
+                class="chart-container"
+                [appApexTooltip]="getTooltipFn($index)"
+              >
                 <app-dynamic-column-chart-v2
                   [componentData]="getColumnData($index)"
                   [identifier]="uuid!"
@@ -74,7 +77,10 @@
                 />
               </div>
             } @else {
-              <div [appApexTooltip]="getTooltipFn($index)">
+              <div
+                class="chart-container"
+                [appApexTooltip]="getTooltipFn($index)"
+              >
                 <apx-chart
                   [series]="chartOption.series!"
                   [chart]="chartOption.chart!"

--- a/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.scss
+++ b/src/app/modules/reports/components/dynamic-charts-v2/dynamic-charts-v2.component.scss
@@ -44,6 +44,15 @@
   }
 }
 
+.chart-container {
+  display: flex;
+  align-items: center;
+
+  app-dynamic-column-chart-v2 {
+    width: 100%;
+  }
+}
+
 .details-aside {
   width: 380px;
   align-self: stretch;

--- a/src/app/shared/components/expandable-card-v2/expandable-card.component.scss
+++ b/src/app/shared/components/expandable-card-v2/expandable-card.component.scss
@@ -159,7 +159,7 @@ $spring-collapse: 100ms cubic-bezier(0.4, 0, 1, 1);
   ::ng-deep .apexcharts-canvas,
   ::ng-deep apx-chart {
     width: 100% !important;
-    height: 100% !important;
+    height: auto !important;
   }
 
   ::ng-deep .apexcharts-tooltip {


### PR DESCRIPTION
## Description

Adjust styles to center the charts in the middle of the card if the card next to it is bigger.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


