### PR TITLE
fix: show errors but don't set control as invalid

### DIFF
--- a/src/app/core/factories/forms/upload-input/upload-input.component.html
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.html
@@ -27,7 +27,7 @@
 
   @if (errorMatcher.hasErrors()) {
     <p class="file-error-message">
-      {{ formUtils.getFieldError(form(), field()) }}
+      {{ errorMessage() }}
     </p>
   }
   <input #fileInput type="file" hidden (change)="onFileSelected($event)" />

--- a/src/app/core/factories/forms/upload-input/upload-input.component.scss
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.scss
@@ -46,6 +46,12 @@ $color-accent-hover: #4a8a7c;
       border-color: #ba1a1a !important;
     }
 
+    .mdc-text-field--outlined {
+      &:hover .mat-mdc-notch-piece {
+        border-bottom-color: #ba1a1a !important;
+      }
+    }
+
     .mdc-notched-outline__notch {
       border-bottom-color: #ba1a1a;
     }

--- a/src/app/core/factories/forms/upload-input/upload-input.component.ts
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.ts
@@ -41,7 +41,7 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
 
   selectedFiles = signal<File[]>([]);
   fileErrors = signal<string[]>([]);
-  selectedErrors = signal<ValidationErrors[]>([]);
+  errorMessage = signal<string | null>(null);
 
   readonly errorMatcher = new FileErrorStateMatcher();
 
@@ -71,7 +71,6 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
     let accumulatedErrors: ValidationErrors = {};
 
     this.fileErrors.set([]);
-    this.selectedErrors.set([]);
 
     for (const file of input.files) {
       const errors = this.validate(file);
@@ -94,10 +93,14 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
     input.value = '';
 
     if (Object.keys(accumulatedErrors).length > 0) {
-      control?.setErrors(accumulatedErrors);
+      const formattedError = this.formUtils.getTextError(
+        accumulatedErrors,
+        this.field().label
+      );
+      this.errorMessage.set(formattedError);
       this.errorMatcher.setHasErrors(true);
     } else {
-      control?.setErrors(null);
+      this.errorMessage.set(null);
       this.errorMatcher.setHasErrors(false);
     }
   }


### PR DESCRIPTION
## Description
- Stop setting errors to control to void marking form as invalid
- Use error manager of upload input component
- Fixed a style issue when errors were shown


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


