### PR TITLE
fix(feature-flags): restrict v2 toggle to admins and add query param …

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -27,7 +27,10 @@ export const appConfig: ApplicationConfig = {
       const featureFlags = inject(FeatureFlagsService);
 
       await authService.init();
-      await firstValueFrom(featureFlags.loadFlags());
+
+      if (authService.isAuthenticated()) {
+        await firstValueFrom(featureFlags.loadFlags());
+      }
     }),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),

--- a/src/app/core/components/feature-flags/feature-flags.service.ts
+++ b/src/app/core/components/feature-flags/feature-flags.service.ts
@@ -4,6 +4,7 @@ import { map, tap, Observable, catchError, of } from 'rxjs';
 import { Router } from '@angular/router';
 import { FEATURE_FLAGS } from './feature-flags';
 import { environment } from 'src/environments/environment';
+import { UserDataService } from '@core/services/access/user-data.service';
 
 interface FeatureFlag {
   id: number;
@@ -12,27 +13,37 @@ interface FeatureFlag {
 }
 
 /**
- * Service responsible for evaluating feature flags based on URL query parameters.
+ * Service responsible for evaluating feature flags.
  *
  * Behavior:
- * 1.In production, feature flags are restricted and cannot be arbitrarily enabled.
- * 2.In non-production environments, feature flags can be toggled via query params
- *   for testing and validation purposes.
- *
- * Example:
- *   ?newSection=true or ?newSection=false.
+ * 1. Flags are controlled by the backend (toggle in the user menu, admin-only),
+ *    but that value only applies to admin users.
+ * 2. Non-admin users always default to v1, regardless of the backend value,
+ *    unless overridden via query params (see below).
+ * 3. Any user can force-enable v2 for their own session via `?v2=true`,
+ *    or an individual flag via `?flagName=true`. This works for any role
+ *    and takes precedence over both the backend value and the admin check.
  */
 
 @Injectable({ providedIn: 'root' })
 export class FeatureFlagsService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
+  private readonly userData = inject(UserDataService);
   private readonly baseUrl = environment.apiUrl + '/api/v1/feature-flags';
 
   private _flags = signal<Record<string, boolean>>({});
   flags = computed(() => this._flags());
 
   private _flagMeta = signal<FeatureFlag[]>([]);
+
+  private queryParams = computed(() => {
+    return this.router.routerState.root.snapshot.queryParams;
+  });
+
+  private isAdminUser = computed(
+    () => this.userData.user()?.role === 'Eras Admin'
+  );
 
   loadFlags(): Observable<void> {
     return this.http.get<FeatureFlag[]>(this.baseUrl).pipe(
@@ -56,6 +67,13 @@ export class FeatureFlagsService {
   }
 
   isEnabled(flag: string): boolean {
+    const params = this.queryParams();
+
+    if (params['v2'] === 'true') return true;
+    if (params[flag] === 'true') return true;
+
+    if (!this.isAdminUser()) return false;
+
     return this._flags()[flag] ?? false;
   }
 

--- a/src/app/core/interceptors/keycloak-interceptor.ts
+++ b/src/app/core/interceptors/keycloak-interceptor.ts
@@ -24,7 +24,7 @@ export const keycloakHttpInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(authReq).pipe(
     catchError((error: HttpErrorResponse) => {
-      if (error.status === 401) {
+      if (error.status === 401 && authService.isAuthenticated()) {
         return authService.handleRefresh(authReq, next);
       }
       return throwError(() => error);

--- a/src/app/core/services/access/access.service.ts
+++ b/src/app/core/services/access/access.service.ts
@@ -1,7 +1,8 @@
-import { HttpHandlerFn, HttpRequest } from '@angular/common/http';
+import { HttpEvent, HttpHandlerFn, HttpRequest } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 
 import Keycloak from 'keycloak-js';
+import { from, switchMap, Observable } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
 
@@ -9,6 +10,7 @@ import { environment } from 'src/environments/environment';
 export class AuthService {
   private keycloak = inject(Keycloak);
   private isInitialized = false;
+  private isLoggingOut = false;
   private TOKEN_KEY = 'keycloak_token';
   // TODO: save tokens on a more secure place, e.g. httpOnly cookies
   private REFRESH_TOKEN_KEY = 'keycloak_refreshToken';
@@ -58,31 +60,35 @@ export class AuthService {
   }
 
   logout() {
+    if (this.isLoggingOut) return;
+
+    if (!this.keycloak.authenticated) {
+      this.clearTokens();
+      return;
+    }
+
+    this.isLoggingOut = true;
     this.clearTokens();
     this.keycloak.logout();
   }
 
-  updateToken() {
+  async updateToken(): Promise<boolean> {
     try {
-      this.keycloak.updateToken(this.UPDATE_TOKEN_TIME).then(refreshed => {
-        if (refreshed) {
-          this.storeTokens();
-        } else {
-          this.clearTokens();
-        }
+      const refreshed = await this.keycloak.updateToken(this.UPDATE_TOKEN_TIME);
 
-        return refreshed;
-      });
+      if (refreshed) {
+        this.storeTokens();
+      } else {
+        this.clearTokens();
+      }
 
-      return false;
+      return refreshed;
     } catch (error) {
       console.error(
         'An error has ocured while refreshing the access token',
         error
       );
-      this.logout();
       this.clearTokens();
-
       return false;
     }
   }
@@ -95,21 +101,24 @@ export class AuthService {
     return this.keycloak.refreshToken;
   }
 
-  handleRefresh(req: HttpRequest<unknown>, next: HttpHandlerFn) {
-    const isRefreshed = this.updateToken();
+  handleRefresh(
+    req: HttpRequest<unknown>,
+    next: HttpHandlerFn
+  ): Observable<HttpEvent<unknown>> {
+    return from(this.updateToken()).pipe(
+      switchMap(isRefreshed => {
+        if (isRefreshed) {
+          const accessToken = this.getAccessToken();
+          const retryReq = req.clone({
+            setHeaders: { Authorization: `Bearer ${accessToken}` },
+          });
+          return next(retryReq);
+        }
 
-    if (isRefreshed) {
-      const accessToken = this.getAccessToken();
-      const retryReq = req.clone({
-        setHeaders: { Authorization: `Bearer ${accessToken}` },
-      });
-      return next(retryReq);
-    }
-
-    this.logout();
-    this.clearTokens();
-
-    return next(req);
+        this.logout();
+        return next(req);
+      })
+    );
   }
 
   isAuthenticated() {

--- a/src/app/modules/lists/components/list-students-by-poll/list-students-by-poll.component.spec.ts
+++ b/src/app/modules/lists/components/list-students-by-poll/list-students-by-poll.component.spec.ts
@@ -4,6 +4,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ListStudentsByPollComponent } from './list-students-by-poll.component';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import Keycloak from 'keycloak-js';
 
 describe('ListStudentsByPollComponent', () => {
   const mockActivatedRoute = {
@@ -26,7 +27,10 @@ describe('ListStudentsByPollComponent', () => {
         HttpClientModule,
         BrowserAnimationsModule,
       ],
-      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: Keycloak, useValue: {} },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ListStudentsByPollComponent);

--- a/src/app/modules/reports/components/polls-answered/polls-answered.component.spec.ts
+++ b/src/app/modules/reports/components/polls-answered/polls-answered.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
+import Keycloak from 'keycloak-js';
 import { PollInstanceService } from '@core/services/api/poll-instance.service';
 import { CohortService } from '@core/services/api/cohort.service';
 import { PollService } from '@core/services/api/poll.service';
@@ -18,7 +19,7 @@ describe('PollsAnsweredComponent', () => {
   ]);
   const mockPollService = jasmine.createSpyObj('PollService', [
     'getPollsByCohortId',
-    'getAllPolls', // Se agregó el método faltante
+    'getAllPolls',
   ]);
 
   beforeEach(async () => {
@@ -39,6 +40,7 @@ describe('PollsAnsweredComponent', () => {
         { provide: PollInstanceService, useValue: mockPollInstanceService },
         { provide: CohortService, useValue: mockCohortService },
         { provide: PollService, useValue: mockPollService },
+        { provide: Keycloak, useValue: {} },
         provideNoopAnimations(),
         provideHttpClient(),
       ],

--- a/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.spec.ts
+++ b/src/app/modules/reports/components/summary-charts/risk-details/risk-details.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import RiskDetailsComponent from './risk-details.component';
 import { provideHttpClient } from '@angular/common/http';
+import Keycloak from 'keycloak-js';
 
 describe('RiskDetailsComponent', () => {
   let component: RiskDetailsComponent;
@@ -16,6 +17,7 @@ describe('RiskDetailsComponent', () => {
           useValue: { data: { riskGroup: { data: [] } } },
         },
         provideHttpClient(),
+        { provide: Keycloak, useValue: {} },
       ],
     }).compileComponents();
 

--- a/src/app/modules/students/students-list/students-list.component.spec.ts
+++ b/src/app/modules/students/students-list/students-list.component.spec.ts
@@ -4,6 +4,7 @@ import { StudentsListComponent } from './students-list.component';
 import { HttpClientModule } from '@angular/common/http';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import Keycloak from 'keycloak-js';
 
 describe('StudentsListComponent', () => {
   const mockActivatedRoute = {
@@ -22,7 +23,10 @@ describe('StudentsListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [StudentsListComponent, HttpClientModule],
-      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: Keycloak, useValue: {} },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StudentsListComponent);

--- a/src/app/shared/components/modals/modal-question-details/modal-question-details.component.spec.ts
+++ b/src/app/shared/components/modals/modal-question-details/modal-question-details.component.spec.ts
@@ -14,6 +14,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ComponentValueType } from '@core/models/types/risk-students-detail.type';
 import { EvaluationDetailsService } from '@core/services/api/evaluation-details.service';
 import { provideHttpClient } from '@angular/common/http';
+import Keycloak from 'keycloak-js';
 
 describe('ModalQuestionDetailsComponent', () => {
   let component: ModalQuestionDetailsComponent;
@@ -75,6 +76,7 @@ describe('ModalQuestionDetailsComponent', () => {
       ],
       providers: [
         provideHttpClient(),
+        { provide: Keycloak, useValue: {} },
         {
           provide: MAT_DIALOG_DATA,
           useValue: mockDialogData,


### PR DESCRIPTION
## Description

Add ?v2=true / ?flag=true query param override to isEnabled(), allowing any user (including non-admins) to force-enable v2 or a specific flag for their own session via URL, without affecting the global backend toggle

Fix infinite reload loop on logout 

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


