### PR TITLE
Fix/fe 953/assessments dropdown issue

### DIFF
--- a/src/app/modules/assessments/components/interventions/interventions.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <app-list-filters
-    [filterFields]="filters"
+    [filterFields]="filters()"
     (appliedFilters)="handleFilters($event)"
   ></app-list-filters>
 

--- a/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
@@ -1,0 +1,134 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InterventionsComponent } from './interventions.component';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  AssessmentModel,
+  AssessmentStatus,
+} from '@core/models/assessment.model';
+import { AssessmentService } from '@core/services/api/assessement.service';
+import { of } from 'rxjs';
+import {
+  AppliedFilter,
+  FilterName,
+} from '@shared/components/list-filters/models/list-filters.interface';
+
+// Helpers
+const assessments: AssessmentModel[] = [
+  {
+    id: 1,
+    createdAtUtc: '2026-07-03T10:00:00Z',
+    createdBy: 'admin',
+    service: 'Support',
+    studentIds: ['103', '215'],
+    status: AssessmentStatus.Created,
+    interventions: [],
+  },
+  {
+    id: 2,
+    createdAtUtc: '2026-07-03T10:00:00Z',
+    createdBy: 'admin',
+    service: 'Counseling',
+    studentIds: ['108', '63'],
+    status: AssessmentStatus.InProgress,
+    interventions: [],
+  },
+  {
+    id: 3,
+    createdAtUtc: '2026-07-03T10:00:00Z',
+    createdBy: 'admin',
+    service: 'Psychology',
+    studentIds: ['2', '456'],
+    status: AssessmentStatus.Rejected,
+    interventions: [],
+  },
+];
+
+describe('InterventionsComponent', () => {
+  let component: InterventionsComponent;
+  let fixture: ComponentFixture<InterventionsComponent>;
+
+  let assessmentServiceSpy: jasmine.SpyObj<AssessmentService>;
+
+  beforeEach(async () => {
+    assessmentServiceSpy = jasmine.createSpyObj('AssessmentService', [
+      'getAll',
+    ]);
+
+    // Default AssessmentService.getAll value
+    assessmentServiceSpy.getAll.and.returnValue(of(assessments));
+
+    await TestBed.configureTestingModule({
+      imports: [InterventionsComponent],
+      providers: [provideHttpClient()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterventionsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should build assessment, type, and status filters once assessments load', () => {
+    fixture.detectChanges();
+
+    const filters = component.filters();
+    const assessmentFilter = filters.find(
+      f => f.name === FilterName.Assessment
+    );
+    const statusFilter = filters.find(f => f.name === FilterName.Status);
+    const typeFilter = filters.find(f => f.name === FilterName.Type);
+
+    expect(assessmentFilter).toBeDefined();
+    expect(statusFilter).toBeDefined();
+    expect(typeFilter).toBeDefined();
+  });
+
+  it('should build assessment options with the loaded assessments', () => {
+    component['allAssessments'].set(assessments);
+    fixture.detectChanges();
+
+    const filters = component.filters();
+    const assessmentFilter = filters.find(
+      f => f.name === FilterName.Assessment
+    );
+
+    expect(assessmentFilter).toBeDefined();
+    expect(assessmentFilter?.options?.length).toBe(assessments.length);
+    expect(assessmentFilter?.options?.[0].label).toBe(
+      '07/03/2026 – Support (Created)'
+    );
+    expect(assessmentFilter?.options?.[1].label).toBe(
+      '07/03/2026 – Counseling (In Progress)'
+    );
+    expect(assessmentFilter?.options?.[2].label).toBe(
+      '07/03/2026 – Psychology (Rejected)'
+    );
+  });
+
+  it('should set selectedAssessmentId when an Assessment filter with a value is present', () => {
+    component.handleFilters([{ name: FilterName.Assessment, value: 2 }]);
+
+    expect(component.selectedAssessmentId()).toBe(2);
+  });
+
+  it('should not change selectedAssessmentId if there is no Assessment filter', () => {
+    component.onAssessmentChange(1);
+    component.handleFilters([
+      { name: FilterName.Type, value: 'virtual-select' },
+    ]);
+
+    expect(component.selectedAssessmentId()).toBe(1);
+  });
+
+  it('should store the applied filters', () => {
+    const filters: AppliedFilter[] = [
+      { name: FilterName.Assessment, value: 2 },
+    ];
+    component.handleFilters(filters);
+
+    expect(component.appliedFilters()).toEqual(filters);
+  });
+});

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -6,6 +6,8 @@ import {
   signal,
   WritableSignal,
   ViewChild,
+  computed,
+  Signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
@@ -85,48 +87,25 @@ export class InterventionsComponent implements OnInit {
     [AssessmentStatus.Rejected]: 'Rejected',
   };
 
-  private readonly assessmentOptions = signal<SingleSelectItem[]>([]);
-  private readonly statusOptions = signal<MultipleSelectItem[]>([]);
-  private readonly typeOptions = signal<MultipleSelectItem[]>([]);
-
   readonly appliedFilters = signal<AppliedFilter[]>([]);
+  readonly filters: Signal<FilterField[]> = computed(() => {
+    const assessmentOptions = this._mapToOptionAssessments(
+      this.allAssessments()
+    );
+    const statusOptions = this._mapStatus();
+    const typeOptions = this._mapTypes();
 
-  filters: FilterField[] = [];
+    return this._buildFilters({
+      assessmentOptions,
+      statusOptions,
+      typeOptions,
+    });
+  });
 
   @ViewChild('interventionList') interventionList!: InterventionListComponent;
 
   ngOnInit(): void {
     this.loadAssessments();
-    this._buildFiltersOptions();
-    this.filters = [
-      {
-        name: FilterName.Assessment,
-        disabled: false,
-        label: 'Assessment',
-        type: FilterType.virtualSelect,
-        value: null,
-        options: this.assessmentOptions(),
-        validators: [Validators.required],
-      },
-      {
-        name: FilterName.Type,
-        disabled: false,
-        label: 'Type',
-        type: FilterType.virtualMultiSelect,
-        value: null,
-        options: this.typeOptions(),
-        validators: [Validators.required],
-      },
-      {
-        name: FilterName.Status,
-        disabled: false,
-        label: 'Status',
-        type: FilterType.virtualMultiSelect,
-        value: null,
-        options: this.statusOptions(),
-        validators: [Validators.required],
-      },
-    ];
   }
 
   handleFilters(filters: AppliedFilter[]) {
@@ -171,14 +150,44 @@ export class InterventionsComponent implements OnInit {
       });
   }
 
-  private _buildFiltersOptions() {
-    this.assessmentOptions.set(this._mapAssessments());
-    this.statusOptions.set(this._mapStatus());
-    this.typeOptions.set(this._mapTypes());
+  private _buildFilters(
+    filtersOptions: Record<string, SingleSelectItem[] | MultipleSelectItem[]>
+  ) {
+    return [
+      {
+        name: FilterName.Assessment,
+        disabled: false,
+        label: 'Assessment',
+        type: FilterType.virtualSelect,
+        value: null,
+        options: filtersOptions['assessmentOptions'],
+        validators: [Validators.required],
+      },
+      {
+        name: FilterName.Type,
+        disabled: false,
+        label: 'Type',
+        type: FilterType.virtualMultiSelect,
+        value: null,
+        options: filtersOptions['typeOptions'],
+        validators: [Validators.required],
+      },
+      {
+        name: FilterName.Status,
+        disabled: false,
+        label: 'Status',
+        type: FilterType.virtualMultiSelect,
+        value: null,
+        options: filtersOptions['statusOptions'],
+        validators: [Validators.required],
+      },
+    ];
   }
 
-  private _mapAssessments(): SingleSelectItem[] {
-    return this.allAssessments().map(assessment => {
+  private _mapToOptionAssessments(
+    assessments: AssessmentModel[]
+  ): SingleSelectItem[] {
+    return assessments.map(assessment => {
       const date = new Date(assessment.createdAtUtc);
       const dateStr = date.toLocaleDateString('en-US', {
         month: '2-digit',


### PR DESCRIPTION
## Description

Make filters reactive using `computed` signals depending on `allAssessment` signal.
Added unit tests related to filters in the `interventions` component.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


