### PR TITLE
Refactor: relocate evaluation processes section

### DIFF
--- a/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
+++ b/src/app/core/components/sidebar/sidebar v2/sidebar.model-v2.ts
@@ -5,15 +5,12 @@ export const SIDEBAR_MENUS_NEW: Menu[] = [
   {
     label: 'Students',
     icon: 'school',
-    children: [
-      {
-        label: 'Student Monitoring',
-        route: '/_unused/student-option',
-        forProduction: false,
-      },
-      { label: 'Evaluation Processes', route: '/evaluation-process' },
-      { label: 'Students List', route: '/students' },
-    ],
+    route: '/students',
+  },
+  {
+    label: 'Evaluation Processes',
+    icon: 'playlist_add_check',
+    route: '/evaluation-process',
   },
   {
     label: 'Reports',

--- a/src/app/modules/imports/components/import-preview/import-preview.component.ts
+++ b/src/app/modules/imports/components/import-preview/import-preview.component.ts
@@ -74,10 +74,11 @@ export class ImportPreviewComponent implements OnInit {
           this.importedPollData = data;
           this.loadingSubject.next(false);
           if (data.length < 1) {
-            this.dialogService.openDialog(
-              IMPORT_MESSAGES.ANSWERS_PREVIEW_EMPTY,
-              'success'
-            );
+            this.dialogService
+              .openDialog(IMPORT_MESSAGES.ANSWERS_PREVIEW_EMPTY, 'success')
+              .subscribe(() => {
+                this.router.navigate(['/evaluation-process']);
+              });
           } else {
             this.dialogService.openDialog(
               IMPORT_MESSAGES.ANSWERS_PREVIEW_OK,


### PR DESCRIPTION
## Description

- The route of the evaluation process was removed from the Students section and moved to a new tab in the sideNavBar.
- Fixed the redirection issue that occurred when trying to import an evaluation without data (answers). Clicking the "Ok" button now redirects to the previous page.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#949 
