### PR TITLE
Refactor: update of status and attendance in interventions and assessments

### DIFF
--- a/src/app/core/factories/forms/form-factory.interface.ts
+++ b/src/app/core/factories/forms/form-factory.interface.ts
@@ -2,7 +2,7 @@ import { FormGroup, ValidatorFn } from '@angular/forms';
 import { EventEmitter, InputSignal } from '@angular/core';
 
 import { FormUtils } from '@core/utils/forms/form-utils';
-import { Lookup } from '@core/models/lookup';
+import { Lookup, LookupExtended } from '@core/models/lookup';
 import { FloatLabelType } from '@angular/material/form-field';
 
 export type FieldType =
@@ -40,7 +40,7 @@ export interface DynamicField {
   placeholder?: string;
   validators?: (ValidatorFn | string)[];
   value?: ValueType;
-  options?: Lookup[];
+  options?: (Lookup | LookupExtended)[];
   multipleSelect?: boolean;
   disabled?: boolean;
   floatingLabel?: FloatLabelType;

--- a/src/app/core/factories/forms/select-input/select-input.component.ts
+++ b/src/app/core/factories/forms/select-input/select-input.component.ts
@@ -20,6 +20,7 @@ import {
   ALERT_RISK_COLORS,
   ALERT_RISK_LABEL_COLORS,
 } from '@core/constants/alertRiskLevel';
+import { LookupExtended } from '@core/models/lookup';
 
 @Component({
   selector: 'app-select-input',
@@ -51,6 +52,7 @@ export class SelectInputComponent implements DynamicInputComponent {
     ),
     { initialValue: null }
   );
+
   selectedOption = computed(() => {
     const value = this.fieldValue();
     return this.field().options?.find(o => o.value === value);
@@ -61,10 +63,18 @@ export class SelectInputComponent implements DynamicInputComponent {
   }
 
   getRiskLevelColor(level: string): string {
-    return ALERT_RISK_COLORS[level] ?? ALERT_RISK_COLORS['default'];
+    const optionWithColor = this.selectedOption();
+    if ((optionWithColor as LookupExtended).colors !== undefined) {
+      return (optionWithColor as LookupExtended).colors.background;
+    }
+    return ALERT_RISK_COLORS[level];
   }
 
   getRiskLevelLabelColor(level: string): string {
+    const optionWithColor = this.selectedOption();
+    if ((optionWithColor as LookupExtended).colors !== undefined) {
+      return (optionWithColor as LookupExtended).colors.label;
+    }
     return ALERT_RISK_LABEL_COLORS[level] ?? ALERT_RISK_LABEL_COLORS['default'];
   }
 }

--- a/src/app/core/models/assessment.model.ts
+++ b/src/app/core/models/assessment.model.ts
@@ -49,6 +49,7 @@ export interface InterventionModel {
   attachments?: string[] | null;
   uploadInput?: File[] | null;
   riskLevelName?: string;
+  endRiskLevelName?: InterventionStatus;
 }
 
 export interface InterventionAttendanceModel {

--- a/src/app/core/models/lookup.ts
+++ b/src/app/core/models/lookup.ts
@@ -2,3 +2,10 @@ export interface Lookup {
   label: string;
   value: string | number;
 }
+
+export interface LookupExtended extends Lookup {
+  colors: {
+    label: string;
+    background: string;
+  };
+}

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
@@ -89,6 +89,7 @@
                     mat-icon-button
                     type="button"
                     matTooltip="Edit"
+                    [disabled]="item.status === 'Finalized'"
                     (click)="onEditClick(item)"
                   >
                     <mat-icon>edit</mat-icon>
@@ -131,6 +132,7 @@
                     <button
                       mat-menu-item
                       type="button"
+                      [disabled]="item.status === 'Finalized'"
                       (click)="onEditClick(item)"
                     >
                       <mat-icon>edit</mat-icon><span>Edit</span>

--- a/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
@@ -19,10 +19,7 @@ import {
   DynamicField,
   FormCreation,
 } from '@core/factories/forms/form-factory.interface';
-import {
-  AssessmentModel,
-  AssessmentStatus,
-} from '@core/models/assessment.model';
+import { AssessmentModel } from '@core/models/assessment.model';
 import { ToastNotificationData } from '@core/models/toast-notification.model';
 import { AssessmentService } from '@core/services/api/assessement.service';
 import { ToastNotificationService } from '@core/services/toast-notification.service';
@@ -32,6 +29,36 @@ import {
   EditAssessmentModel,
 } from '@modules/assessments/models/assessments.interfaces';
 import { Subscription } from 'rxjs';
+
+const STATUS_OPTIONS = [
+  {
+    value: 'Remitted',
+    label: 'Remitted',
+    allowed: ['Remitted'],
+    colors: {
+      label: '#333399',
+      background: '#cdcde1',
+    },
+  },
+  {
+    value: 'InProgress',
+    label: 'InProgress',
+    allowed: ['Remitted', 'InProgress'],
+    colors: {
+      label: '#854d0e',
+      background: '#fef9c3',
+    },
+  },
+  {
+    value: 'Finalized',
+    label: 'Finalized',
+    allowed: ['InProgress'],
+    colors: {
+      label: '#117473',
+      background: '#afeae9',
+    },
+  },
+];
 
 @Component({
   selector: 'app-edit-assessment-modal',
@@ -62,6 +89,7 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
       service: data.assessment.service,
       students: data.assessment.studentIds,
       submitter: data.assessment.createdBy,
+      status: data.assessment.status,
     };
 
     this.formFields = [
@@ -84,6 +112,20 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         validators: [Validators.required],
         floatingLabel: 'always',
         value: this.data.assessment.createdAtUtc,
+      },
+      {
+        type: 'select',
+        name: 'status',
+        label: 'Status',
+        options: STATUS_OPTIONS.filter(s =>
+          s.allowed.includes(data.assessment.status)
+        ),
+        validators: [Validators.required],
+        floatingLabel: 'always',
+        selectConfig: {
+          displayMode: 'chips',
+        },
+        value: this.data.assessment.status,
       },
       {
         type: 'select',
@@ -153,7 +195,7 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         assignedProfessional: this.form.value.professional,
         studentIds: this.form.value.students,
         comments: this.form.value.professionalComment,
-        status: AssessmentStatus.Remitted,
+        status: this.form.value.status,
         interventions: [],
       };
 

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.html
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h2 mat-dialog-title>
-    {{ isEditMode ? 'Edit Intervention' : 'New Intervention' }}
+    {{ 'Edit Intervention' }}
   </h2>
   <mat-icon mat-dialog-close>close</mat-icon>
 </div>
@@ -57,7 +57,7 @@
       [disabled]="isSubmitDisabled"
       (click)="submitIntervention()"
     >
-      {{ isEditMode ? 'Save' : 'Create' }}
+      {{ 'Save' }}
     </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.html
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h2 mat-dialog-title>
-    {{ 'New Intervention' }}
+    {{ isEditMode ? 'Edit Intervention' : 'New Intervention' }}
   </h2>
   <mat-icon mat-dialog-close>close</mat-icon>
 </div>
@@ -57,7 +57,7 @@
       [disabled]="isSubmitDisabled"
       (click)="submitIntervention()"
     >
-      {{ 'Create' }}
+      {{ isEditMode ? 'Save' : 'Create' }}
     </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.scss
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.scss
@@ -1,0 +1,140 @@
+.file-upload-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-upload-label {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.file-upload-hint {
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.file-upload-actions {
+  display: flex;
+  align-items: center;
+}
+
+.file-upload-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--primary-color, #00796b);
+  border: 1px dashed var(--primary-color, #00796b);
+  border-radius: 6px;
+  padding: 8px 16px;
+  transition: background-color 0.2s;
+
+  &:hover:not(.disabled) {
+    background-color: rgba(0, 121, 107, 0.06);
+  }
+
+  &.disabled {
+    color: rgba(0, 0, 0, 0.26);
+    border-color: rgba(0, 0, 0, 0.26);
+    cursor: not-allowed;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 13px;
+}
+
+.file-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.file-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-size {
+  color: rgba(0, 0, 0, 0.4);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.file-remove-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: rgba(0, 0, 0, 0.4);
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.file-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+mat-dialog-content {
+  padding-bottom: 50px;
+}
+
+.form-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-bottom: 8px;
+}
+
+.student-info-readonly {
+  display: flex !important;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  margin-top: 16px !important;
+}
+
+.attendance-section {
+  margin-top: 8px !important;
+}

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.spec.ts
@@ -1,0 +1,199 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditInterventionModalComponent } from './edit-intervention-modal.component';
+import { InterventionService } from '@core/services/api/intervention.service';
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import {
+  InterventionStatus,
+  InterventionType,
+} from '@core/models/assessment.model';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+describe('EditInterventionModalComponent', () => {
+  let component: EditInterventionModalComponent;
+  let fixture: ComponentFixture<EditInterventionModalComponent>;
+  let interventionService: jasmine.SpyObj<InterventionService>;
+  let toastService: jasmine.SpyObj<ToastNotificationService>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<EditInterventionModalComponent>>;
+
+  const dialogData = {
+    assessmentId: 1,
+    professional: {
+      label: 'John Doe',
+      value: '10',
+    },
+    students: [
+      {
+        label: 'Student 1',
+        value: '1',
+      },
+      {
+        label: 'Student 2',
+        value: '2',
+      },
+    ],
+    intervention: {
+      id: 100,
+      kind: InterventionType.Group,
+      studentIds: [1, 2],
+      activity: 'Activity',
+      area: 'Area',
+      mode: 'Online',
+      comments: 'Some comments',
+      riskLevelName: 'Low',
+      status: 'Remitted',
+      endRiskLevelName: '',
+      attachments: ['folder/file1.pdf', 'folder/file2.pdf'],
+      attendance: {
+        1: true,
+        2: false,
+      },
+      dateUtc: '2024-01-01',
+    },
+  };
+
+  beforeEach(async () => {
+    interventionService = jasmine.createSpyObj('InterventionService', [
+      'deleteAttachment',
+      'getByAssessment',
+      'upsertInterventions',
+      'uploadAttachments',
+    ]);
+
+    toastService = jasmine.createSpyObj('ToastNotificationService', [
+      'showToast',
+    ]);
+
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    interventionService.getByAssessment.and.returnValue(of([]));
+    interventionService.upsertInterventions.and.returnValue(of([]));
+    interventionService.uploadAttachments.and.returnValue(of(['']));
+
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, EditInterventionModalComponent],
+      providers: [
+        {
+          provide: InterventionService,
+          useValue: interventionService,
+        },
+        {
+          provide: ToastNotificationService,
+          useValue: toastService,
+        },
+        {
+          provide: MatDialogRef,
+          useValue: dialogRef,
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: dialogData,
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(EditInterventionModalComponent);
+    component = fixture.componentInstance;
+
+    component.setFormGroup(
+      new FormGroup({
+        type: new FormControl(InterventionType.Group),
+        students: new FormControl(['1', '2']),
+        date: new FormControl('2024-01-01'),
+        activity: new FormControl('Activity'),
+        area: new FormControl('Area'),
+        mode: new FormControl('Online'),
+        comments: new FormControl('comments'),
+        uploadInput: new FormControl([]),
+        riskLevelName: new FormControl('Low'),
+        status: new FormControl('Remitted'),
+      })
+    );
+
+    fixture.detectChanges();
+  });
+
+  it('should initialize initial data', () => {
+    component.ngOnInit();
+    expect(component.isGroup()).toBeTrue();
+    expect(component.existingAttachments.length).toBe(2);
+  });
+
+  it('should update attendance', () => {
+    component.onAttendanceChange(['2']);
+
+    expect(component.attendedStudentIds()).toEqual(['2']);
+    expect(component.form.dirty).toBeTrue();
+  });
+
+  it('should remove attachment', () => {
+    component.removeExistingAttachment(0);
+
+    expect(component.existingAttachments.length).toBe(1);
+    expect(component.attachmentsToDelete).toEqual(['file1.pdf']);
+  });
+
+  it('should add end risk level', () => {
+    component['addEndRiskLevelField']();
+
+    expect(component.form.contains('endRiskLevelName')).toBeTrue();
+  });
+
+  it('should remove end risk level', () => {
+    component['addEndRiskLevelField']();
+
+    component['removeEndRiskLevelField']();
+
+    expect(component.form.contains('endRiskLevelName')).toBeFalse();
+  });
+
+  it('should update successfully', () => {
+    component['updateIntervention']();
+
+    expect(interventionService.getByAssessment).toHaveBeenCalled();
+    expect(interventionService.upsertInterventions).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+    expect(toastService.showToast).toHaveBeenCalled();
+  });
+
+  it('should handle update error', () => {
+    interventionService.getByAssessment.and.returnValue(
+      throwError(() => ({
+        statusText: 'Bad Request',
+        error: {
+          title: 'Failure',
+        },
+      }))
+    );
+
+    component['updateIntervention']();
+
+    expect(toastService.showToast).toHaveBeenCalled();
+  });
+
+  it('should allow only Remitted and In Progress when current status is Remitted', () => {
+    component.data.intervention!.status = InterventionStatus.Remitted;
+
+    component.ngOnInit();
+
+    const statusField = component.formFields.find(f => f.name === 'status');
+
+    expect(statusField!.options!.map(o => o.value)).toEqual([
+      'Remitted',
+      'InProgress',
+    ]);
+  });
+
+  it('should allow only Finalized and In Progress when current status is In Progress', () => {
+    component.data.intervention!.status = InterventionStatus.InProgress;
+
+    component.ngOnInit();
+
+    const statusField = component.formFields.find(f => f.name === 'status');
+
+    expect(statusField!.options!.map(o => o.value)).toEqual([
+      'InProgress',
+      'Finalized',
+    ]);
+  });
+});

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
@@ -180,10 +180,6 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
     return !this.form || this.form.invalid || this.form.pristine;
   }
 
-  get isEditMode(): boolean {
-    return !!this.data.intervention;
-  }
-
   constructor(
     public dialogRef: MatDialogRef<EditInterventionModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewInterventionDialogData

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
@@ -29,10 +29,7 @@ import {
   DynamicField,
   FormCreation,
 } from '@core/factories/forms/form-factory.interface';
-import {
-  InterventionMode,
-  InterventionType,
-} from '@core/models/assessment.model';
+import { InterventionType } from '@core/models/assessment.model';
 import {
   AddInterventionPayload,
   InterventionService,
@@ -43,82 +40,19 @@ import { MatSelectModule } from '@angular/material/select';
 import { InterventionModel } from '@core/models/assessment.model';
 import { of, concatMap, Observable, forkJoin } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
-const ALLOWED_MIME_TYPES = [
-  'application/pdf',
-  'image/jpeg',
-  'image/png',
-  'text/plain',
-];
-const ALLOWED_EXTENSIONS = '.pdf,.jpg,.png,.txt';
-const MAX_FILES = 2;
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-
-const TYPE_OPTIONS = [
-  { value: 'Individual', label: 'Individual' },
-  { value: 'Group', label: 'Group' },
-];
-
-const RISK_OPTIONS = [
-  { value: 'Low', label: 'Low', color: 'success' },
-  { value: 'Medium', label: 'Medium', color: 'warning' },
-  { value: 'High', label: 'High', color: 'danger' },
-];
-
-const STATUS_OPTIONS = [
-  {
-    value: 'Remitted',
-    label: 'Remitted',
-    allowed: ['Remitted'],
-    colors: {
-      label: '#333399',
-      background: '#cdcde1',
-    },
-  },
-  {
-    value: 'InProgress',
-    label: 'InProgress',
-    allowed: ['Remitted', 'InProgress'],
-    colors: {
-      label: '#854d0e',
-      background: '#fef9c3',
-    },
-  },
-  {
-    value: 'Finalized',
-    label: 'Finalized',
-    allowed: ['InProgress'],
-    colors: {
-      label: '#117473',
-      background: '#afeae9',
-    },
-  },
-];
-
-const ACTIVITY_OPTIONS = [
-  { value: 'tutoring', label: 'Tutoring' },
-  { value: 'counseling', label: 'Counseling' },
-  { value: 'workshop', label: 'Workshop' },
-  { value: 'mentoring', label: 'Mentoring' },
-];
-
-const AREA_OPTIONS = [
-  { value: 'academic', label: 'Academic' },
-  { value: 'social', label: 'Social' },
-  { value: 'emotional', label: 'Emotional' },
-  { value: 'vocational', label: 'Vocational' },
-];
-
-const MODE_OPTIONS = [
-  { value: InterventionMode.InPlace, label: 'In place' },
-  { value: InterventionMode.Remote, label: 'Remote' },
-];
-
-export interface StudentLookup {
-  value: number;
-  label: string;
-  riskLevel?: number;
-}
+import {
+  ACTIVITY_OPTIONS,
+  ALLOWED_EXTENSIONS,
+  ALLOWED_MIME_TYPES,
+  AREA_OPTIONS,
+  MAX_FILE_SIZE_BYTES,
+  MAX_FILES,
+  MODE_OPTIONS,
+  RISK_OPTIONS,
+  STATUS_OPTIONS,
+  StudentLookup,
+  TYPE_OPTIONS,
+} from '../interventions.constants';
 
 export interface NewInterventionDialogData {
   assessmentId: number;
@@ -168,14 +102,6 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
   attendedStudentIds = signal<string[]>([]);
 
   readonly numberOfParticipants = computed(() => this.data.students.length);
-
-  readonly selectedStudentCount = computed(() => {
-    if (!this.isGroup()) return 1;
-    if (!this.form || !this.form.get('students'))
-      return this.data.students.length;
-    const selected = (this.form.get('students')?.value as string[]) ?? [];
-    return selected.length || this.data.students.length;
-  });
 
   get isSubmitDisabled(): boolean {
     return !this.form || this.form.invalid || this.form.pristine;
@@ -511,10 +437,6 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
         endRiskLevelName: v.endRiskLevelName,
       },
     };
-  }
-
-  closeAndResetDialog(): void {
-    this.dialogRef.close();
   }
 
   private updateIntervention(): void {

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
@@ -11,6 +11,7 @@ import {
   DestroyRef,
 } from '@angular/core';
 import {
+  FormControl,
   FormGroup,
   FormsModule,
   ReactiveFormsModule,
@@ -373,6 +374,22 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
         this.buildAttendance();
         this.buildFormFields();
       });
+
+    this.form
+      .get('status')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(value => {
+        const isFinalized = value === 'Finalized';
+        const control = this.form.get('riskLevelName');
+
+        if (isFinalized) {
+          control?.disable();
+          this.addEndRiskLevelField();
+        } else {
+          control?.enable();
+          this.removeEndRiskLevelField();
+        }
+      });
   }
 
   private prefillForm(): void {
@@ -491,6 +508,7 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
         attachments: [],
         riskLevelName: v.riskLevelName,
         status: v.status,
+        endRiskLevelName: v.endRiskLevelName,
       },
     };
   }
@@ -582,5 +600,44 @@ export class EditInterventionModalComponent implements FormCreation, OnInit {
       this.existingAttachments.map(path => this.getFileName(path))
     );
     return uploadInputValue.filter(file => !existingNames.has(file.name));
+  }
+
+  private addEndRiskLevelField(): void {
+    if (this.form.contains('endRiskLevelName')) return;
+
+    this.form.addControl(
+      'endRiskLevelName',
+      new FormControl(
+        {
+          value: this.data.intervention?.endRiskLevelName ?? '',
+          disabled: false,
+        },
+        [Validators.required]
+      )
+    );
+
+    if (!this.formFields.some(f => f.name === 'endRiskLevelName')) {
+      this.formFields = [
+        ...this.formFields,
+        {
+          type: 'select',
+          name: 'endRiskLevelName',
+          label: 'End Risk Level',
+          validators: [Validators.required],
+          options: RISK_OPTIONS,
+          floatingLabel: 'always',
+          selectConfig: { displayMode: 'chips' },
+        },
+      ];
+    }
+  }
+
+  private removeEndRiskLevelField(): void {
+    if (this.form.contains('endRiskLevelName')) {
+      this.form.removeControl('endRiskLevelName');
+    }
+    this.formFields = this.formFields.filter(
+      f => f.name !== 'endRiskLevelName'
+    );
   }
 }

--- a/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/edit-intervention-modal/edit-intervention-modal.component.ts
@@ -28,7 +28,6 @@ import {
   DynamicField,
   FormCreation,
 } from '@core/factories/forms/form-factory.interface';
-import { ToastNotificationData } from '@core/models/toast-notification.model';
 import {
   InterventionMode,
   InterventionType,
@@ -41,7 +40,7 @@ import { ToastNotificationService } from '@core/services/toast-notification.serv
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { InterventionModel } from '@core/models/assessment.model';
-import { map, of, concatMap } from 'rxjs';
+import { of, concatMap, Observable, forkJoin } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 const ALLOWED_MIME_TYPES = [
@@ -63,6 +62,36 @@ const RISK_OPTIONS = [
   { value: 'Low', label: 'Low', color: 'success' },
   { value: 'Medium', label: 'Medium', color: 'warning' },
   { value: 'High', label: 'High', color: 'danger' },
+];
+
+const STATUS_OPTIONS = [
+  {
+    value: 'Remitted',
+    label: 'Remitted',
+    allowed: ['Remitted'],
+    colors: {
+      label: '#333399',
+      background: '#cdcde1',
+    },
+  },
+  {
+    value: 'InProgress',
+    label: 'InProgress',
+    allowed: ['Remitted', 'InProgress'],
+    colors: {
+      label: '#854d0e',
+      background: '#fef9c3',
+    },
+  },
+  {
+    value: 'Finalized',
+    label: 'Finalized',
+    allowed: ['InProgress'],
+    colors: {
+      label: '#117473',
+      background: '#afeae9',
+    },
+  },
 ];
 
 const ACTIVITY_OPTIONS = [
@@ -98,7 +127,7 @@ export interface NewInterventionDialogData {
 }
 
 @Component({
-  selector: 'app-new-intervention-modal',
+  selector: 'app-edit-intervention-modal',
   imports: [
     FormsModule,
     FormFactoryComponent,
@@ -111,14 +140,18 @@ export interface NewInterventionDialogData {
     NgFor,
     ReactiveFormsModule,
   ],
-  templateUrl: './new-intervention-modal.component.html',
-  styleUrl: '../../../styles/assessments-modal-styles.scss',
+  templateUrl: './edit-intervention-modal.component.html',
+  styleUrls: [
+    '../../../styles/assessments-modal-styles.scss',
+    './edit-intervention-modal.component.scss',
+  ],
 })
-export class NewInterventionModalComponent implements FormCreation, OnInit {
+export class EditInterventionModalComponent implements FormCreation, OnInit {
   private readonly interventionService = inject(InterventionService);
   private readonly toastService = inject(ToastNotificationService);
   private readonly destroyRef = inject(DestroyRef);
 
+  private _prefillValues: Record<string, unknown> = {};
   existingAttachments: string[] = [];
   attachmentsToDelete: string[] = [];
   attendedStudentIdsModel: string[] = [];
@@ -147,14 +180,18 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
     return !this.form || this.form.invalid || this.form.pristine;
   }
 
+  get isEditMode(): boolean {
+    return !!this.data.intervention;
+  }
+
   constructor(
-    public dialogRef: MatDialogRef<NewInterventionModalComponent>,
+    public dialogRef: MatDialogRef<EditInterventionModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NewInterventionDialogData
   ) {}
 
   ngOnInit(): void {
-    this.isGroup.set(this.data.students.length > 1);
-    this.buildAttendance();
+    this.isGroup.set(this.data.intervention!.kind === InterventionType.Group);
+    this.prefillForm();
     this.buildFormFields();
   }
 
@@ -165,8 +202,8 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
       : InterventionType.Individual;
 
     const defaultStudentIds = this.isGroup()
-      ? this.data.students.map(s => s.value)
-      : [this.data.students[0]?.value];
+      ? this.data.intervention!.studentIds
+      : [this.data.intervention!.studentIds[0]];
     this.studentsSelected.set(defaultStudentIds);
 
     const topFields: DynamicField[] = [
@@ -232,7 +269,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
       selectConfig: {
         displayMode: 'chips',
       },
-      value: this.data.students.map(s => s.value),
+      value: this.data.intervention!.studentIds,
     };
 
     const studentsIndividualField: DynamicField = {
@@ -243,7 +280,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
       options: this.data.students,
       validators: [Validators.required],
       floatingLabel: 'always',
-      value: this.data.students[0]?.value,
+      value: this.data.intervention!.studentIds[0],
     };
 
     const bottomFields: DynamicField[] = [
@@ -258,6 +295,20 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
           displayMode: 'chips',
         },
         value: RISK_OPTIONS.at(1)?.label,
+      },
+      {
+        type: 'select',
+        name: 'status',
+        label: 'Status',
+        options: STATUS_OPTIONS.filter(s =>
+          s.allowed.includes(this.data.intervention!.status ?? '')
+        ),
+        validators: [Validators.required],
+        floatingLabel: 'always',
+        selectConfig: {
+          displayMode: 'chips',
+        },
+        value: this.data.intervention!.status,
       },
       {
         type: 'select',
@@ -281,7 +332,9 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
           allowedExtensions: ALLOWED_EXTENSIONS,
           allowedMimeTypes: ALLOWED_MIME_TYPES,
           onFileRemoved: fileIndex => this.removeExistingAttachment(fileIndex),
-          prefillFileNames: [],
+          prefillFileNames: (this.data.intervention!.attachments ?? []).map(p =>
+            this.getFileName(p)
+          ),
         },
         floatingLabel: 'always',
       },
@@ -310,6 +363,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
 
   setFormGroup(event: FormGroup): void {
     this.form = event;
+    this.form.patchValue(this._prefillValues);
 
     this.form
       .get('type')
@@ -323,6 +377,31 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
         this.buildAttendance();
         this.buildFormFields();
       });
+  }
+
+  private prefillForm(): void {
+    const iv = this.data.intervention!;
+
+    this._prefillValues = {
+      type: iv.kind,
+      date: iv.dateUtc,
+      activity: iv.activity,
+      area: iv.area,
+      mode: iv.mode,
+      comments: iv.comments,
+      uploadInput: (iv.attachments ?? []).map(p => this.getFileName(p)),
+      riskLevelName: iv.riskLevelName,
+      status: iv.status,
+    };
+
+    const attended = Object.entries(iv.attendance ?? {})
+      .filter(([, v]) => v)
+      .map(([k]) => String(k));
+
+    this.attendedStudentIds.set(attended);
+    this.attendedStudentIdsModel = attended;
+
+    this.existingAttachments = iv.attachments ?? [];
   }
 
   private buildAttendance(): void {
@@ -377,39 +456,8 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
       return;
     }
 
-    const payload = this.buildPayload();
-
-    this.interventionService
-      .createIntervention(payload)
-      .pipe(
-        concatMap((created: InterventionModel) => {
-          if (this.form.value.uploadInput.length === 0) return of(created);
-          return this.interventionService
-            .uploadAttachments(created.id!, this.form.value.uploadInput)
-            .pipe(map(() => created));
-        })
-      )
-      .subscribe({
-        next: () => {
-          const toast: ToastNotificationData = {
-            title: 'Intervention created successfully',
-            message: `The ${this.isGroup() ? 'group' : 'individual'} intervention has been registered.`,
-            type: 'success',
-          };
-          this.toastService.showToast(toast);
-        },
-        error: (err: HttpErrorResponse) => {
-          const toast: ToastNotificationData = {
-            title: 'Form Submission Failed',
-            message: `${err.statusText}: ${err.error?.title ?? 'There was an error submitting the form. Please try again later.'}`,
-            type: 'error',
-          };
-          this.toastService.showToast(toast, true);
-        },
-        complete: () => {
-          this.dialogRef.close(true);
-        },
-      });
+    this.updateIntervention();
+    return;
   }
 
   private buildPayload(): AddInterventionPayload {
@@ -446,12 +494,74 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
         attendance: attendanceRecord,
         attachments: [],
         riskLevelName: v.riskLevelName,
+        status: v.status,
       },
     };
   }
 
   closeAndResetDialog(): void {
     this.dialogRef.close();
+  }
+
+  private updateIntervention(): void {
+    const iv = this.data.intervention!;
+    const payload = this.buildPayload();
+    const updated: InterventionModel = {
+      ...iv,
+      ...payload.intervention,
+      id: iv.id,
+      attachments: this.existingAttachments,
+    } as InterventionModel;
+
+    const deleteObs: Observable<unknown> = this.attachmentsToDelete.length
+      ? forkJoin(
+          this.attachmentsToDelete.map(fileName =>
+            this.interventionService.deleteAttachment(iv.id!, fileName)
+          )
+        )
+      : of(null);
+
+    deleteObs
+      .pipe(
+        concatMap(() =>
+          this.interventionService.getByAssessment(this.data.assessmentId)
+        ),
+        concatMap((existing: InterventionModel[]) => {
+          const merged = existing.map(e => (e.id === iv.id ? updated : e));
+          return this.interventionService.upsertInterventions(
+            this.data.assessmentId,
+            merged
+          );
+        }),
+        concatMap(() => {
+          const filesToUpload = this.getNewFilesToUpload();
+          if (!filesToUpload.length) return of(null);
+          return this.interventionService.uploadAttachments(
+            iv.id!,
+            filesToUpload
+          );
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.toastService.showToast({
+            title: 'Intervention updated successfully',
+            message: 'The intervention has been updated.',
+            type: 'success',
+          });
+        },
+        error: (err: HttpErrorResponse) => {
+          this.toastService.showToast(
+            {
+              title: 'Update Failed',
+              message: `${err.statusText}: ${err.error?.title ?? 'There was an error updating the intervention.'}`,
+              type: 'error',
+            },
+            true
+          );
+        },
+        complete: () => this.dialogRef.close(true),
+      });
   }
 
   removeExistingAttachment(index: number): void {
@@ -466,5 +576,15 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
   getFileName(path: string): string {
     if (path === undefined) return '';
     return path.split('/').pop() ?? path;
+  }
+
+  private getNewFilesToUpload(): File[] {
+    const uploadInputValue = this.form.get('uploadInput')?.value as File[];
+    if (!uploadInputValue?.length) return [];
+
+    const existingNames = new Set(
+      this.existingAttachments.map(path => this.getFileName(path))
+    );
+    return uploadInputValue.filter(file => !existingNames.has(file.name));
   }
 }

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -136,6 +136,7 @@
                     mat-icon-button
                     type="button"
                     matTooltip="Edit"
+                    [disabled]="item.status === 'Finalized'"
                     (click)="onEditClick(item)"
                   >
                     <mat-icon>edit</mat-icon>
@@ -178,6 +179,7 @@
                     <button
                       mat-menu-item
                       type="button"
+                      [disabled]="item.status === 'Finalized'"
                       (click)="onEditClick(item)"
                     >
                       <mat-icon>edit</mat-icon><span>Edit</span>

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -39,12 +39,14 @@
     </div>
   </div>
 } @else {
-  <div class="page-header">
-    <button mat-flat-button type="button" (click)="onCreateClick()">
-      <mat-icon>add</mat-icon>
-      Create Intervention
-    </button>
-  </div>
+  @if (!statusFinalizedAssessment) {
+    <div class="page-header">
+      <button mat-flat-button type="button" (click)="onCreateClick()">
+        <mat-icon>add</mat-icon>
+        Create Intervention
+      </button>
+    </div>
+  }
 
   <div
     class="push-layout-container"
@@ -136,7 +138,9 @@
                     mat-icon-button
                     type="button"
                     matTooltip="Edit"
-                    [disabled]="item.status === 'Finalized'"
+                    [disabled]="
+                      item.status === 'Finalized' || statusFinalizedAssessment
+                    "
                     (click)="onEditClick(item)"
                   >
                     <mat-icon>edit</mat-icon>
@@ -153,6 +157,7 @@
                     mat-icon-button
                     type="button"
                     matTooltip="Delete"
+                    [disabled]="statusFinalizedAssessment"
                     (click)="onDeleteClick(item)"
                   >
                     <mat-icon>delete</mat-icon>
@@ -179,7 +184,9 @@
                     <button
                       mat-menu-item
                       type="button"
-                      [disabled]="item.status === 'Finalized'"
+                      [disabled]="
+                        item.status === 'Finalized' || statusFinalizedAssessment
+                      "
                       (click)="onEditClick(item)"
                     >
                       <mat-icon>edit</mat-icon><span>Edit</span>
@@ -187,6 +194,7 @@
                     <button
                       mat-menu-item
                       type="button"
+                      [disabled]="statusFinalizedAssessment"
                       (click)="onDeleteClick(item)"
                     >
                       <mat-icon>delete</mat-icon><span>Delete</span>

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -137,7 +137,6 @@ export class InterventionListComponent {
   }
 
   protected onEditClick(item: InterventionModel): void {
-    console.log('hihihihi', item);
     this.editClicked.emit(item);
   }
 

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -137,6 +137,7 @@ export class InterventionListComponent {
   }
 
   protected onEditClick(item: InterventionModel): void {
+    console.log('hihihihi', item);
     this.editClicked.emit(item);
   }
 

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -20,7 +20,10 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { InterventionPillBadgeComponent } from './intervention-status-badge/intervention-pill-badge.component';
 import { InterventionDetailComponent } from '../interventions-detail/intervention-detail.component';
-import { InterventionModel } from '@core/models/assessment.model';
+import {
+  AssessmentModel,
+  InterventionModel,
+} from '@core/models/assessment.model';
 import { InterventionService } from '@core/services/api/intervention.service';
 import {
   StudentProfileData,
@@ -28,6 +31,7 @@ import {
 } from '../../assessment-list/assessment-student-data/assessment-student-data.component';
 import { AppliedFilter } from '@shared/components/list-filters/models/list-filters.interface';
 import { InterventionFilterStrategy } from '@shared/components/list-filters/strategies/interventions.strategy';
+import { AssessmentService } from '@core/services/api/assessement.service';
 
 export interface InterventionRowViewModel extends InterventionModel {
   studentDisplay: StudentProfileData[] | string;
@@ -57,6 +61,7 @@ export interface InterventionRowViewModel extends InterventionModel {
 })
 export class InterventionListComponent {
   private readonly interventionService = inject(InterventionService);
+  private readonly assessmentService = inject(AssessmentService);
   private readonly filterStrategy = inject(InterventionFilterStrategy);
 
   @Input() pageSize = 10;
@@ -71,10 +76,15 @@ export class InterventionListComponent {
     this.assessmentId.set(value);
     if (value != null) {
       this.loadInterventions(value);
+      this.loadAssessment(value);
     } else {
       this.interventions.set([]);
+      this.assessment.set(null);
     }
   }
+
+  protected readonly assessment = signal<AssessmentModel | null>(null);
+  protected readonly isLoadingAssessment = signal(false);
 
   readonly appliedFilters = input<AppliedFilter[]>([]);
 
@@ -119,6 +129,10 @@ export class InterventionListComponent {
   });
 
   protected readonly hasInterventions = signal(false);
+
+  get statusFinalizedAssessment(): boolean {
+    return this.assessment()?.status === 'Finalized';
+  }
 
   protected onPageChange(event: PageEvent): void {
     this.pageIndex.set(event.pageIndex);
@@ -192,5 +206,21 @@ export class InterventionListComponent {
     return comments.length > 60
       ? `${comments.slice(0, 60).trim()}...`
       : comments;
+  }
+
+  private loadAssessment(assessmentId: number): void {
+    this.isLoadingAssessment.set(true);
+
+    this.assessmentService.getById(assessmentId.toString()).subscribe({
+      next: data => {
+        this.assessment.set(data);
+        this.isLoadingAssessment.set(false);
+      },
+      error: error => {
+        console.error('Failed to load assessment', error);
+        this.assessment.set(null);
+        this.isLoadingAssessment.set(false);
+      },
+    });
   }
 }

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -41,6 +41,7 @@ import {
   MultipleSelectItem,
   SingleSelectItem,
 } from '@shared/components/form-field-virtual-scroll/interfaces/select';
+import { EditInterventionModalComponent } from './edit-intervention-modal/edit-intervention-modal.component';
 
 @Component({
   selector: 'app-interventions',
@@ -279,7 +280,7 @@ export class InterventionsComponent implements OnInit {
     }));
 
     this.matDialog
-      .open(NewInterventionModalComponent, {
+      .open(EditInterventionModalComponent, {
         width: '520px',
         disableClose: true,
         data: {

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -42,6 +42,9 @@ import {
   SingleSelectItem,
 } from '@shared/components/form-field-virtual-scroll/interfaces/select';
 import { EditInterventionModalComponent } from './edit-intervention-modal/edit-intervention-modal.component';
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { ToastNotificationData } from '@core/models/toast-notification.model';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-interventions',
@@ -67,6 +70,7 @@ export class InterventionsComponent implements OnInit {
   private readonly matDialog = inject(MatDialog);
 
   private readonly interventionService = inject(InterventionService);
+  private readonly toastService = inject(ToastNotificationService);
 
   readonly isLoadingAssessments: WritableSignal<boolean> = signal(false);
   private readonly allAssessments: WritableSignal<AssessmentModel[]> = signal(
@@ -319,9 +323,44 @@ export class InterventionsComponent implements OnInit {
         this.interventionService
           .deleteIntervention(assessmentId, intervention.id!)
           .subscribe({
-            next: () => this.interventionList.loadInterventions(assessmentId),
-            error: err => console.error('Failed to delete intervention', err),
+            next: () => {
+              const toastData = this.buildSuccessToastDataObject(intervention);
+              this.toastService.showToast(toastData);
+              this.interventionList.loadInterventions(assessmentId);
+            },
+            error: err => {
+              const toastData = this.buildErrorToastDataObject(
+                intervention,
+                err
+              );
+              this.toastService.showToast(toastData, true);
+              console.error('Failed to delete intervention', err);
+            },
           });
       });
+  }
+  private buildSuccessToastDataObject(
+    item: InterventionModel
+  ): ToastNotificationData {
+    return {
+      title: 'Intervention removed successfully',
+      message: `Intervention with id: ${item.id} was removed`,
+      type: 'success',
+    };
+  }
+
+  private buildErrorToastDataObject(
+    item: InterventionModel,
+    error: HttpErrorResponse
+  ): ToastNotificationData {
+    const message =
+      item.status !== 'Remitted'
+        ? `The item with id: ${item.id} cannot be removed due to its status.`
+        : `${error.statusText}: The item was not found with id: ${item.id}`;
+    return {
+      title: 'Intervention removed failed',
+      message: message,
+      type: 'error',
+    };
   }
 }

--- a/src/app/modules/assessments/components/interventions/interventions.constants.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.constants.ts
@@ -1,0 +1,77 @@
+import { InterventionMode } from '@core/models/assessment.model';
+
+export const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'text/plain',
+];
+export const ALLOWED_EXTENSIONS = '.pdf,.jpg,.png,.txt';
+export const MAX_FILES = 2;
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+export const TYPE_OPTIONS = [
+  { value: 'Individual', label: 'Individual' },
+  { value: 'Group', label: 'Group' },
+];
+
+export const RISK_OPTIONS = [
+  { value: 'Low', label: 'Low', color: 'success' },
+  { value: 'Medium', label: 'Medium', color: 'warning' },
+  { value: 'High', label: 'High', color: 'danger' },
+];
+
+export const STATUS_OPTIONS = [
+  {
+    value: 'Remitted',
+    label: 'Remitted',
+    allowed: ['Remitted'],
+    colors: {
+      label: '#333399',
+      background: '#cdcde1',
+    },
+  },
+  {
+    value: 'InProgress',
+    label: 'InProgress',
+    allowed: ['Remitted', 'InProgress'],
+    colors: {
+      label: '#854d0e',
+      background: '#fef9c3',
+    },
+  },
+  {
+    value: 'Finalized',
+    label: 'Finalized',
+    allowed: ['InProgress'],
+    colors: {
+      label: '#117473',
+      background: '#afeae9',
+    },
+  },
+];
+
+export const ACTIVITY_OPTIONS = [
+  { value: 'tutoring', label: 'Tutoring' },
+  { value: 'counseling', label: 'Counseling' },
+  { value: 'workshop', label: 'Workshop' },
+  { value: 'mentoring', label: 'Mentoring' },
+];
+
+export const AREA_OPTIONS = [
+  { value: 'academic', label: 'Academic' },
+  { value: 'social', label: 'Social' },
+  { value: 'emotional', label: 'Emotional' },
+  { value: 'vocational', label: 'Vocational' },
+];
+
+export const MODE_OPTIONS = [
+  { value: InterventionMode.InPlace, label: 'In place' },
+  { value: InterventionMode.Remote, label: 'Remote' },
+];
+
+export interface StudentLookup {
+  value: number;
+  label: string;
+  riskLevel?: number;
+}

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.html
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.html
@@ -16,7 +16,9 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button mat-dialog-close class="cancel-button">Cancel</button>
+    <button mat-dialog-close class="cancel-button" [disabled]="isSubmitting">
+      Cancel
+    </button>
     <button
       class="action-button"
       type="submit"
@@ -24,7 +26,7 @@
       [disabled]="isSubmitDisabled"
       (click)="submitIntervention()"
     >
-      {{ 'Create' }}
+      {{ isSubmitting ? 'Creating...' : 'Create' }}
     </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.html
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.html
@@ -12,39 +12,6 @@
         [fields]="formFields"
         (formReady)="setFormGroup($event)"
       ></app-form-factory>
-
-      <div class="attendance-section">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Attendance</mat-label>
-          @if (isGroup()) {
-            <mat-select
-              [multiple]="true"
-              [ngModel]="attendedStudentIdsModel"
-              (ngModelChange)="onAttendanceChange($event)"
-            >
-              <mat-option
-                *ngFor="let student of data.students"
-                [value]="student.value.toString()"
-              >
-                {{ student.label }}
-              </mat-option>
-            </mat-select>
-          } @else {
-            <mat-select
-              [ngModel]="attendedStudentIdsModel[0]"
-              (ngModelChange)="onAttendanceChange($event)"
-            >
-              <mat-option [value]="null">None</mat-option>
-              <mat-option
-                *ngFor="let student of data.students"
-                [value]="student.value.toString()"
-              >
-                {{ student.label }}
-              </mat-option>
-            </mat-select>
-          }
-        </mat-form-field>
-      </div>
     </div>
   </mat-dialog-content>
 

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.spec.ts
@@ -1,0 +1,149 @@
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+  InterventionModel,
+  InterventionType,
+} from '@core/models/assessment.model';
+import { of } from 'rxjs';
+import {
+  NewInterventionDialogData,
+  NewInterventionModalComponent,
+} from './new-intervention-modal.component';
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { InterventionService } from '@core/services/api/intervention.service';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+describe('NewInterventionModalComponent', () => {
+  let component: NewInterventionModalComponent;
+  let fixture: ComponentFixture<NewInterventionModalComponent>;
+  let mockInterventionService: jasmine.SpyObj<InterventionService>;
+  let mockToastService: jasmine.SpyObj<ToastNotificationService>;
+  let mockDialogRef: jasmine.SpyObj<
+    MatDialogRef<NewInterventionModalComponent>
+  >;
+
+  const mockData: NewInterventionDialogData = {
+    assessmentId: 1,
+    professional: { label: 'Dr. Smith', value: '10' },
+    students: [
+      { label: 'Student A', value: 1 },
+      { label: 'Student B', value: 2 },
+    ],
+  };
+
+  beforeEach(async () => {
+    mockInterventionService = jasmine.createSpyObj('InterventionService', [
+      'createIntervention',
+      'uploadAttachments',
+    ]);
+    mockToastService = jasmine.createSpyObj('ToastNotificationService', [
+      'showToast',
+    ]);
+    mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [NewInterventionModalComponent],
+      providers: [
+        { provide: InterventionService, useValue: mockInterventionService },
+        { provide: ToastNotificationService, useValue: mockToastService },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: mockData },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NewInterventionModalComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set isGroup to true on init when more than one student', () => {
+    component.ngOnInit();
+    expect(component.isGroup()).toBeTrue();
+  });
+
+  it('should build form fields including students field on init', () => {
+    component.ngOnInit();
+    const names = component.formFields.map(f => f.name);
+    expect(names).toContain('students');
+    expect(names).toContain('date');
+    expect(names).toContain('type');
+  });
+
+  it('should compute numberOfParticipants from data.students length', () => {
+    expect(component.numberOfParticipants()).toBe(2);
+  });
+
+  it('should return true for isSubmitDisabled when form is not set', () => {
+    expect(component.isSubmitDisabled).toBeTrue();
+  });
+
+  it('should close dialog without result on closeAndResetDialog', () => {
+    component.closeAndResetDialog();
+    expect(mockDialogRef.close).toHaveBeenCalledWith();
+  });
+
+  it('should return file name from a path', () => {
+    const result = component.getFileName('folder/subfolder/file.pdf');
+    expect(result).toBe('file.pdf');
+  });
+
+  it('should return empty string when path is undefined', () => {
+    const result = component.getFileName(undefined as unknown as string);
+    expect(result).toBe('');
+  });
+
+  it('should remove existing attachment and mark form dirty', () => {
+    component.existingAttachments = ['folder/file1.pdf', 'folder/file2.pdf'];
+    component.form = new FormGroup({});
+    spyOn(component.form, 'markAsDirty');
+
+    component.removeExistingAttachment(0);
+
+    expect(component.attachmentsToDelete).toContain('file1.pdf');
+    expect(component.existingAttachments).toEqual(['folder/file2.pdf']);
+    expect(component.form.markAsDirty).toHaveBeenCalled();
+  });
+
+  it('should not call service when form is invalid on submitIntervention', () => {
+    component.form = new FormGroup({
+      date: new FormControl(null, Validators.required),
+    });
+
+    component.submitIntervention();
+
+    expect(mockInterventionService.createIntervention).not.toHaveBeenCalled();
+  });
+
+  it('should call service and close dialog with true on successful submitIntervention', () => {
+    component.ngOnInit();
+    component.form = new FormGroup({
+      date: new FormControl(new Date().toISOString()),
+      type: new FormControl(InterventionType.Individual),
+      activity: new FormControl('Activity'),
+      area: new FormControl('Area'),
+      mode: new FormControl('Mode'),
+      students: new FormControl([
+        { name: 'ana', email: 'an@mail.com' },
+        { name: 'abi', email: 'abi@mail.com' },
+      ]),
+      riskLevelName: new FormControl('Low'),
+      professionalId: new FormControl(10),
+      uploadInput: new FormControl([]),
+      comments: new FormControl('Some comments here'),
+    });
+
+    const created: InterventionModel = { id: 1 } as InterventionModel;
+    mockInterventionService.createIntervention.and.returnValue(of(created));
+
+    component.submitIntervention();
+
+    expect(mockInterventionService.createIntervention).toHaveBeenCalled();
+    expect(mockToastService.showToast).toHaveBeenCalled();
+    expect(mockDialogRef.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
@@ -95,6 +95,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
   formInstance = new EventEmitter<FormGroup>();
   formFields: DynamicField[] = [];
   form!: FormGroup;
+  isSubmitting = false;
 
   readonly numberOfParticipants = computed(() => this.data.students.length);
 
@@ -107,7 +108,9 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
   });
 
   get isSubmitDisabled(): boolean {
-    return !this.form || this.form.invalid || this.form.pristine;
+    return (
+      !this.form || this.form.invalid || this.form.pristine || this.isSubmitting
+    );
   }
 
   constructor(
@@ -288,6 +291,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
     if (this.form.invalid) return;
 
     const payload = this.buildPayload();
+    this.isSubmitting = true;
 
     this.interventionService
       .createIntervention(payload)
@@ -315,6 +319,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
             type: 'error',
           };
           this.toastService.showToast(toast, true);
+          this.isSubmitting = false;
         },
         complete: () => {
           this.dialogRef.close(true);

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
@@ -29,10 +29,7 @@ import {
   FormCreation,
 } from '@core/factories/forms/form-factory.interface';
 import { ToastNotificationData } from '@core/models/toast-notification.model';
-import {
-  InterventionMode,
-  InterventionType,
-} from '@core/models/assessment.model';
+import { InterventionType } from '@core/models/assessment.model';
 import {
   AddInterventionPayload,
   InterventionService,
@@ -43,46 +40,17 @@ import { MatSelectModule } from '@angular/material/select';
 import { InterventionModel } from '@core/models/assessment.model';
 import { map, of, concatMap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
-const ALLOWED_MIME_TYPES = [
-  'application/pdf',
-  'image/jpeg',
-  'image/png',
-  'text/plain',
-];
-const ALLOWED_EXTENSIONS = '.pdf,.jpg,.png,.txt';
-const MAX_FILES = 2;
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-
-const TYPE_OPTIONS = [
-  { value: 'Individual', label: 'Individual' },
-  { value: 'Group', label: 'Group' },
-];
-
-const RISK_OPTIONS = [
-  { value: 'Low', label: 'Low', color: 'success' },
-  { value: 'Medium', label: 'Medium', color: 'warning' },
-  { value: 'High', label: 'High', color: 'danger' },
-];
-
-const ACTIVITY_OPTIONS = [
-  { value: 'tutoring', label: 'Tutoring' },
-  { value: 'counseling', label: 'Counseling' },
-  { value: 'workshop', label: 'Workshop' },
-  { value: 'mentoring', label: 'Mentoring' },
-];
-
-const AREA_OPTIONS = [
-  { value: 'academic', label: 'Academic' },
-  { value: 'social', label: 'Social' },
-  { value: 'emotional', label: 'Emotional' },
-  { value: 'vocational', label: 'Vocational' },
-];
-
-const MODE_OPTIONS = [
-  { value: InterventionMode.InPlace, label: 'In place' },
-  { value: InterventionMode.Remote, label: 'Remote' },
-];
+import {
+  ACTIVITY_OPTIONS,
+  ALLOWED_EXTENSIONS,
+  ALLOWED_MIME_TYPES,
+  AREA_OPTIONS,
+  MAX_FILE_SIZE_BYTES,
+  MAX_FILES,
+  MODE_OPTIONS,
+  RISK_OPTIONS,
+  TYPE_OPTIONS,
+} from '../interventions.constants';
 
 export interface StudentLookup {
   value: number;
@@ -149,7 +117,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
 
   ngOnInit(): void {
     this.isGroup.set(this.data.students.length > 1);
-    // this.buildAttendance();
     this.buildFormFields();
   }
 
@@ -320,10 +287,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
   submitIntervention(): void {
     if (this.form.invalid) return;
 
-    // const selectedStudents: string[] = this.isGroup()
-    //   ? (this.form.value.students as string[]).map(String)
-    //   : [String(this.form.value.students)];
-
     const payload = this.buildPayload();
 
     this.interventionService
@@ -367,12 +330,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
     const studentIds: number[] = isGroup
       ? (v.students as string[]).map(Number)
       : [Number(v.students)];
-
-    // const attendanceRecord: Record<number, boolean> = {};
-    // this.data.students.forEach(student => {
-    //   attendanceRecord[Number(student.value)] =
-    //     this.attendedStudentIds().includes(String(student.value));
-    // });
 
     const kindIntervention = this.formFields.find(
       field => field.name === 'type'

--- a/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
+++ b/src/app/modules/assessments/components/interventions/new-intervention-modal/new-intervention-modal.component.ts
@@ -1,4 +1,4 @@
-import { NgClass, NgFor } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   Component,
@@ -108,7 +108,6 @@ export interface NewInterventionDialogData {
     MatFormFieldModule,
     MatSelectModule,
     NgClass,
-    NgFor,
     ReactiveFormsModule,
   ],
   templateUrl: './new-intervention-modal.component.html',
@@ -121,7 +120,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
 
   existingAttachments: string[] = [];
   attachmentsToDelete: string[] = [];
-  attendedStudentIdsModel: string[] = [];
 
   isGroup = signal<boolean>(false);
   studentsSelected = signal<number[]>([]);
@@ -129,9 +127,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
   formInstance = new EventEmitter<FormGroup>();
   formFields: DynamicField[] = [];
   form!: FormGroup;
-
-  attendance = signal<{ student: StudentLookup; attended: boolean }[]>([]);
-  attendedStudentIds = signal<string[]>([]);
 
   readonly numberOfParticipants = computed(() => this.data.students.length);
 
@@ -154,7 +149,7 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
 
   ngOnInit(): void {
     this.isGroup.set(this.data.students.length > 1);
-    this.buildAttendance();
+    // this.buildAttendance();
     this.buildFormFields();
   }
 
@@ -318,64 +313,16 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
         const nowGroup = value === InterventionType.Group;
         if (nowGroup === this.isGroup()) return;
         this.isGroup.set(nowGroup);
-        this.attendedStudentIds.set([]);
-        this.attendedStudentIdsModel = [];
-        this.buildAttendance();
         this.buildFormFields();
       });
-  }
-
-  private buildAttendance(): void {
-    this.attendance.set(
-      this.data.students.map(student => ({ student, attended: false }))
-    );
-  }
-
-  onAttendanceChange(selectedValues: string[] | string | null): void {
-    const asArray = !selectedValues
-      ? []
-      : Array.isArray(selectedValues)
-        ? selectedValues
-        : [String(selectedValues)];
-
-    this.attendedStudentIds.set(asArray);
-    this.attendedStudentIdsModel = asArray;
-
-    const current = this.attendance().map(item => ({
-      ...item,
-      attended: asArray.includes(String(item.student.value)),
-    }));
-    this.attendance.set(current);
-    this.form.markAsDirty();
   }
 
   submitIntervention(): void {
     if (this.form.invalid) return;
 
-    const selectedStudents: string[] = this.isGroup()
-      ? (this.form.value.students as string[]).map(String)
-      : [String(this.form.value.students)];
-
-    const attendedIds: string[] = Array.isArray(this.attendedStudentIds())
-      ? this.attendedStudentIds()
-      : [this.attendedStudentIds() as unknown as string];
-
-    const invalidAttendees = attendedIds.filter(
-      id => !selectedStudents.includes(String(id))
-    );
-
-    if (invalidAttendees.length > 0) {
-      this.toastService.showToast(
-        {
-          title: 'Invalid attendance',
-          message:
-            'Attendance can only include students selected for this intervention.',
-          type: 'error',
-        },
-        true
-      );
-      return;
-    }
+    // const selectedStudents: string[] = this.isGroup()
+    //   ? (this.form.value.students as string[]).map(String)
+    //   : [String(this.form.value.students)];
 
     const payload = this.buildPayload();
 
@@ -421,11 +368,11 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
       ? (v.students as string[]).map(Number)
       : [Number(v.students)];
 
-    const attendanceRecord: Record<number, boolean> = {};
-    this.data.students.forEach(student => {
-      attendanceRecord[Number(student.value)] =
-        this.attendedStudentIds().includes(String(student.value));
-    });
+    // const attendanceRecord: Record<number, boolean> = {};
+    // this.data.students.forEach(student => {
+    //   attendanceRecord[Number(student.value)] =
+    //     this.attendedStudentIds().includes(String(student.value));
+    // });
 
     const kindIntervention = this.formFields.find(
       field => field.name === 'type'
@@ -443,7 +390,6 @@ export class NewInterventionModalComponent implements FormCreation, OnInit {
         studentIds,
         area: v.area,
         numberOfParticipants: studentIds.length,
-        attendance: attendanceRecord,
         attachments: [],
         riskLevelName: v.riskLevelName,
       },

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.html
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.html
@@ -11,15 +11,17 @@
   </mat-dialog-content>
 
   <mat-dialog-actions>
-    <button mat-dialog-close class="cancel-button">Cancel</button>
+    <button mat-dialog-close class="cancel-button" [disabled]="isSubmitting">
+      Cancel
+    </button>
     <button
       class="action-button"
       type="submit"
       [ngClass]="{ 'disabled-button': form.invalid || form.pristine }"
-      [disabled]="form.invalid || form.pristine"
+      [disabled]="form.invalid || form.pristine || isSubmitting"
       (click)="submitAssessment()"
     >
-      Create
+      {{ isSubmitting ? 'Creating...' : 'Create' }}
     </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -34,6 +34,7 @@ export class NewAssessmentModalComponent implements FormCreation {
   formInstance = new EventEmitter<FormGroup>();
   formFields: DynamicField[] = [];
   form!: FormGroup;
+  isSubmitting = false;
 
   constructor(
     public dialogRef: MatDialogRef<NewAssessmentModalComponent>,
@@ -109,7 +110,9 @@ export class NewAssessmentModalComponent implements FormCreation {
   }
 
   submitAssessment() {
-    if (this.form.valid) {
+    if (this.form.valid && !this.isSubmitting) {
+      this.isSubmitting = true;
+
       const newAssessment: AssessmentModel = {
         createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
@@ -131,6 +134,7 @@ export class NewAssessmentModalComponent implements FormCreation {
           const toastData = this.buildErrorToastDataObject(err);
           this.toastService.showToast(toastData, true);
           console.error(err);
+          this.isSubmitting = false;
         },
         complete: () => {
           this.dialogRef.close();

--- a/src/app/modules/assessments/models/assessments.interfaces.ts
+++ b/src/app/modules/assessments/models/assessments.interfaces.ts
@@ -1,4 +1,7 @@
-import { AssessmentModel } from '@core/models/assessment.model';
+import {
+  AssessmentModel,
+  AssessmentStatus,
+} from '@core/models/assessment.model';
 import { Lookup } from '@core/models/lookup';
 
 export interface AssessmentsLookups {
@@ -20,4 +23,5 @@ export interface EditAssessmentModel {
   service: string;
   students: string[];
   submitter: string;
+  status: AssessmentStatus;
 }

--- a/src/styles/utils/_forms.scss
+++ b/src/styles/utils/_forms.scss
@@ -66,20 +66,26 @@ mat-option[appselectall] {
   box-shadow: 1px var(--color-neutral-200) blur(3px);
 }
 
+app-edit-intervention-modal form,
 app-new-intervention-modal form {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
+app-edit-intervention-modal form > :nth-child(1),
 app-new-intervention-modal form > :nth-child(1),
+app-edit-intervention-modal form > :nth-child(2),
 app-new-intervention-modal form > :nth-child(2),
+app-edit-intervention-modal form > :nth-child(4),
 app-new-intervention-modal form > :nth-child(4),
+app-edit-intervention-modal form > :nth-child(5),
 app-new-intervention-modal form > :nth-child(5) {
   width: calc(50% - 32px);
   flex: 1 1 calc(50% - 16px);
 }
 
+app-edit-intervention-modal mat-form-field,
 app-new-intervention-modal mat-form-field {
   margin-bottom: 0px;
 }
@@ -92,28 +98,30 @@ app-new-intervention-modal
   flex: 1 1 100%;
 }
 
-app-edit-intervention-modal form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-app-edit-intervention-modal form > :nth-child(1),
-app-edit-intervention-modal form > :nth-child(2),
-app-edit-intervention-modal form > :nth-child(4),
-app-edit-intervention-modal form > :nth-child(5) {
-  width: calc(50% - 32px);
-  flex: 1 1 calc(50% - 16px);
-}
-
-app-edit-intervention-modal mat-form-field {
-  margin-bottom: 0px;
-}
-
 app-edit-intervention-modal
   form
   > :not(:nth-child(1)):not(:nth-child(2)):not(:nth-child(4)):not(
     :nth-child(5)
   ) {
   flex: 1 1 100%;
+}
+
+app-edit-assessment-modal form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+app-edit-assessment-modal form > :nth-child(2),
+app-edit-assessment-modal form > :nth-child(3) {
+  width: calc(50% - 32px);
+  flex: 1 1 calc(50% - 16px);
+}
+
+app-edit-assessment-modal form > :not(:nth-child(2)):not(:nth-child(3)) {
+  flex: 1 1 100%;
+}
+
+app-edit-assessment-modal mat-form-field {
+  margin-bottom: 0px;
 }

--- a/src/styles/utils/_forms.scss
+++ b/src/styles/utils/_forms.scss
@@ -91,3 +91,29 @@ app-new-intervention-modal
   ) {
   flex: 1 1 100%;
 }
+
+app-edit-intervention-modal form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+app-edit-intervention-modal form > :nth-child(1),
+app-edit-intervention-modal form > :nth-child(2),
+app-edit-intervention-modal form > :nth-child(4),
+app-edit-intervention-modal form > :nth-child(5) {
+  width: calc(50% - 32px);
+  flex: 1 1 calc(50% - 16px);
+}
+
+app-edit-intervention-modal mat-form-field {
+  margin-bottom: 0px;
+}
+
+app-edit-intervention-modal
+  form
+  > :not(:nth-child(1)):not(:nth-child(2)):not(:nth-child(4)):not(
+    :nth-child(5)
+  ) {
+  flex: 1 1 100%;
+}


### PR DESCRIPTION
## Description

- Separation of 'Edit' and 'New Interventions' 
- A status field was added to the edit modal for both assessments and interventions
- A restriction was added to prevent the editing of finalised records
- The end risk level field is now dynamic when the 'Finalized' status is selected. The old risk level is also disabled
- Added tests for edit and new intervention modal components

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

