### PR TITLE
fix: Evaluation processes display stored statuses in v2

### DIFF
--- a/src/app/core/constants/StatusEvaluation.ts
+++ b/src/app/core/constants/StatusEvaluation.ts
@@ -24,3 +24,14 @@ export const STATUS_LABEL_COLORS: Record<string, string> = {
   Uncompleted: '#991B1B',
   default: '#63656A',
 };
+
+export const TOOLTIP_EVALUATIONS: Record<string, string> = {
+  Pending: 'This evaluation has not been imported yet.',
+  Ready:
+    'This evaluation has not ended yet. The poll may also have been used by other evaluations.',
+  InProgress: 'This evaluation has bee imported and it is in progress',
+  Completed: 'This evaluation has been imported and completed.',
+  Uncompleted:
+    'This evaluation was not completed before the deadline. The poll may also have been used by other evaluations.',
+  default: 'This evaluation process has not defined status.',
+};

--- a/src/app/core/constants/common.ts
+++ b/src/app/core/constants/common.ts
@@ -2,4 +2,10 @@ export const Status = {
   INCOMPLETE: 'Incomplete',
   NOT_STARTED: 'Not started yet',
   IN_PROGRESS: 'In progress',
+  // For v2
+  PENDING: 'Pending',
+  READY: 'Ready',
+  INPROGRESS: 'InProgress',
+  COMPLETED: 'Completed',
+  UNCOMPLETED: 'Uncompleted',
 };

--- a/src/app/core/utils/routing/route-metadata.ts
+++ b/src/app/core/utils/routing/route-metadata.ts
@@ -16,6 +16,7 @@ export const ROUTE_METADATA = {
     breadcrumb: 'Cosmic Latte',
   },
   EVALUATION_PROCESS: {
+    headerTitle: 'Evaluation Process',
     breadcrumb: 'Evaluation Process',
   },
   IMPORT_PREVIEW: {

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
@@ -24,6 +24,7 @@
   <ng-template #status let-element>
     @if (displayV2()) {
       <span
+        [matTooltip]="getStatusTooltip(element.status)"
         [style.backgroundColor]="getStatusColor(element.status)"
         [style.color]="getStatusLabelColor(element.status)"
         class="badge"

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.html
@@ -1,7 +1,9 @@
-<h1 class="page-title">Evaluation Processes</h1>
+@if (!displayV2()) {
+  <h1 class="page-title">Evaluation Processes</h1>
+}
 
 @if (this.totalEvaluations !== 0) {
-  <div align="end">
+  <div align="end" class="button-add-evaluation">
     <app-eras-button
       [textButton]="'Add new'"
       [iconButton]="'add'"
@@ -20,7 +22,17 @@
   [actionDatas]="actionDatas"
 >
   <ng-template #status let-element>
-    <app-badge-status [element]="element" />
+    @if (displayV2()) {
+      <span
+        [style.backgroundColor]="getStatusColor(element.status)"
+        [style.color]="getStatusLabelColor(element.status)"
+        class="badge"
+      >
+        {{ getStatusLabel(element.status) }}
+      </span>
+    } @else {
+      <app-badge-status [element]="element" />
+    }
   </ng-template>
 </app-list>
 

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.scss
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.scss
@@ -1,0 +1,4 @@
+.button-add-evaluation {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -1,4 +1,12 @@
-import { Component, HostListener, inject, OnInit } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  HostListener,
+  inject,
+  OnInit,
+  untracked,
+} from '@angular/core';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -37,6 +45,11 @@ import { Pagination } from '@core/services/interfaces/server.type';
 import { FeatureFlagsService } from '@core/components/feature-flags/feature-flags.service';
 import { RouteDataService } from '@core/services/route-data.service';
 import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
+import {
+  STATUS_COLORS,
+  STATUS_EVALUATIONS,
+  STATUS_LABEL_COLORS,
+} from '@core/constants/StatusEvaluation';
 
 @Component({
   selector: 'app-evaluation-process-list',
@@ -52,6 +65,10 @@ import { FEATURE_FLAGS } from '@core/components/feature-flags/feature-flags';
     MatTooltipModule,
   ],
   templateUrl: './evaluation-process-list.component.html',
+  styleUrls: [
+    '../../../home-v2/recent-alerts/recent-alerts.component.scss',
+    './evaluation-process-list.component.scss',
+  ],
 })
 export class EvaluationProcessListComponent implements OnInit {
   private router = inject(Router);
@@ -115,11 +132,14 @@ export class EvaluationProcessListComponent implements OnInit {
   totalEvaluations = 0;
   isMobile = false;
   isLoading = false;
-  importPollsDisabled = [Status.INCOMPLETE, Status.NOT_STARTED];
+  importPollsDisabled = [Status.INCOMPLETE, Status.NOT_STARTED, Status.READY];
   pagination: Pagination = {
     page: 0,
     pageSize: 10,
   };
+  displayV2 = computed(() =>
+    this.featureFlagsService.isEnabled(FEATURE_FLAGS.reportsV2)
+  );
 
   @HostListener('window:resize', ['$event'])
   onResize(event: UIEvent): void {
@@ -129,6 +149,15 @@ export class EvaluationProcessListComponent implements OnInit {
 
   ngOnInit(): void {
     this.isMobile = window.innerWidth < 600;
+  }
+
+  constructor() {
+    effect(() => {
+      this.displayV2();
+      untracked(() => {
+        this.getEvaluationProcess();
+      });
+    });
   }
 
   handleLoadCalled(event: EventLoad) {
@@ -335,6 +364,9 @@ export class EvaluationProcessListComponent implements OnInit {
   }
 
   transformStatus(data: EvaluationModel[]): EvaluationModel[] {
+    if (this.displayV2()) {
+      return data;
+    }
     data.forEach((evaluation: EvaluationModel) => {
       evaluation.status = getStatusForEvaluationProcess(evaluation);
     });
@@ -347,6 +379,18 @@ export class EvaluationProcessListComponent implements OnInit {
 
   isVisible(item: EvaluationModel) {
     return !this.importPollsDisabled.includes(item.status);
+  }
+
+  getStatusLabel(status: string): string {
+    return STATUS_EVALUATIONS[status] ?? STATUS_EVALUATIONS['default'];
+  }
+
+  getStatusColor(status: string): string {
+    return STATUS_COLORS[status] ?? STATUS_COLORS['default'];
+  }
+
+  getStatusLabelColor(status: string): string {
+    return STATUS_LABEL_COLORS[status] ?? STATUS_LABEL_COLORS['default'];
   }
 
   private _updatePaginator() {

--- a/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
+++ b/src/app/modules/lists/components/evaluacion-process/evaluation-process-list.component.ts
@@ -49,6 +49,7 @@ import {
   STATUS_COLORS,
   STATUS_EVALUATIONS,
   STATUS_LABEL_COLORS,
+  TOOLTIP_EVALUATIONS,
 } from '@core/constants/StatusEvaluation';
 
 @Component({
@@ -132,7 +133,7 @@ export class EvaluationProcessListComponent implements OnInit {
   totalEvaluations = 0;
   isMobile = false;
   isLoading = false;
-  importPollsDisabled = [Status.INCOMPLETE, Status.NOT_STARTED, Status.READY];
+  importPollsDisabled = [Status.INCOMPLETE, Status.NOT_STARTED];
   pagination: Pagination = {
     page: 0,
     pageSize: 10,
@@ -383,6 +384,10 @@ export class EvaluationProcessListComponent implements OnInit {
 
   getStatusLabel(status: string): string {
     return STATUS_EVALUATIONS[status] ?? STATUS_EVALUATIONS['default'];
+  }
+
+  getStatusTooltip(status: string): string {
+    return TOOLTIP_EVALUATIONS[status] ?? TOOLTIP_EVALUATIONS['default'];
   }
 
   getStatusColor(status: string): string {


### PR DESCRIPTION
## Description

When the v2 is enabled the statuses of each evaluation process must display the stored status.
Added tooltip with context of imported or unimported poll in the evaluation process.
Some constants were reused to show the same colors as the recent alerts table statuses.

The following rules to status were applied before in BE, so the v2 will display the statuses:

- Pending: No poll has been assigned to the evaluation.
- Ready: At least one poll has been assigned, no poll instance contains submitted responses, and the evaluation deadline has not passed.
- In Progress: At least one poll instance contains submitted responses (or references a previously submitted poll instance), and the evaluation deadline has not passed.
- Completed: At least one poll instance contains submitted responses (or references a previously submitted poll instance), and the evaluation deadline has passed.
- Uncompleted: No poll instance contains submitted responses (or references a previously submitted poll instance), and the evaluation deadline has passed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#960 