### PR TITLE
fix: recent alerts badge is displayed without wrapping

### DIFF
--- a/src/app/core/constants/StatusEvaluation.ts
+++ b/src/app/core/constants/StatusEvaluation.ts
@@ -29,7 +29,7 @@ export const TOOLTIP_EVALUATIONS: Record<string, string> = {
   Pending: 'This evaluation has not been imported yet.',
   Ready:
     'This evaluation has not ended yet. The poll may also have been used by other evaluations.',
-  InProgress: 'This evaluation has bee imported and it is in progress',
+  InProgress: 'This evaluation has been imported and it is in progress',
   Completed: 'This evaluation has been imported and completed.',
   Uncompleted:
     'This evaluation was not completed before the deadline. The poll may also have been used by other evaluations.',

--- a/src/app/modules/home-v2/recent-alerts/recent-alerts.component.scss
+++ b/src/app/modules/home-v2/recent-alerts/recent-alerts.component.scss
@@ -33,4 +33,7 @@ $inter: 'Inter', sans-serif;
   font-size: 12px;
   line-height: 16px;
   font-weight: 500;
+  display: block;
+  width: fit-content;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Description

Some statuses in the 'Evaluation Processes' table are displayed without wrapping
Errata fix for status in the tooltip: InProgress

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

JU-DEV-Bootcamps/ERAS#526
