### PR TITLE
520 bug dev interventions multiple documents can be added when editing

### DIFF
--- a/src/app/core/factories/forms/upload-input/upload-input.component.spec.ts
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.spec.ts
@@ -1,0 +1,251 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormGroup,
+  FormControl,
+  FormGroupDirective,
+  ControlContainer,
+  ValidatorFn,
+} from '@angular/forms';
+import { UploadInputComponent } from './upload-input.component';
+import { DynamicField } from '../form-factory.interface';
+
+describe('UploadInputComponent', () => {
+  let component: UploadInputComponent;
+  let fixture: ComponentFixture<UploadInputComponent>;
+  let form: FormGroup;
+
+  const baseField = (overrides: Partial<DynamicField> = {}): DynamicField =>
+    ({
+      type: 'file',
+      name: 'uploadInput',
+      label: 'Attached Document (s)',
+      fileConfig: {
+        maxFiles: 5,
+        maxSizeMb: 1024,
+        allowedExtensions: '.pdf,.docx',
+        allowedMimeTypes: ['application/pdf'],
+        prefillFileNames: [],
+      },
+      ...overrides,
+    }) as DynamicField;
+
+  const makeFile = (
+    name: string,
+    type = 'application/pdf',
+    size = 100
+  ): File => {
+    const file = new File(['a'.repeat(size)], name, { type });
+    return file;
+  };
+
+  const setup = (field: DynamicField) => {
+    fixture = TestBed.createComponent(UploadInputComponent);
+    component = fixture.componentInstance;
+
+    form = new FormGroup({ uploadInput: new FormControl(null) });
+
+    fixture.componentRef.setInput('field', field);
+    fixture.componentRef.setInput('form', form);
+
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UploadInputComponent],
+      providers: [
+        { provide: ControlContainer, useValue: new FormGroupDirective([], []) },
+      ],
+    }).compileComponents();
+  });
+
+  const selectFiles = (files: File[]) => {
+    const dataTransfer = new DataTransfer();
+    files.forEach(f => dataTransfer.items.add(f));
+    const input = document.createElement('input');
+    input.type = 'file';
+    Object.defineProperty(input, 'files', { value: dataTransfer.files });
+    component.onFileSelected({ target: input } as unknown as Event);
+  };
+
+  describe('basic file selection', () => {
+    beforeEach(() => setup(baseField()));
+
+    it('should add a valid file to selectedFiles', () => {
+      selectFiles([makeFile('doc1.pdf')]);
+      expect(component.selectedFiles().length).toBe(1);
+      expect(component.fileNames()).toEqual(['doc1.pdf']);
+    });
+
+    it('should update the form control value on selection', () => {
+      selectFiles([makeFile('doc1.pdf')]);
+      expect(form.get('uploadInput')?.value.length).toBe(1);
+    });
+
+    it('should reject duplicate files (same name and size)', () => {
+      selectFiles([makeFile('doc1.pdf')]);
+      selectFiles([makeFile('doc1.pdf')]);
+      expect(component.selectedFiles().length).toBe(1);
+      expect(component.errorMatcher.hasErrors()).toBeTrue();
+    });
+
+    it('should reject files with disallowed mime type', () => {
+      selectFiles([makeFile('image.png', 'image/png')]);
+      expect(component.selectedFiles().length).toBe(0);
+    });
+
+    it('should reject files exceeding maxSizeMb', () => {
+      setup(
+        baseField({ fileConfig: { ...baseField().fileConfig, maxSizeMb: 1 } })
+      );
+      selectFiles([makeFile('big.pdf', 'application/pdf', 5)]);
+      // size (5 bytes) > maxSizeMb configured as 1 in validate() comparison
+      expect(component.selectedFiles().length).toBe(0);
+    });
+
+    it('should remove a file and update the form control', () => {
+      selectFiles([makeFile('doc1.pdf'), makeFile('doc2.pdf')]);
+      component.removeFile(0);
+      expect(component.selectedFiles().length).toBe(1);
+      expect(component.fileNames()).toEqual(['doc2.pdf']);
+    });
+  });
+
+  describe('maxFiles enforcement (existing behavior)', () => {
+    it('should block adding a new file once maxFiles is reached', () => {
+      setup(
+        baseField({ fileConfig: { ...baseField().fileConfig, maxFiles: 2 } })
+      );
+      selectFiles([
+        makeFile('doc1.pdf'),
+        makeFile('doc2.pdf'),
+        makeFile('doc3.pdf'),
+      ]);
+      expect(component.selectedFiles().length).toBe(2);
+    });
+  });
+
+  describe('maxFilesExceeded validation (new behavior)', () => {
+    it('should mark control invalid on init when prefill exceeds maxFiles', () => {
+      const field = baseField({
+        fileConfig: {
+          ...baseField().fileConfig,
+          maxFiles: 5,
+          prefillFileNames: [
+            'a.pdf',
+            'b.pdf',
+            'c.pdf',
+            'd.pdf',
+            'e.pdf',
+            'f.pdf',
+            'g.pdf',
+          ],
+        },
+      });
+      setup(field);
+
+      expect(component.selectedFiles().length).toBe(7);
+      expect(form.get('uploadInput')?.invalid).toBeTrue();
+      expect(
+        form.get('uploadInput')?.errors?.['maxFilesExceeded']
+      ).toBeTruthy();
+    });
+
+    it('should not mark control invalid when prefill is within maxFiles', () => {
+      const field = baseField({
+        fileConfig: {
+          ...baseField().fileConfig,
+          maxFiles: 5,
+          prefillFileNames: ['a.pdf', 'b.pdf', 'c.pdf'],
+        },
+      });
+      setup(field);
+
+      expect(form.get('uploadInput')?.errors?.['maxFilesExceeded']).toBeFalsy();
+    });
+
+    it('should clear maxFilesExceeded once files are removed below the limit', () => {
+      const field = baseField({
+        fileConfig: {
+          ...baseField().fileConfig,
+          maxFiles: 5,
+          prefillFileNames: [
+            'a.pdf',
+            'b.pdf',
+            'c.pdf',
+            'd.pdf',
+            'e.pdf',
+            'f.pdf',
+          ],
+        },
+      });
+      setup(field);
+
+      expect(
+        form.get('uploadInput')?.errors?.['maxFilesExceeded']
+      ).toBeTruthy();
+
+      component.removeFile(0);
+
+      expect(form.get('uploadInput')?.errors?.['maxFilesExceeded']).toBeFalsy();
+      expect(form.get('uploadInput')?.valid).toBeTrue();
+    });
+
+    it('should keep other existing errors when clearing maxFilesExceeded', () => {
+      const field = baseField({
+        fileConfig: {
+          ...baseField().fileConfig,
+          maxFiles: 5,
+          prefillFileNames: [
+            'a.pdf',
+            'b.pdf',
+            'c.pdf',
+            'd.pdf',
+            'e.pdf',
+            'f.pdf',
+          ],
+        },
+      });
+      setup(field);
+
+      const control = form.get('uploadInput');
+      const alwaysFails: ValidatorFn = () => ({ someOtherError: true });
+      control?.addValidators(alwaysFails);
+      control?.updateValueAndValidity();
+
+      expect(control?.errors?.['maxFilesExceeded']).toBeTruthy();
+      expect(control?.errors?.['someOtherError']).toBeTruthy();
+
+      component.removeFile(0);
+
+      expect(control?.errors?.['maxFilesExceeded']).toBeFalsy();
+      expect(control?.errors?.['someOtherError']).toBeTruthy();
+    });
+
+    it('should re-trigger maxFilesExceeded on selection even if under per-add maxFiles cap', () => {
+      // Edge case: prefill already at limit, further selection attempts should
+      // still be blocked by validate(), and control should remain invalid.
+      const field = baseField({
+        fileConfig: {
+          ...baseField().fileConfig,
+          maxFiles: 5,
+          prefillFileNames: ['a.pdf', 'b.pdf', 'c.pdf', 'd.pdf', 'e.pdf'],
+        },
+      });
+      setup(field);
+
+      selectFiles([makeFile('f.pdf')]);
+
+      expect(component.selectedFiles().length).toBe(5);
+      expect(form.get('uploadInput')?.errors?.['maxFilesExceeded']).toBeFalsy();
+    });
+  });
+
+  describe('ngOnInit without prefill', () => {
+    it('should not populate selectedFiles when prefillFileNames is empty', () => {
+      setup(baseField());
+      expect(component.selectedFiles().length).toBe(0);
+      expect(form.get('uploadInput')?.errors).toBeFalsy();
+    });
+  });
+});

--- a/src/app/core/factories/forms/upload-input/upload-input.component.ts
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.ts
@@ -5,6 +5,7 @@ import {
   FormGroupDirective,
   ReactiveFormsModule,
   ValidationErrors,
+  ValidatorFn,
 } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import {
@@ -54,16 +55,34 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
     return this.field().fileConfig ?? {};
   }
 
+  private get maxFiles(): number {
+    return this.config.maxFiles ?? 1;
+  }
+
+  private maxFilesValidator(): ValidatorFn {
+    return (): ValidationErrors | null => {
+      const current = this.selectedFiles().length;
+      return current > this.maxFiles
+        ? { maxFilesExceeded: { max: this.maxFiles, current } }
+        : null;
+    };
+  }
+
   ngOnInit(): void {
+    const control = this.form().get(this.field().name);
+    control?.addValidators(this.maxFilesValidator());
+
     const names = this.config.prefillFileNames ?? [];
-    if (!names.length) return;
+    if (!names.length) {
+      control?.updateValueAndValidity();
+      return;
+    }
 
     const placeholders = names.map(name => new File([], name));
     this.selectedFiles.set(placeholders);
 
-    const control = this.form().get(this.field().name);
     control?.setValue(names);
-    this.applyMaxFilesValidation();
+    this.syncMaxFilesMessage();
   }
 
   onFileSelected(event: Event): void {
@@ -105,50 +124,34 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
       this.errorMatcher.setHasErrors(false);
     }
 
-    this.applyMaxFilesValidation();
+    this.syncMaxFilesMessage();
   }
 
   removeFile(index: number): void {
     this.selectedFiles.update(prev => prev.filter((file, i) => i !== index));
     this.config.onFileRemoved?.(index);
-    this.form().get(this.field().name)?.setValue(this.selectedFiles());
-    this.form().get(this.field().name)?.markAsDirty();
+    const control = this.form().get(this.field().name);
+    control?.setValue(this.selectedFiles());
+    control?.markAsDirty();
     this.errorMatcher.setHasErrors(false);
-    this.applyMaxFilesValidation();
+    this.errorMessage.set(null);
+    this.syncMaxFilesMessage();
   }
 
-  private applyMaxFilesValidation(): void {
+  private syncMaxFilesMessage(): void {
     const control = this.form().get(this.field().name);
-    if (!control) return;
-
-    const maxFiles = this.field().fileConfig?.maxFiles ?? 1;
-    const currentErrors = { ...(control.errors ?? {}) };
-
-    if (this.selectedFiles().length > maxFiles) {
-      currentErrors['maxFilesExceeded'] = { max: maxFiles };
-      control.setErrors(currentErrors);
+    if (control?.hasError('maxFilesExceeded')) {
+      const removeCount = this.selectedFiles().length - this.maxFiles;
       this.errorMessage.set(
-        `You can only attach up to ${maxFiles} documents. Please remove ${
-          this.selectedFiles().length - maxFiles
-        } file(s) before saving.`
+        `You can only attach up to ${this.maxFiles} documents. Please remove ${removeCount} file(s) before saving.`
       );
       this.errorMatcher.setHasErrors(true);
-    } else if (currentErrors['maxFilesExceeded']) {
-      delete currentErrors['maxFilesExceeded'];
-      const remaining = Object.keys(currentErrors).length
-        ? currentErrors
-        : null;
-      control.setErrors(remaining);
-      if (!remaining) {
-        this.errorMessage.set(null);
-        this.errorMatcher.setHasErrors(false);
-      }
     }
   }
 
   private validate(file: File): ValidationErrors | null {
     const FILE_CONFIG = {
-      maxFiles: this.field().fileConfig?.maxFiles ?? 1,
+      maxFiles: this.maxFiles,
       maxSizeMb: this.field().fileConfig?.maxSizeMb ?? 1024,
       allowedMimeTypes: this.field().fileConfig?.allowedMimeTypes ?? [],
       allowedExtensions: this.field().fileConfig?.allowedExtensions ?? '',

--- a/src/app/core/factories/forms/upload-input/upload-input.component.ts
+++ b/src/app/core/factories/forms/upload-input/upload-input.component.ts
@@ -63,6 +63,7 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
 
     const control = this.form().get(this.field().name);
     control?.setValue(names);
+    this.applyMaxFilesValidation();
   }
 
   onFileSelected(event: Event): void {
@@ -103,6 +104,8 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
       this.errorMessage.set(null);
       this.errorMatcher.setHasErrors(false);
     }
+
+    this.applyMaxFilesValidation();
   }
 
   removeFile(index: number): void {
@@ -111,6 +114,36 @@ export class UploadInputComponent implements DynamicInputComponent, OnInit {
     this.form().get(this.field().name)?.setValue(this.selectedFiles());
     this.form().get(this.field().name)?.markAsDirty();
     this.errorMatcher.setHasErrors(false);
+    this.applyMaxFilesValidation();
+  }
+
+  private applyMaxFilesValidation(): void {
+    const control = this.form().get(this.field().name);
+    if (!control) return;
+
+    const maxFiles = this.field().fileConfig?.maxFiles ?? 1;
+    const currentErrors = { ...(control.errors ?? {}) };
+
+    if (this.selectedFiles().length > maxFiles) {
+      currentErrors['maxFilesExceeded'] = { max: maxFiles };
+      control.setErrors(currentErrors);
+      this.errorMessage.set(
+        `You can only attach up to ${maxFiles} documents. Please remove ${
+          this.selectedFiles().length - maxFiles
+        } file(s) before saving.`
+      );
+      this.errorMatcher.setHasErrors(true);
+    } else if (currentErrors['maxFilesExceeded']) {
+      delete currentErrors['maxFilesExceeded'];
+      const remaining = Object.keys(currentErrors).length
+        ? currentErrors
+        : null;
+      control.setErrors(remaining);
+      if (!remaining) {
+        this.errorMessage.set(null);
+        this.errorMatcher.setHasErrors(false);
+      }
+    }
   }
 
   private validate(file: File): ValidationErrors | null {

--- a/src/app/modules/assessments/components/interventions/interventions.constants.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.constants.ts
@@ -7,7 +7,7 @@ export const ALLOWED_MIME_TYPES = [
   'text/plain',
 ];
 export const ALLOWED_EXTENSIONS = '.pdf,.jpg,.png,.txt';
-export const MAX_FILES = 2;
+export const MAX_FILES = 5;
 export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 export const TYPE_OPTIONS = [


### PR DESCRIPTION
## Description

max_files was set to 2 instead of the intended 5, and exceeding the
limit only blocked new file selection without invalidating the form
or disabling the Save button.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


