### PR TITLE
Feature/fe 970/register services and professionals from UI

### DIFF
--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.html
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.html
@@ -1,78 +1,82 @@
-<mat-form-field
-  [floatLabel]="field().floatingLabel ?? 'auto'"
-  class="w-full"
-  appearance="outline"
->
-  <mat-label>{{ field().label }}</mat-label>
-  @if (!isCreating()) {
-    <mat-icon matPrefix>search</mat-icon>
-  }
-
-  <input
-    matInput
-    #trigger="matAutocompleteTrigger"
-    type="text"
-    [formControl]="control()"
-    [placeholder]="
-      isCreating()
-        ? (field().selectConfig?.addNewLabel ?? 'New' + field().label)
-        : (field().placeholder ?? 'Search')
-    "
-    [matAutocomplete]="auto"
-    [disabled]="isSaving()"
-    (input)="onInput($any($event.target).value)"
-  />
-
-  @if (isCreating()) {
-    @if (isSaving()) {
-      <mat-spinner matSuffix diameter="18"></mat-spinner>
-    } @else {
-      <button
-        matSuffix
-        mat-button
-        color="primary"
-        type="button"
-        [disabled]="!searchTerm().trim()"
-        (click)="save(trigger)"
-      >
-        Save
-      </button>
-      <button
-        matSuffix
-        mat-icon-button
-        type="button"
-        (click)="cancelCreating()"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    }
-  }
-  <mat-autocomplete
-    #auto="matAutocomplete"
-    [displayWith]="displayFn"
-    (optionSelected)="onOptionSelected($event.option.value)"
+<div class="upload-field-wrapper">
+  <mat-form-field
+    [floatLabel]="field().floatingLabel ?? 'auto'"
+    class="w-full"
+    appearance="outline"
   >
-    @if (field().selectConfig?.onCreateRecord && !hasExactMatch()) {
-      <mat-option class="add-new-option" (click)="startCreating()">
-        <mat-icon>add</mat-icon>
-        {{ field().selectConfig?.addNewLabel ?? 'New ' + field().label }}
-      </mat-option>
+    <mat-label>{{ field().label }}</mat-label>
+    @if (!isCreating()) {
+      <mat-icon matPrefix>search</mat-icon>
     }
 
-    @for (option of filteredOptions(); track option.value) {
-      <mat-option [value]="option">{{ option.label }}</mat-option>
-    }
+    <input
+      matInput
+      #trigger="matAutocompleteTrigger"
+      type="text"
+      [formControl]="control()"
+      [placeholder]="
+        isCreating()
+          ? (field().selectConfig?.addNewLabel ?? 'New' + field().label)
+          : (field().placeholder ?? 'Search')
+      "
+      [matAutocomplete]="auto"
+      [disabled]="isSaving()"
+      (input)="onInput($any($event.target).value)"
+    />
 
-    @if (
-      filteredOptions().length === 0 && !field().selectConfig?.onCreateRecord
-    ) {
-      <mat-option disabled>No results found</mat-option>
+    @if (isCreating()) {
+      @if (isSaving()) {
+        <mat-spinner matSuffix diameter="18"></mat-spinner>
+      } @else {
+        <div class="button-save-cancel">
+          <button
+            matSuffix
+            mat-button
+            color="primary"
+            type="button"
+            [disabled]="!searchTerm().trim()"
+            (click)="save(trigger)"
+          >
+            Save
+          </button>
+          <button
+            matSuffix
+            mat-icon-button
+            type="button"
+            (click)="cancelCreating()"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+      }
     }
-  </mat-autocomplete>
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      [displayWith]="displayFn"
+      (optionSelected)="onOptionSelected($event.option.value)"
+    >
+      @if (field().selectConfig?.onCreateRecord && !hasExactMatch()) {
+        <mat-option class="add-new-option" (click)="startCreating()">
+          <mat-icon>add</mat-icon>
+          {{ field().selectConfig?.addNewLabel ?? 'New ' + field().label }}
+        </mat-option>
+      }
 
-  @if (createError()) {
-    <mat-error>{{ createError() }}</mat-error>
-  } @else if (formUtils.isValidField(form(), field().name)) {
-    <mat-error>{{ formUtils.getFieldError(form(), field()) }}</mat-error>
-  }
-</mat-form-field>
+      @for (option of filteredOptions(); track option.value) {
+        <mat-option [value]="option">{{ option.label }}</mat-option>
+      }
+
+      @if (
+        filteredOptions().length === 0 && !field().selectConfig?.onCreateRecord
+      ) {
+        <mat-option disabled>No results found</mat-option>
+      }
+    </mat-autocomplete>
+
+    @if (createError()) {
+      <mat-error>{{ createError() }}</mat-error>
+    } @else if (formUtils.isValidField(form(), field().name)) {
+      <mat-error>{{ formUtils.getFieldError(form(), field()) }}</mat-error>
+    }
+  </mat-form-field>
+</div>

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.html
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.html
@@ -1,0 +1,78 @@
+<mat-form-field
+  [floatLabel]="field().floatingLabel ?? 'auto'"
+  class="w-full"
+  appearance="outline"
+>
+  <mat-label>{{ field().label }}</mat-label>
+  @if (!isCreating()) {
+    <mat-icon matPrefix>search</mat-icon>
+  }
+
+  <input
+    matInput
+    #trigger="matAutocompleteTrigger"
+    type="text"
+    [formControlName]="field().label"
+    [placeholder]="
+      isCreating()
+        ? (field().selectConfig?.addNewLabel ?? 'New' + field().label)
+        : (field().placeholder ?? 'Search')
+    "
+    [matAutocomplete]="auto"
+    [disabled]="isSaving()"
+    (input)="onInput($any($event.target).value)"
+  />
+
+  @if (isCreating()) {
+    @if (isSaving()) {
+      <mat-spinner matSuffix diameter="18"></mat-spinner>
+    } @else {
+      <button
+        matSuffix
+        mat-button
+        color="primary"
+        type="button"
+        [disabled]="!searchTerm().trim()"
+        (click)="save(trigger)"
+      >
+        Save
+      </button>
+      <button
+        matSuffix
+        mat-icon-button
+        type="button"
+        (click)="cancelCreating()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    }
+  }
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    [displayWith]="displayFn"
+    (optionSelected)="onOptionSelected($event.option.value)"
+  >
+    @if (field().selectConfig?.onCreateRecord && !hasExactMatch()) {
+      <mat-option class="add-new-option" (click)="startCreating()">
+        <mat-icon>add</mat-icon>
+        {{ field().selectConfig?.addNewLabel ?? 'New ' + field().label }}
+      </mat-option>
+    }
+
+    @for (option of filteredOptions(); track option.label) {
+      <mat-option [value]="option">{{ option.label }}</mat-option>
+    }
+
+    @if (
+      filteredOptions().length === 0 && !field().selectConfig?.onCreateRecord
+    ) {
+      <mat-option disabled>No results found</mat-option>
+    }
+  </mat-autocomplete>
+
+  @if (createError()) {
+    <mat-error>{{ createError() }}</mat-error>
+  } @else if (formUtils.isValidField(form(), field().name)) {
+    <mat-error>{{ formUtils.getFieldError(form(), field()) }}</mat-error>
+  }
+</mat-form-field>

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.html
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.html
@@ -12,7 +12,7 @@
     matInput
     #trigger="matAutocompleteTrigger"
     type="text"
-    [formControlName]="field().label"
+    [formControlName]="field().name"
     [placeholder]="
       isCreating()
         ? (field().selectConfig?.addNewLabel ?? 'New' + field().label)

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.html
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.html
@@ -12,7 +12,7 @@
     matInput
     #trigger="matAutocompleteTrigger"
     type="text"
-    [formControlName]="field().name"
+    [formControl]="control()"
     [placeholder]="
       isCreating()
         ? (field().selectConfig?.addNewLabel ?? 'New' + field().label)
@@ -59,7 +59,7 @@
       </mat-option>
     }
 
-    @for (option of filteredOptions(); track option.label) {
+    @for (option of filteredOptions(); track option.value) {
       <mat-option [value]="option">{{ option.label }}</mat-option>
     }
 

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.html
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.html
@@ -32,6 +32,7 @@
           <button
             matSuffix
             mat-button
+            class="save"
             color="primary"
             type="button"
             [disabled]="!searchTerm().trim()"

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.scss
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.scss
@@ -1,0 +1,30 @@
+$font-text-md: var(--font-size-medium);
+
+.button-save-cancel {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: $font-text-md;
+  font-weight: 500;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+}
+
+.upload-field-wrapper {
+  position: relative;
+
+  mat-form-field {
+    margin-bottom: 0;
+  }
+
+  &:has(.field-error) .choose-file-button {
+    top: 24%;
+  }
+}

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.scss
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.scss
@@ -19,12 +19,4 @@ $font-text-md: var(--font-size-medium);
 
 .upload-field-wrapper {
   position: relative;
-
-  mat-form-field {
-    margin-bottom: 0;
-  }
-
-  &:has(.field-error) .choose-file-button {
-    top: 24%;
-  }
 }

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.spec.ts
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.spec.ts
@@ -1,22 +1,207 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CreatableInputComponent } from './creatable-input.component';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { DynamicField } from '../form-factory.interface';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { of, throwError } from 'rxjs';
 
 describe('CreatableInputComponent', () => {
   let component: CreatableInputComponent;
   let fixture: ComponentFixture<CreatableInputComponent>;
 
+  let form: FormGroup;
+  let field: Partial<DynamicField>;
+  // let control: FormControl;
+
   beforeEach(async () => {
+    // control = new FormControl(null);
+    form = new FormGroup({
+      category: new FormControl(null),
+    });
+    field = {
+      name: 'category',
+      options: [
+        { label: 'Device1', value: 'device1' },
+        { label: 'Device2', value: 'device2' },
+        { label: 'Device3', value: 'device3' },
+      ],
+      selectConfig: {},
+    } as DynamicField;
     await TestBed.configureTestingModule({
-      imports: [CreatableInputComponent],
+      imports: [ReactiveFormsModule, CreatableInputComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreatableInputComponent);
     component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('form', form);
+    fixture.componentRef.setInput('field', field);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should filter options case-insensitively', () => {
+    component.searchTerm.set('1');
+    expect(component.filteredOptions()).toEqual([
+      { label: 'Device1', value: 'device1' },
+    ]);
+  });
+
+  it('should trim whitespace and lowerCase', () => {
+    component.searchTerm.set('  device ');
+    expect(component.filteredOptions()).toEqual([
+      { label: 'Device1', value: 'device1' },
+      { label: 'Device2', value: 'device2' },
+      { label: 'Device3', value: 'device3' },
+    ]);
+  });
+
+  it('should return empty array when nothing matches', () => {
+    component.searchTerm.set('monitor');
+    expect(component.filteredOptions()).toEqual([]);
+  });
+
+  it('should return true when search term is empty', () => {
+    component.searchTerm.set('');
+    expect(component.hasExactMatch()).toBeTrue();
+  });
+
+  it('should return true for exact match', () => {
+    component.searchTerm.set('device1');
+    expect(component.hasExactMatch()).toBeTrue();
+  });
+
+  it('should return false when there is no exact match', () => {
+    component.searchTerm.set('dev');
+    expect(component.hasExactMatch()).toBeFalse();
+  });
+
+  it('should return empty string for null', () => {
+    expect(component.displayFn(null)).toBe('');
+  });
+
+  it('should return string value unchanged', () => {
+    expect(component.displayFn('abc')).toBe('abc');
+  });
+
+  it('should return lookup label', () => {
+    expect(component.displayFn({ label: 'Test', value: 'Test' })).toBe('Test');
+  });
+  it('should update search term and clear errors', () => {
+    component.createError.set('Some error');
+    component.onInput('hello');
+    expect(component.searchTerm()).toBe('hello');
+    expect(component.createError()).toBeNull();
+  });
+  it('should set the control value and reset state', () => {
+    const option = {
+      label: 'Apple',
+      value: 1,
+    };
+    component.searchTerm.set('abc');
+    component.isCreating.set(true);
+    component.onOptionSelected(option);
+    expect(form.get('category')?.value).toEqual(option);
+    expect(component.searchTerm()).toBe('');
+    expect(component.isCreating()).toBeFalse();
+  });
+  it('should enable creating mode and clear errors', () => {
+    component.createError.set('error');
+    component.startCreating();
+    expect(component.isCreating()).toBeTrue();
+    expect(component.createError()).toBeNull();
+  });
+  it('should disable creating mode and clear errors', () => {
+    component.isCreating.set(true);
+    component.createError.set('error');
+    component.cancelCreating();
+    expect(component.isCreating()).toBeFalse();
+    expect(component.createError()).toBeNull();
+  });
+
+  describe('save', () => {
+    let trigger: jasmine.SpyObj<MatAutocompleteTrigger>;
+
+    beforeEach(() => {
+      trigger = jasmine.createSpyObj('MatAutocompleteTrigger', ['closePanel']);
+    });
+
+    it('should do nothing when search term is empty', () => {
+      const spy = jasmine.createSpy();
+
+      field!.selectConfig!.onCreateRecord = spy;
+
+      component.searchTerm.set('   ');
+
+      component.save(trigger);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when onCreateRecord is missing', () => {
+      field.selectConfig = {};
+
+      component.searchTerm.set('New');
+
+      component.save(trigger);
+
+      expect(component.isSaving()).toBeFalse();
+    });
+
+    it('should create a new option successfully', () => {
+      const created = {
+        label: 'Ignored',
+        value: 999,
+      };
+      field.selectConfig!.onCreateRecord = jasmine
+        .createSpy()
+        .and.returnValue(of(created));
+      component.searchTerm.set('New Item');
+
+      component.save(trigger);
+
+      expect(field!.selectConfig!.onCreateRecord).toHaveBeenCalledWith(
+        'New Item'
+      );
+
+      expect(form.get('category')?.value).toEqual({
+        label: 'New Item',
+        value: 'New Item',
+      });
+
+      expect(component.searchTerm()).toBe('');
+      expect(component.isCreating()).toBeFalse();
+      expect(component.isSaving()).toBeFalse();
+      expect(component.createError()).toBeNull();
+      expect(trigger.closePanel).toHaveBeenCalled();
+    });
+
+    it('should set error when creation fails', () => {
+      field.selectConfig!.onCreateRecord = jasmine.createSpy().and.returnValue(
+        throwError(() => ({
+          error: {
+            message: 'Creation failed',
+          },
+        }))
+      );
+      component.searchTerm.set('New Item');
+      component.save(trigger);
+      expect(component.createError()).toBe('Creation failed');
+      expect(component.isSaving()).toBeFalse();
+      expect(trigger.closePanel).not.toHaveBeenCalled();
+    });
+
+    it('should clear previous error before saving', () => {
+      field.selectConfig!.onCreateRecord = jasmine
+        .createSpy()
+        .and.returnValue(of({}));
+
+      component.createError.set('Old error');
+      component.searchTerm.set('Test');
+
+      component.save(trigger);
+
+      expect(component.createError()).toBeNull();
+    });
   });
 });

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.spec.ts
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreatableInputComponent } from './creatable-input.component';
+
+describe('CreatableInputComponent', () => {
+  let component: CreatableInputComponent;
+  let fixture: ComponentFixture<CreatableInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreatableInputComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreatableInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
@@ -1,0 +1,112 @@
+import { Component, computed, input, signal } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormUtils } from '@core/utils/forms/form-utils';
+import { DynamicField } from '../form-factory.interface';
+import { MatLabel } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
+import {
+  MatAutocompleteModule,
+  MatAutocompleteTrigger,
+} from '@angular/material/autocomplete';
+import { Lookup } from '@core/models/lookup';
+import { finalize } from 'rxjs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-creatable-component',
+  imports: [
+    ReactiveFormsModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatLabel,
+    MatFormFieldModule,
+    MatAutocompleteModule,
+  ],
+  templateUrl: './creatable-input.component.html',
+  styleUrl: './creatable-input.component.scss',
+})
+export class CreatableInputComponent {
+  field = input.required<DynamicField>();
+  form = input.required<FormGroup>();
+  formUtils = FormUtils;
+
+  private _control = computed(() => this.form().get(this.field().name));
+
+  private _createdOptions = signal<Lookup[]>([]);
+
+  searchTerm = signal<string>('');
+  isCreating = signal(false);
+  isSaving = signal(false);
+  createError = signal<string | null>(null);
+
+  filteredOptions = computed(() => {
+    const options = (this.field().options ?? []) as Lookup[];
+    const term = (this.searchTerm() ?? '').toString().toLowerCase().trim();
+
+    if (!term) return options;
+
+    return options.filter(option => option.label.toLowerCase().includes(term));
+  });
+
+  hasExactMatch = computed(() => {
+    const term = this.searchTerm().trim().toLowerCase();
+    if (!term) return true;
+    return this.filteredOptions().some(o => o.label.toLowerCase() === term);
+  });
+
+  displayFn = (value: string | Lookup | null): string => {
+    if (!value) return '';
+    return typeof value === 'string' ? value : (value.label ?? '');
+  };
+
+  onInput(inputValue: string): void {
+    this.searchTerm.set(inputValue);
+    this.createError.set(null);
+  }
+
+  onOptionSelected(option: Lookup): void {
+    this._control()?.setValue(option);
+    this.searchTerm.set('');
+    this.isCreating.set(false);
+  }
+
+  startCreating(): void {
+    this.isCreating.set(true);
+    this.createError.set(null);
+  }
+
+  cancelCreating(): void {
+    this.isCreating.set(false);
+    this.createError.set(null);
+  }
+
+  save(trigger: MatAutocompleteTrigger): void {
+    const name = this.searchTerm().trim();
+    const onCreateFn = this.field().selectConfig?.onCreateRecord;
+
+    if (!name || !onCreateFn) return;
+
+    this.isSaving.set(true);
+    this.createError.set(null);
+
+    onCreateFn(name)
+      .pipe(finalize(() => this.isSaving.set(false)))
+      .subscribe({
+        next: created => {
+          this._createdOptions.update(opts => [...opts, created]);
+          this._control()?.setValue(created);
+          this.searchTerm.set('');
+          this.isCreating.set(false);
+          trigger.closePanel();
+        },
+        error: err => {
+          this.createError.set(err?.error?.message);
+        },
+      });
+  }
+}

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
@@ -1,7 +1,7 @@
-import { Component, computed, input, signal } from '@angular/core';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Component, computed, input, InputSignal, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormUtils } from '@core/utils/forms/form-utils';
-import { DynamicField } from '../form-factory.interface';
+import { DynamicField, DynamicInputComponent } from '../form-factory.interface';
 import { MatLabel } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import {
@@ -14,6 +14,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-creatable-component',
@@ -25,17 +26,18 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     MatProgressSpinnerModule,
     MatLabel,
     MatFormFieldModule,
+    CommonModule,
     MatAutocompleteModule,
   ],
   templateUrl: './creatable-input.component.html',
   styleUrl: './creatable-input.component.scss',
 })
-export class CreatableInputComponent {
-  field = input.required<DynamicField>();
-  form = input.required<FormGroup>();
+export class CreatableInputComponent implements DynamicInputComponent {
+  field: InputSignal<DynamicField> = input.required<DynamicField>();
+  form: InputSignal<FormGroup> = input.required<FormGroup>();
   formUtils = FormUtils;
 
-  private _control = computed(() => this.form().get(this.field().name));
+  control = computed(() => this.form().get(this.field().name) as FormControl);
 
   private _createdOptions = signal<Lookup[]>([]);
 
@@ -70,7 +72,7 @@ export class CreatableInputComponent {
   }
 
   onOptionSelected(option: Lookup): void {
-    this._control()?.setValue(option);
+    this.control()?.setValue(option);
     this.searchTerm.set('');
     this.isCreating.set(false);
   }
@@ -98,8 +100,9 @@ export class CreatableInputComponent {
       .pipe(finalize(() => this.isSaving.set(false)))
       .subscribe({
         next: created => {
+          created = { label: name, value: name };
           this._createdOptions.update(opts => [...opts, created]);
-          this._control()?.setValue(created);
+          this.control()?.setValue(created);
           this.searchTerm.set('');
           this.isCreating.set(false);
           trigger.closePanel();

--- a/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
+++ b/src/app/core/factories/forms/creatable-input/creatable-input.component.ts
@@ -48,11 +48,14 @@ export class CreatableInputComponent implements DynamicInputComponent {
 
   filteredOptions = computed(() => {
     const options = (this.field().options ?? []) as Lookup[];
+    const lastOptions = [...options, ...this._createdOptions()];
     const term = (this.searchTerm() ?? '').toString().toLowerCase().trim();
 
-    if (!term) return options;
+    if (!term) return lastOptions;
 
-    return options.filter(option => option.label.toLowerCase().includes(term));
+    return lastOptions.filter(option =>
+      option.label.toLowerCase().includes(term)
+    );
   });
 
   hasExactMatch = computed(() => {
@@ -91,7 +94,7 @@ export class CreatableInputComponent implements DynamicInputComponent {
     const name = this.searchTerm().trim();
     const onCreateFn = this.field().selectConfig?.onCreateRecord;
 
-    if (!name || !onCreateFn) return;
+    if (!name || !onCreateFn || this.hasExactMatch()) return;
 
     this.isSaving.set(true);
     this.createError.set(null);

--- a/src/app/core/factories/forms/form-factory.interface.ts
+++ b/src/app/core/factories/forms/form-factory.interface.ts
@@ -4,6 +4,7 @@ import { EventEmitter, InputSignal } from '@angular/core';
 import { FormUtils } from '@core/utils/forms/form-utils';
 import { Lookup, LookupExtended } from '@core/models/lookup';
 import { FloatLabelType } from '@angular/material/form-field';
+import { Observable } from 'rxjs';
 
 export type FieldType =
   | 'date'
@@ -13,7 +14,8 @@ export type FieldType =
   | 'password'
   | 'searchableSelect'
   | 'file'
-  | 'number';
+  | 'number'
+  | 'creatableSelect';
 
 export type ValueType =
   | string
@@ -47,6 +49,8 @@ export interface DynamicField {
   fileConfig?: FileFieldConfig;
   selectConfig?: {
     displayMode?: ModeType;
+    addNewLabel?: string;
+    onCreateRecord?: (name: string) => Observable<Lookup>;
   };
   max?: number;
   min?: number;

--- a/src/app/core/factories/forms/form-factory.service.ts
+++ b/src/app/core/factories/forms/form-factory.service.ts
@@ -10,6 +10,7 @@ import { PasswordInputComponent } from './password-input/password-input.componen
 import { SearchableSelectComponent } from './searchable-select/searchable-select.component';
 import { UploadInputComponent } from './upload-input/upload-input.component';
 import { NumberInputComponent } from './number-input/number-input.component';
+import { CreatableInputComponent } from './creatable-input/creatable-input.component';
 
 @Injectable({
   providedIn: 'root',
@@ -24,6 +25,7 @@ export class FormFactoryService {
     searchableSelect: SearchableSelectComponent,
     file: UploadInputComponent,
     number: NumberInputComponent,
+    creatableSelect: CreatableInputComponent,
   };
 
   getComponentByType(type: string): Type<DynamicInputComponent> {

--- a/src/app/modules/assessments/components/assessments.component.spec.ts
+++ b/src/app/modules/assessments/components/assessments.component.spec.ts
@@ -3,6 +3,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AssessmentsComponent } from './assessments.component';
 import { provideHttpClient } from '@angular/common/http';
 import Keycloak from 'keycloak-js';
+import { of, throwError } from 'rxjs';
+import { UserDataService } from '@core/services/access/user-data.service';
+import { StudentService } from '@core/services/api/student.service';
+import { ProfessionalsService } from '@modules/supports-referrals/services/professionals.service';
+import { JuServicesService } from '@modules/supports-referrals/services/juServices.service';
+import { MatDialog } from '@angular/material/dialog';
+import { AssessmentModel } from '@core/models/assessment.model';
+import { EditAssessmentModalComponent } from './edit-assessment-modal/edit-assessment-modal.component';
+import { NewAssessmentModalComponent } from './new-assessment-modal/new-assessment-modal.component';
+import { AssessmentService } from '@core/services/api/assessement.service';
 
 const keycloakMock = {
   token: 'fake-token',
@@ -13,14 +23,83 @@ describe('AssessmentsComponent', () => {
   let component: AssessmentsComponent;
   let fixture: ComponentFixture<AssessmentsComponent>;
 
+  let dialog: jasmine.SpyObj<MatDialog>;
+  let juServicesService: jasmine.SpyObj<JuServicesService>;
+  let professionalsService: jasmine.SpyObj<ProfessionalsService>;
+  let studentService: jasmine.SpyObj<StudentService>;
+  let userDataService: jasmine.SpyObj<UserDataService>;
+
+  const dialogRef = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+  dialogRef.afterClosed.and.returnValue(of(undefined));
+
   beforeEach(async () => {
+    dialog = jasmine.createSpyObj('MatDialog', ['open']);
+    juServicesService = jasmine.createSpyObj('JuServicesService', [
+      'getAllJuServices',
+      'addNewService',
+    ]);
+    professionalsService = jasmine.createSpyObj('ProfessionalsService', [
+      'getAllProfessionals',
+      'addNewProfessional',
+    ]);
+    studentService = jasmine.createSpyObj('StudentService', ['getAllStudents']);
+    userDataService = jasmine.createSpyObj('UserDataService', ['user']);
+    userDataService.user.and.returnValue({
+      fullName: 'John Doe',
+    });
+    studentService.getAllStudents.and.returnValue(
+      of({
+        items: [
+          {
+            id: 1,
+            name: 'Student One',
+            uuid: '',
+            email: 'd',
+            isImported: false,
+            studentDetail: {
+              id: 1,
+              studentId: 1,
+              enrolledCourses: 2,
+              gradedCourses: 2,
+              timeDeliveryRate: 6,
+              avgScore: 5,
+              coursesUnderAvg: 5,
+              pureScoreDiff: 1,
+              standardScoreDiff: 2,
+              lastAccessDays: 1,
+            },
+            cohortId: 5,
+          },
+        ],
+        count: 1,
+      })
+    );
+    const assessmentServiceMock = {
+      getAll: jasmine.createSpy().and.returnValue(of([])),
+      deleteAssessment: jasmine.createSpy().and.returnValue(of(undefined)),
+      clearCache: jasmine.createSpy(),
+    };
+    dialog.open.and.returnValue(dialogRef);
+
     await TestBed.configureTestingModule({
       imports: [AssessmentsComponent],
       providers: [
-        { provide: Keycloak, useValue: keycloakMock },
         provideHttpClient(),
+        { provide: Keycloak, useValue: keycloakMock },
+        { provide: MatDialog, useValue: dialog },
+        { provide: AssessmentService, useValue: assessmentServiceMock },
+        { provide: JuServicesService, useValue: juServicesService },
+        { provide: ProfessionalsService, useValue: professionalsService },
+        { provide: StudentService, useValue: studentService },
+        { provide: UserDataService, useValue: userDataService },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(AssessmentsComponent, {
+        set: {
+          providers: [{ provide: MatDialog, useValue: dialog }],
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(AssessmentsComponent);
     component = fixture.componentInstance;
@@ -29,5 +108,202 @@ describe('AssessmentsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should throw error by getting lookups', () => {
+    juServicesService.getAllJuServices.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+    expect(component.lookupLoading()).toBeFalse();
+  });
+
+  it('should load static lookups on init', () => {
+    expect(studentService.getAllStudents).toHaveBeenCalled();
+    expect(userDataService.user).toHaveBeenCalled();
+    expect(component.lookupLoading()).toBeFalse();
+  });
+
+  it('should use mocked dialog', () => {
+    expect(component['matDialog']).toBe(dialog);
+  });
+  it('should open create dialog', () => {
+    juServicesService.getAllJuServices.and.returnValue(
+      of({
+        items: [
+          {
+            name: 'Speech',
+            id: 1,
+            audit: {
+              createdBy: 'configurator',
+              createdAt: new Date(),
+              modifiedBy: 'configurator',
+              modifiedAt: new Date(),
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+    professionalsService.getAllProfessionals.and.returnValue(
+      of({
+        items: [
+          {
+            name: 'Jane',
+            id: 1,
+            uuid: '1',
+            audit: {
+              createdBy: 'configurator',
+              createdAt: new Date(),
+              modifiedBy: 'configurator',
+              modifiedAt: new Date(),
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+    component.openCreateModal();
+
+    expect(juServicesService.getAllJuServices).toHaveBeenCalled();
+    expect(professionalsService.getAllProfessionals).toHaveBeenCalled();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      NewAssessmentModalComponent,
+      jasmine.objectContaining({
+        data: jasmine.objectContaining({
+          services: jasmine.any(Array),
+          professionals: jasmine.any(Array),
+        }),
+      })
+    );
+  });
+
+  it('should open edit dialog', () => {
+    juServicesService.getAllJuServices.and.returnValue(
+      of({ items: [], count: 0 })
+    );
+    professionalsService.getAllProfessionals.and.returnValue(
+      of({ items: [], count: 0 })
+    );
+    const assessment = {
+      id: 10,
+    } as AssessmentModel;
+    component.openEditModal(assessment);
+    expect(dialog.open).toHaveBeenCalledWith(
+      EditAssessmentModalComponent,
+      jasmine.objectContaining({
+        data: jasmine.objectContaining({
+          assessment,
+        }),
+      })
+    );
+  });
+
+  it('should create a service', () => {
+    juServicesService.addNewService.and.returnValue(
+      of({
+        id: 1,
+        name: 'Speech',
+        audit: {
+          createdBy: 'test',
+          createdAt: new Date(),
+          modifiedBy: 'test',
+          modifiedAt: new Date(),
+        },
+      })
+    );
+    component['createService']('Speech').subscribe(result => {
+      expect(result).toEqual({
+        label: 'Speech',
+        value: 'Speech',
+      });
+    });
+    expect(juServicesService.addNewService).toHaveBeenCalled();
+  });
+
+  it('should create a professional and return lookup value', () => {
+    professionalsService.addNewProfessional.and.returnValue(
+      of({
+        id: 1,
+        name: 'Jane',
+        uuid: 'uuid',
+        audit: {
+          createdBy: 'test',
+          createdAt: new Date(),
+          modifiedBy: 'test',
+          modifiedAt: new Date(),
+        },
+      })
+    );
+    component['createProfessional']('Jane').subscribe(result => {
+      expect(result).toEqual({
+        label: 'Jane',
+        value: 'Jane',
+      });
+    });
+    expect(professionalsService.addNewProfessional).toHaveBeenCalled();
+  });
+
+  it('should stop loading when create modal lookup fails', () => {
+    juServicesService.getAllJuServices.and.returnValue(
+      throwError(() => new Error('Failed loading services'))
+    );
+    professionalsService.getAllProfessionals.and.returnValue(
+      of({
+        items: [],
+        count: 0,
+      })
+    );
+    component.openCreateModal();
+    expect(component.lookupLoading()).toBeFalse();
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should stop loading when edit modal lookup fails', () => {
+    juServicesService.getAllJuServices.and.returnValue(
+      throwError(() => new Error('Failed loading services'))
+    );
+    professionalsService.getAllProfessionals.and.returnValue(
+      of({
+        items: [],
+        count: 0,
+      })
+    );
+    component.openEditModal({
+      id: 1,
+    } as AssessmentModel);
+    expect(component.lookupLoading()).toBeFalse();
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should open create modal when there is a preselected student', () => {
+    spyOnProperty(history, 'state', 'get').and.returnValue({
+      preselectedStudentId: 123,
+    });
+
+    juServicesService.getAllJuServices.and.returnValue(
+      of({
+        items: [],
+        count: 0,
+      })
+    );
+
+    professionalsService.getAllProfessionals.and.returnValue(
+      of({
+        items: [],
+        count: 0,
+      })
+    );
+
+    component.ngOnInit();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      NewAssessmentModalComponent,
+      jasmine.objectContaining({
+        data: jasmine.objectContaining({
+          preselectedStudentId: 123,
+        }),
+      })
+    );
   });
 });

--- a/src/app/modules/assessments/components/assessments.component.ts
+++ b/src/app/modules/assessments/components/assessments.component.ts
@@ -13,7 +13,7 @@ import { JuServicesService } from '@modules/supports-referrals/services/juServic
 import { ProfessionalsService } from '@modules/supports-referrals/services/professionals.service';
 import { StudentService } from '@core/services/api/student.service';
 import { UserDataService } from '@core/services/access/user-data.service';
-import { forkJoin, map, Observable, of, tap } from 'rxjs';
+import { forkJoin, map, Observable, of } from 'rxjs';
 import { mapFields } from '@modules/supports-referrals/utils/fieldMapper';
 import { AssessmentsLookups } from '../models/assessments.interfaces';
 import { AssessmentListComponent } from './assessment-list/assessment-list.component';
@@ -196,13 +196,6 @@ export class AssessmentsComponent implements OnInit {
       },
     };
     return this.professionalsService.addNewProfessional(newProfessional).pipe(
-      tap((created: AssignedProfessional) => {
-        const option: Lookup = { label: created.name, value: created.name };
-        this.lookups.update(current => ({
-          ...current,
-          professionals: [...current.professionals, option],
-        }));
-      }),
       map(
         (created: AssignedProfessional): Lookup => ({
           label: created.name,
@@ -224,13 +217,6 @@ export class AssessmentsComponent implements OnInit {
       },
     };
     return this.juServicesService.addNewService(service).pipe(
-      tap((created: JuService) => {
-        const option: Lookup = { label: created.name, value: created.name };
-        this.lookups.update(current => ({
-          ...current,
-          services: [...current.services, option],
-        }));
-      }),
       map(
         (created: JuService): Lookup => ({
           label: created.name,

--- a/src/app/modules/assessments/components/assessments.component.ts
+++ b/src/app/modules/assessments/components/assessments.component.ts
@@ -13,7 +13,7 @@ import { JuServicesService } from '@modules/supports-referrals/services/juServic
 import { ProfessionalsService } from '@modules/supports-referrals/services/professionals.service';
 import { StudentService } from '@core/services/api/student.service';
 import { UserDataService } from '@core/services/access/user-data.service';
-import { forkJoin, map, Observable, switchMap, tap } from 'rxjs';
+import { forkJoin, map, Observable, of, tap } from 'rxjs';
 import { mapFields } from '@modules/supports-referrals/utils/fieldMapper';
 import { AssessmentsLookups } from '../models/assessments.interfaces';
 import { AssessmentListComponent } from './assessment-list/assessment-list.component';
@@ -59,47 +59,74 @@ export class AssessmentsComponent implements OnInit {
   lookupLoading: WritableSignal<boolean> = signal<boolean>(false);
 
   ngOnInit(): void {
-    this.checkPreselectedStudent();
-    // this.lookupLoading.set(true);
-    // this.getLookups()
-    //   .pipe(takeUntilDestroyed(this.destroyRef))
-    //   .subscribe({
-    //     next: lookups => this.lookups.set(lookups),
-    //     error: err => console.error('Error retrieving lookups', err),
-    //     complete: () => {
-    //       this.lookupLoading.set(false);
-    //       this.checkPreselectedStudent();
-    //     },
-    //   });
+    this.lookupLoading.set(true);
+    forkJoin({
+      profiles: of(
+        mapFields([this.userDataService.user()!], 'fullName', 'fullName')
+      ),
+      students: this.studentService
+        .getAllStudents()
+        .pipe(map(students => mapFields(students.items, 'name', 'id'))),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ profiles, students }) => {
+          this.lookups.update(current => ({ ...current, profiles, students }));
+        },
+        error: err => console.error('Error retrieving static lookups', err),
+        complete: () => {
+          this.lookupLoading.set(false);
+          this.checkPreselectedStudent();
+        },
+      });
   }
 
   private getLookups(): Observable<AssessmentsLookups> {
-    console.log('aire');
-
     return forkJoin({
       services: this.juServicesService.getAllJuServices(),
-      firstProfessionals: this.professionalsService.getAllProfessionals(),
+      professionals: this.professionalsService.getAllProfessionals({
+        page: 0,
+        pageSize: 1000,
+      }),
       students: this.studentService.getAllStudents(),
     }).pipe(
-      switchMap(({ firstProfessionals, services, students }) =>
-        this.professionalsService
-          .getAllProfessionals({
-            page: 0,
-            pageSize: firstProfessionals.count,
-          })
-          .pipe(
-            map(professionals => ({
-              profiles: mapFields(
-                [this.userDataService.user()!],
-                'fullName',
-                'fullName'
-              ),
-              services: mapFields(services.items, 'name', 'name'),
-              professionals: mapFields(professionals.items, 'name', 'name'),
-              students: mapFields(students.items, 'name', 'id'),
-            }))
-          )
-      )
+      map(({ professionals, services, students }) => ({
+        // this.professionalsService
+        //   .getAllProfessionals({
+        //     page: 0,
+        //     pageSize: firstProfessionals.count,
+        //   })
+        //   .pipe(
+        // map(professionals => ({
+        profiles: mapFields(
+          [this.userDataService.user()!],
+          'fullName',
+          'fullName'
+        ),
+        services: mapFields(services.items, 'name', 'name'),
+        professionals: mapFields(professionals.items, 'name', 'name'),
+        students: mapFields(students.items, 'name', 'id'),
+      }))
+      // ))
+      // )
+      // )
+    );
+  }
+
+  private getVolatileLookups(): Observable<
+    Pick<AssessmentsLookups, 'services' | 'professionals'>
+  > {
+    return forkJoin({
+      services: this.juServicesService.getAllJuServices(),
+      professionals: this.professionalsService.getAllProfessionals({
+        page: 0,
+        pageSize: 1000,
+      }),
+    }).pipe(
+      map(({ services, professionals }) => ({
+        services: mapFields(services.items, 'name', 'name'),
+        professionals: mapFields(professionals.items, 'name', 'name'),
+      }))
     );
   }
 
@@ -115,11 +142,15 @@ export class AssessmentsComponent implements OnInit {
 
   openCreateModal(preselectedStudentId?: number) {
     this.lookupLoading.set(true);
-    this.getLookups()
+    this.getVolatileLookups()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: lookups => {
-          this.lookups.set(lookups);
+        next: ({ services, professionals }) => {
+          this.lookups.update(current => ({
+            ...current,
+            services,
+            professionals,
+          }));
           this.lookupLoading.set(false);
           const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
             ...this.modalConfig,
@@ -140,18 +171,50 @@ export class AssessmentsComponent implements OnInit {
           this.lookupLoading.set(false);
         },
       });
+
+    // const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
+    //   ...this.modalConfig,
+    //   data: {
+    //     ...this.lookups(),
+    //     preselectedStudentId,
+    //     createProfessional: this.createProfessional.bind(this),
+    //   },
+    // });
+
+    // dialogRef
+    //   .afterClosed()
+    //   .pipe(takeUntilDestroyed(this.destroyRef))
+    //   .subscribe(() => this.listComponent()?.loadAssessments());
   }
 
   openEditModal(assessment: AssessmentModel) {
-    const dialogRef = this.matDialog.open(EditAssessmentModalComponent, {
-      ...this.modalConfig,
-      data: { assessment, ...this.lookups() },
-    });
+    this.lookupLoading.set(true);
 
-    dialogRef
-      .afterClosed()
+    this.getVolatileLookups()
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.listComponent()?.loadAssessments());
+      .subscribe({
+        next: ({ services, professionals }) => {
+          this.lookups.update(current => ({
+            ...current,
+            services,
+            professionals,
+          }));
+          this.lookupLoading.set(false);
+          const dialogRef = this.matDialog.open(EditAssessmentModalComponent, {
+            ...this.modalConfig,
+            data: { assessment, ...this.lookups() },
+          });
+
+          dialogRef
+            .afterClosed()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => this.listComponent()?.loadAssessments());
+        },
+        error: err => {
+          console.error('Error retrieving lookups', err);
+          this.lookupLoading.set(false);
+        },
+      });
   }
 
   openDeleteModal(assessment: AssessmentModel) {

--- a/src/app/modules/assessments/components/assessments.component.ts
+++ b/src/app/modules/assessments/components/assessments.component.ts
@@ -23,7 +23,10 @@ import { AssessmentModel } from '@core/models/assessment.model';
 import { EditAssessmentModalComponent } from './edit-assessment-modal/edit-assessment-modal.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Lookup } from '@core/models/lookup';
-import { AssignedProfessional } from '@modules/supports-referrals/models/referrals.interfaces';
+import {
+  AssignedProfessional,
+  JuService,
+} from '@modules/supports-referrals/models/referrals.interfaces';
 
 @Component({
   selector: 'app-assessments',
@@ -81,43 +84,14 @@ export class AssessmentsComponent implements OnInit {
       });
   }
 
-  private getLookups(): Observable<AssessmentsLookups> {
-    return forkJoin({
-      services: this.juServicesService.getAllJuServices(),
-      professionals: this.professionalsService.getAllProfessionals({
-        page: 0,
-        pageSize: 1000,
-      }),
-      students: this.studentService.getAllStudents(),
-    }).pipe(
-      map(({ professionals, services, students }) => ({
-        // this.professionalsService
-        //   .getAllProfessionals({
-        //     page: 0,
-        //     pageSize: firstProfessionals.count,
-        //   })
-        //   .pipe(
-        // map(professionals => ({
-        profiles: mapFields(
-          [this.userDataService.user()!],
-          'fullName',
-          'fullName'
-        ),
-        services: mapFields(services.items, 'name', 'name'),
-        professionals: mapFields(professionals.items, 'name', 'name'),
-        students: mapFields(students.items, 'name', 'id'),
-      }))
-      // ))
-      // )
-      // )
-    );
-  }
-
   private getVolatileLookups(): Observable<
     Pick<AssessmentsLookups, 'services' | 'professionals'>
   > {
     return forkJoin({
-      services: this.juServicesService.getAllJuServices(),
+      services: this.juServicesService.getAllJuServices({
+        page: 0,
+        pageSize: 1000,
+      }),
       professionals: this.professionalsService.getAllProfessionals({
         page: 0,
         pageSize: 1000,
@@ -158,6 +132,7 @@ export class AssessmentsComponent implements OnInit {
               ...this.lookups(),
               preselectedStudentId,
               createProfessional: this.createProfessional.bind(this),
+              createService: this.createService.bind(this),
             },
           });
 
@@ -171,20 +146,6 @@ export class AssessmentsComponent implements OnInit {
           this.lookupLoading.set(false);
         },
       });
-
-    // const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
-    //   ...this.modalConfig,
-    //   data: {
-    //     ...this.lookups(),
-    //     preselectedStudentId,
-    //     createProfessional: this.createProfessional.bind(this),
-    //   },
-    // });
-
-    // dialogRef
-    //   .afterClosed()
-    //   .pipe(takeUntilDestroyed(this.destroyRef))
-    //   .subscribe(() => this.listComponent()?.loadAssessments());
   }
 
   openEditModal(assessment: AssessmentModel) {
@@ -235,10 +196,7 @@ export class AssessmentsComponent implements OnInit {
       },
     };
     return this.professionalsService.addNewProfessional(newProfessional).pipe(
-      // map(response => response.),
       tap((created: AssignedProfessional) => {
-        console.log('cretaed0', created);
-
         const option: Lookup = { label: created.name, value: created.name };
         this.lookups.update(current => ({
           ...current,
@@ -247,6 +205,34 @@ export class AssessmentsComponent implements OnInit {
       }),
       map(
         (created: AssignedProfessional): Lookup => ({
+          label: created.name,
+          value: created.name,
+        })
+      )
+    );
+  };
+
+  private createService = (newService: string): Observable<Lookup> => {
+    const service: JuService = {
+      id: 0,
+      name: newService,
+      audit: {
+        createdBy: 'configurator',
+        createdAt: new Date(),
+        modifiedBy: 'configurator',
+        modifiedAt: new Date(),
+      },
+    };
+    return this.juServicesService.addNewService(service).pipe(
+      tap((created: JuService) => {
+        const option: Lookup = { label: created.name, value: created.name };
+        this.lookups.update(current => ({
+          ...current,
+          services: [...current.services, option],
+        }));
+      }),
+      map(
+        (created: JuService): Lookup => ({
           label: created.name,
           value: created.name,
         })

--- a/src/app/modules/assessments/components/assessments.component.ts
+++ b/src/app/modules/assessments/components/assessments.component.ts
@@ -13,7 +13,7 @@ import { JuServicesService } from '@modules/supports-referrals/services/juServic
 import { ProfessionalsService } from '@modules/supports-referrals/services/professionals.service';
 import { StudentService } from '@core/services/api/student.service';
 import { UserDataService } from '@core/services/access/user-data.service';
-import { forkJoin, map, Observable, tap } from 'rxjs';
+import { forkJoin, map, Observable, switchMap, tap } from 'rxjs';
 import { mapFields } from '@modules/supports-referrals/utils/fieldMapper';
 import { AssessmentsLookups } from '../models/assessments.interfaces';
 import { AssessmentListComponent } from './assessment-list/assessment-list.component';
@@ -59,37 +59,47 @@ export class AssessmentsComponent implements OnInit {
   lookupLoading: WritableSignal<boolean> = signal<boolean>(false);
 
   ngOnInit(): void {
-    this.lookupLoading.set(true);
-    this.getLookups()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: lookups => this.lookups.set(lookups),
-        error: err => console.error('Error retrieving lookups', err),
-        complete: () => {
-          this.lookupLoading.set(false);
-          this.checkPreselectedStudent();
-        },
-      });
+    this.checkPreselectedStudent();
+    // this.lookupLoading.set(true);
+    // this.getLookups()
+    //   .pipe(takeUntilDestroyed(this.destroyRef))
+    //   .subscribe({
+    //     next: lookups => this.lookups.set(lookups),
+    //     error: err => console.error('Error retrieving lookups', err),
+    //     complete: () => {
+    //       this.lookupLoading.set(false);
+    //       this.checkPreselectedStudent();
+    //     },
+    //   });
   }
 
   private getLookups(): Observable<AssessmentsLookups> {
+    console.log('aire');
+
     return forkJoin({
       services: this.juServicesService.getAllJuServices(),
-      professionals: this.professionalsService.getAllProfessionals(),
+      firstProfessionals: this.professionalsService.getAllProfessionals(),
       students: this.studentService.getAllStudents(),
     }).pipe(
-      map(({ services, professionals, students }) => {
-        return {
-          profiles: mapFields(
-            [this.userDataService.user()!],
-            'fullName',
-            'fullName'
-          ),
-          services: mapFields(services.items, 'name', 'name'),
-          professionals: mapFields(professionals.items, 'name', 'name'),
-          students: mapFields(students.items, 'name', 'id'),
-        };
-      })
+      switchMap(({ firstProfessionals, services, students }) =>
+        this.professionalsService
+          .getAllProfessionals({
+            page: 0,
+            pageSize: firstProfessionals.count,
+          })
+          .pipe(
+            map(professionals => ({
+              profiles: mapFields(
+                [this.userDataService.user()!],
+                'fullName',
+                'fullName'
+              ),
+              services: mapFields(services.items, 'name', 'name'),
+              professionals: mapFields(professionals.items, 'name', 'name'),
+              students: mapFields(students.items, 'name', 'id'),
+            }))
+          )
+      )
     );
   }
 
@@ -104,19 +114,32 @@ export class AssessmentsComponent implements OnInit {
   }
 
   openCreateModal(preselectedStudentId?: number) {
-    const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
-      ...this.modalConfig,
-      data: {
-        ...this.lookups(),
-        preselectedStudentId,
-        createProfessional: this.createProfessional.bind(this),
-      },
-    });
-
-    dialogRef
-      .afterClosed()
+    this.lookupLoading.set(true);
+    this.getLookups()
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.listComponent()?.loadAssessments());
+      .subscribe({
+        next: lookups => {
+          this.lookups.set(lookups);
+          this.lookupLoading.set(false);
+          const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
+            ...this.modalConfig,
+            data: {
+              ...this.lookups(),
+              preselectedStudentId,
+              createProfessional: this.createProfessional.bind(this),
+            },
+          });
+
+          dialogRef
+            .afterClosed()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => this.listComponent()?.loadAssessments());
+        },
+        error: err => {
+          console.error('error: ', err);
+          this.lookupLoading.set(false);
+        },
+      });
   }
 
   openEditModal(assessment: AssessmentModel) {
@@ -149,11 +172,14 @@ export class AssessmentsComponent implements OnInit {
       },
     };
     return this.professionalsService.addNewProfessional(newProfessional).pipe(
+      // map(response => response.),
       tap((created: AssignedProfessional) => {
+        console.log('cretaed0', created);
+
         const option: Lookup = { label: created.name, value: created.name };
         this.lookups.update(current => ({
           ...current,
-          professionals: [...current.services, option],
+          professionals: [...current.professionals, option],
         }));
       }),
       map(

--- a/src/app/modules/assessments/components/assessments.component.ts
+++ b/src/app/modules/assessments/components/assessments.component.ts
@@ -13,7 +13,7 @@ import { JuServicesService } from '@modules/supports-referrals/services/juServic
 import { ProfessionalsService } from '@modules/supports-referrals/services/professionals.service';
 import { StudentService } from '@core/services/api/student.service';
 import { UserDataService } from '@core/services/access/user-data.service';
-import { forkJoin, map, Observable } from 'rxjs';
+import { forkJoin, map, Observable, tap } from 'rxjs';
 import { mapFields } from '@modules/supports-referrals/utils/fieldMapper';
 import { AssessmentsLookups } from '../models/assessments.interfaces';
 import { AssessmentListComponent } from './assessment-list/assessment-list.component';
@@ -22,6 +22,8 @@ import { NewAssessmentModalComponent } from './new-assessment-modal/new-assessme
 import { AssessmentModel } from '@core/models/assessment.model';
 import { EditAssessmentModalComponent } from './edit-assessment-modal/edit-assessment-modal.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Lookup } from '@core/models/lookup';
+import { AssignedProfessional } from '@modules/supports-referrals/models/referrals.interfaces';
 
 @Component({
   selector: 'app-assessments',
@@ -104,7 +106,11 @@ export class AssessmentsComponent implements OnInit {
   openCreateModal(preselectedStudentId?: number) {
     const dialogRef = this.matDialog.open(NewAssessmentModalComponent, {
       ...this.modalConfig,
-      data: { ...this.lookups(), preselectedStudentId },
+      data: {
+        ...this.lookups(),
+        preselectedStudentId,
+        createProfessional: this.createProfessional.bind(this),
+      },
     });
 
     dialogRef
@@ -129,4 +135,33 @@ export class AssessmentsComponent implements OnInit {
     if (assessment.id === undefined) return;
     this.listComponent()?.loadAssessments();
   }
+
+  private createProfessional = (name: string): Observable<Lookup> => {
+    const newProfessional: AssignedProfessional = {
+      id: 0,
+      name: name,
+      uuid: crypto.randomUUID(),
+      audit: {
+        createdBy: 'configurator',
+        createdAt: new Date(),
+        modifiedBy: 'configurator',
+        modifiedAt: new Date(),
+      },
+    };
+    return this.professionalsService.addNewProfessional(newProfessional).pipe(
+      tap((created: AssignedProfessional) => {
+        const option: Lookup = { label: created.name, value: created.name };
+        this.lookups.update(current => ({
+          ...current,
+          professionals: [...current.services, option],
+        }));
+      }),
+      map(
+        (created: AssignedProfessional): Lookup => ({
+          label: created.name,
+          value: created.name,
+        })
+      )
+    );
+  };
 }

--- a/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.spec.ts
@@ -1,40 +1,223 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ReactiveFormsModule,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { of, throwError } from 'rxjs';
 
 import { EditAssessmentModalComponent } from './edit-assessment-modal.component';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { provideHttpClient } from '@angular/common/http';
-
-const dialogData = {
-  assessment: {},
-  profiles: [],
-  services: [],
-  professionals: [],
-  students: [],
-};
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { AssessmentService } from '@core/services/api/assessement.service';
+import { AssessmentStatus } from '@core/models/assessment.model';
 
 describe('EditAssessmentModalComponent', () => {
   let component: EditAssessmentModalComponent;
   let fixture: ComponentFixture<EditAssessmentModalComponent>;
 
+  let assessmentService: jasmine.SpyObj<AssessmentService>;
+  let toastService: jasmine.SpyObj<ToastNotificationService>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<EditAssessmentModalComponent>>;
+
+  const assessment = {
+    id: 1,
+    createdAtUtc: '2026-01-01',
+    assignedProfessional: 'John',
+    comments: 'comment',
+    service: 'Speech',
+    studentIds: ['1'],
+    createdBy: 'Admin',
+    status: AssessmentStatus.Remitted,
+    interventions: [],
+  };
+
+  const dialogData = {
+    assessment,
+    students: [
+      {
+        label: 'Student One',
+        value: 1,
+      },
+      {
+        label: 'Student Two',
+        value: 2,
+      },
+    ],
+    profiles: [
+      {
+        label: 'Admin',
+        value: 'Admin',
+      },
+    ],
+    services: [
+      {
+        label: 'Speech',
+        value: 'Speech',
+      },
+    ],
+    professionals: [
+      {
+        label: 'John',
+        value: 'John',
+      },
+    ],
+  };
+
   beforeEach(async () => {
+    assessmentService = jasmine.createSpyObj('AssessmentService', [
+      'editAssessment',
+      'clearCache',
+    ]);
+
+    toastService = jasmine.createSpyObj('ToastNotificationService', [
+      'showToast',
+    ]);
+
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
     await TestBed.configureTestingModule({
-      imports: [EditAssessmentModalComponent],
+      imports: [EditAssessmentModalComponent, ReactiveFormsModule],
       providers: [
-        { provide: MAT_DIALOG_DATA, useValue: dialogData },
+        {
+          provide: AssessmentService,
+          useValue: assessmentService,
+        },
+        {
+          provide: ToastNotificationService,
+          useValue: toastService,
+        },
         {
           provide: MatDialogRef,
-          useValue: { close: jasmine.createSpy('close') },
+          useValue: dialogRef,
         },
-        provideHttpClient(),
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: dialogData,
+        },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditAssessmentModalComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
-
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize form fields', () => {
+    expect(component.formFields.length).toBe(7);
+
+    expect(component.formFields[0].name).toBe('students');
+
+    expect(component.formFields[4].name).toBe('service');
+  });
+
+  it('should set form group and detect changes', () => {
+    const form = new FormGroup({
+      students: new FormControl([1]),
+      date: new FormControl('2026-01-01'),
+      submitter: new FormControl('Admin'),
+      service: new FormControl(
+        {
+          value: 'Speech',
+          label: 'speech',
+        },
+        Validators.required
+      ),
+      professional: new FormControl(
+        {
+          label: 'Professional',
+          value: 'professional',
+        },
+        Validators.required
+      ),
+      professionalComment: new FormControl('comment'),
+      status: new FormControl(AssessmentStatus.Remitted),
+    });
+    component['setFormGroup'](form);
+
+    expect(component.form).toBe(form);
+  });
+
+  it('should edit assessment successfully', () => {
+    const form = new FormGroup({
+      date: new FormControl('2026-01-01'),
+      submitter: new FormControl('Admin'),
+      service: new FormControl(
+        {
+          value: 'Speech',
+          label: 'speech',
+        },
+        Validators.required
+      ),
+      professional: new FormControl(
+        {
+          label: 'Professional',
+          value: 'professional',
+        },
+        Validators.required
+      ),
+      students: new FormControl([1]),
+      professionalComment: new FormControl('comment'),
+      status: new FormControl(AssessmentStatus.Remitted),
+    });
+    component['setFormGroup'](form);
+    assessmentService.editAssessment.and.returnValue(
+      of({
+        ...assessment,
+        studentIds: ['1'],
+      })
+    );
+    component['submitAssessment']();
+
+    expect(assessmentService.editAssessment).toHaveBeenCalled();
+    expect(toastService.showToast).toHaveBeenCalled();
+    expect(assessmentService.clearCache).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should show error toast when edit fails', () => {
+    const form = new FormGroup({
+      date: new FormControl('2026-01-01'),
+      submitter: new FormControl('Admin'),
+      service: new FormControl(
+        {
+          value: 'Speech',
+          label: 'speech',
+        },
+        Validators.required
+      ),
+      professional: new FormControl(
+        {
+          value: 'John',
+          label: 'john',
+        },
+        Validators.required
+      ),
+      students: new FormControl([1]),
+      professionalComment: new FormControl('comment'),
+      status: new FormControl(AssessmentStatus.Remitted),
+    });
+    component['setFormGroup'](form);
+    assessmentService.editAssessment.and.returnValue(
+      throwError(() => ({
+        statusText: 'Bad Request',
+        error: {
+          message: 'Invalid data',
+        },
+      }))
+    );
+    component['submitAssessment']();
+    expect(toastService.showToast).toHaveBeenCalled();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should unsubscribe on destroy', () => {
+    const subscription = jasmine.createSpyObj('Subscription', ['unsubscribe']);
+    component['valueChangesSubscription'] = subscription;
+    component.ngOnDestroy();
+    expect(subscription.unsubscribe).toHaveBeenCalled();
   });
 });

--- a/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
@@ -148,13 +148,16 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         value: this.data.assessment.service,
       },
       {
-        type: 'select',
+        type: 'creatableSelect',
         name: 'professional',
         label: 'Professional',
         placeholder: 'Select a professional',
         options: this.data.professionals,
         validators: [Validators.required],
         floatingLabel: 'always',
+        selectConfig: {
+          onCreateRecord: this.data.createProfessional,
+        },
         value: this.data.assessment.assignedProfessional,
       },
       {

--- a/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
@@ -192,7 +192,7 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
         service: this.form.value.service,
-        assignedProfessional: this.form.value.professional,
+        assignedProfessional: this.form.value.professional.value,
         studentIds: this.form.value.students,
         comments: this.form.value.professionalComment,
         status: this.form.value.status,

--- a/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/edit-assessment-modal/edit-assessment-modal.component.ts
@@ -138,7 +138,7 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         value: this.data.assessment.createdBy,
       },
       {
-        type: 'select',
+        type: 'creatableSelect',
         name: 'service',
         label: 'Service',
         placeholder: 'Select service',
@@ -155,9 +155,6 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         options: this.data.professionals,
         validators: [Validators.required],
         floatingLabel: 'always',
-        selectConfig: {
-          onCreateRecord: this.data.createProfessional,
-        },
         value: this.data.assessment.assignedProfessional,
       },
       {
@@ -194,7 +191,7 @@ export class EditAssessmentModalComponent implements FormCreation, OnDestroy {
         id: this.data.assessment.id,
         createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
-        service: this.form.value.service,
+        service: this.form.value.service.value,
         assignedProfessional: this.form.value.professional.value,
         studentIds: this.form.value.students,
         comments: this.form.value.professionalComment,

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
@@ -109,10 +109,6 @@ describe('NewAssessmentModalComponent', () => {
     it('should set default submitter', () => {
       expect(component.formFields[2].value).toBe('teacher');
     });
-
-    it('should set default service', () => {
-      expect(component.formFields[3].value).toBe('speech');
-    });
   });
 
   describe('closeAndResetDialog', () => {

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.spec.ts
@@ -2,23 +2,62 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NewAssessmentModalComponent } from './new-assessment-modal.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { provideHttpClient } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
+import { AssessmentService } from '@core/services/api/assessement.service';
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { AssessmentStatus } from '@core/models/assessment.model';
 
 describe('NewAssessmentModalComponent', () => {
   let component: NewAssessmentModalComponent;
   let fixture: ComponentFixture<NewAssessmentModalComponent>;
+  let assessmentService: jasmine.SpyObj<AssessmentService>;
+  let toastService: jasmine.SpyObj<ToastNotificationService>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<NewAssessmentModalComponent>>;
+
+  const data = {
+    students: [
+      { label: 'John', value: 1 },
+      { label: 'Jane', value: 2 },
+    ],
+    profiles: [{ label: 'Teacher', value: 'teacher' }],
+    services: [{ label: 'Speech', value: 'speech' }],
+    professionals: [{ label: 'Professional', value: 'professional' }],
+    preselectedStudentId: 1,
+    createService: jasmine.createSpy(),
+    createProfessional: jasmine.createSpy(),
+  };
 
   beforeEach(async () => {
+    assessmentService = jasmine.createSpyObj('AssessmentService', [
+      'createAssessment',
+      'clearCache',
+    ]);
+
+    toastService = jasmine.createSpyObj('ToastNotificationService', [
+      'showToast',
+    ]);
+
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
     await TestBed.configureTestingModule({
-      imports: [NewAssessmentModalComponent],
+      imports: [ReactiveFormsModule, NewAssessmentModalComponent],
       providers: [
+        { provide: AssessmentService, useValue: assessmentService },
+        { provide: ToastNotificationService, useValue: toastService },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: { profiles: [{ label: 'Admin', value: 'admin' }] },
+          useValue: data,
         },
         {
           provide: MatDialogRef,
-          useValue: { close: jasmine.createSpy('close') },
+          useValue: dialogRef,
         },
         provideHttpClient(),
       ],
@@ -26,10 +65,200 @@ describe('NewAssessmentModalComponent', () => {
 
     fixture = TestBed.createComponent(NewAssessmentModalComponent);
     component = fixture.componentInstance;
+
     fixture.detectChanges();
+    component.form = new FormGroup({
+      students: new FormControl([1]),
+      date: new FormControl('2024-01-01', Validators.required),
+      submitter: new FormControl('teacher'),
+      service: new FormControl({
+        label: 'Speech',
+        value: 'speech',
+      }),
+      professional: new FormControl(
+        {
+          label: 'Professional',
+          value: 'professional',
+        },
+        Validators.required
+      ),
+      professionalComment: new FormControl('Comment'),
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('constructor', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialize form fields', () => {
+      expect(component.formFields.length).toBe(6);
+
+      expect(component.formFields[0].name).toBe('students');
+      expect(component.formFields[1].name).toBe('date');
+      expect(component.formFields[2].name).toBe('submitter');
+      expect(component.formFields[3].name).toBe('service');
+      expect(component.formFields[4].name).toBe('professional');
+      expect(component.formFields[5].name).toBe('professionalComment');
+    });
+
+    it('should preselect student', () => {
+      expect(component.formFields[0].value).toEqual([1]);
+    });
+
+    it('should set default submitter', () => {
+      expect(component.formFields[2].value).toBe('teacher');
+    });
+
+    it('should set default service', () => {
+      expect(component.formFields[3].value).toBe('speech');
+    });
+  });
+
+  describe('closeAndResetDialog', () => {
+    it('should close dialog', () => {
+      component.closeAndResetDialog();
+
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('setFormGroup', () => {
+    it('should set form', () => {
+      const form = new FormGroup({
+        test: new FormControl('abc'),
+      });
+
+      component.setFormGroup(form);
+
+      expect(component.form).toBe(form);
+    });
+  });
+
+  describe('submitAssessment', () => {
+    it('should not submit while already submitting', () => {
+      component.isSubmitting = true;
+
+      component.submitAssessment();
+
+      expect(assessmentService.createAssessment).not.toHaveBeenCalled();
+    });
+
+    it('should create assessment successfully', () => {
+      const response = {
+        createdAtUtc: '2024-01-01',
+        createdBy: '',
+        service: 'speech',
+        assignedProfessional: 'teacher',
+        studentIds: ['1'],
+        comments: '',
+        status: AssessmentStatus.Remitted,
+        interventions: [],
+      };
+      assessmentService.createAssessment.and.returnValue(of(response));
+      component.submitAssessment();
+      expect(assessmentService.createAssessment).toHaveBeenCalled();
+
+      const request =
+        assessmentService.createAssessment.calls.mostRecent().args[0];
+
+      expect(request.createdBy).toBe('teacher');
+      expect(request.service).toBe('speech');
+      expect(request.assignedProfessional).toBe('professional');
+      expect(request.comments).toBe('Comment');
+      expect(request.status).toBe(AssessmentStatus.Remitted);
+
+      expect(toastService.showToast).toHaveBeenCalled();
+
+      expect(assessmentService.clearCache).toHaveBeenCalled();
+
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+
+    it('should handle createAssessment error', () => {
+      const error = new HttpErrorResponse({
+        status: 400,
+        statusText: 'Bad Request',
+        error: {
+          title: 'Validation failed',
+        },
+      });
+
+      assessmentService.createAssessment.and.returnValue(
+        throwError(() => error)
+      );
+
+      spyOn(console, 'error');
+
+      component.submitAssessment();
+
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          title: 'Form Submission Failed',
+          message: 'Bad Request: Validation failed',
+          type: 'error',
+        }),
+        true
+      );
+
+      expect(component.isSubmitting).toBeFalse();
+
+      expect(console.error).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('success toast', () => {
+    it('should build message for one student', () => {
+      const toast = component['buildSuccessToastDataObject']({
+        studentIds: ['1'],
+        createdAtUtc: '01/01/2026',
+        createdBy: 'constructor',
+        service: 'new',
+        status: AssessmentStatus.Finalized,
+        interventions: [],
+      });
+      expect(toast.message).not.toContain('other');
+    });
+
+    it('should build message for multiple students', () => {
+      const toast = component['buildSuccessToastDataObject']({
+        studentIds: ['1', '2'],
+        createdAtUtc: '01/01/2026',
+        createdBy: 'constructor',
+        service: 'new',
+        status: AssessmentStatus.Finalized,
+        interventions: [],
+      });
+      expect(toast.message).toContain('other 1 students');
+    });
+  });
+
+  describe('error toast', () => {
+    it('should use API error message', () => {
+      const toast = component['buildErrorToastDataObject'](
+        new HttpErrorResponse({
+          statusText: 'Bad Request',
+          error: {
+            title: 'Invalid data',
+          },
+        })
+      );
+
+      expect(toast).toEqual({
+        title: 'Form Submission Failed',
+        message: 'Bad Request: Invalid data',
+        type: 'error',
+      });
+    });
+
+    it('should use default error message', () => {
+      const toast = component['buildErrorToastDataObject'](
+        new HttpErrorResponse({
+          statusText: 'Bad Request',
+          error: {},
+        })
+      );
+      expect(toast.message).toContain('There was an error submitting the form');
+    });
   });
 });

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -121,7 +121,7 @@ export class NewAssessmentModalComponent implements FormCreation {
         createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
         service: this.form.value.service,
-        assignedProfessional: this.form.value.professional,
+        assignedProfessional: this.form.value.professional.value,
         studentIds: this.form.value.students,
         comments: this.form.value.professionalComment,
         status: AssessmentStatus.Remitted,

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -80,15 +80,19 @@ export class NewAssessmentModalComponent implements FormCreation {
         options: this.data.services,
         validators: [Validators.required],
         floatingLabel: 'always',
+        value: this.data.services[0]?.value,
       },
       {
-        type: 'select',
+        type: 'creatableSelect',
         name: 'professional',
         label: 'Professional',
         placeholder: 'Select a professional',
         options: this.data.professionals,
         validators: [Validators.required],
         floatingLabel: 'always',
+        selectConfig: {
+          onCreateRecord: this.data.createProfessional,
+        },
       },
       {
         type: 'textarea',

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -73,7 +73,7 @@ export class NewAssessmentModalComponent implements FormCreation {
         value: this.data.profiles?.[0]?.value ?? null,
       },
       {
-        type: 'select',
+        type: 'creatableSelect',
         name: 'service',
         label: 'Service',
         placeholder: 'Select service',
@@ -81,6 +81,9 @@ export class NewAssessmentModalComponent implements FormCreation {
         validators: [Validators.required],
         floatingLabel: 'always',
         value: this.data.services[0]?.value,
+        selectConfig: {
+          onCreateRecord: this.data.createService,
+        },
       },
       {
         type: 'creatableSelect',
@@ -120,7 +123,7 @@ export class NewAssessmentModalComponent implements FormCreation {
       const newAssessment: AssessmentModel = {
         createdAtUtc: new Date(this.form.value.date).toISOString(),
         createdBy: this.form.value.submitter,
-        service: this.form.value.service,
+        service: this.form.value.service.value,
         assignedProfessional: this.form.value.professional.value,
         studentIds: this.form.value.students,
         comments: this.form.value.professionalComment,

--- a/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
+++ b/src/app/modules/assessments/components/new-assessment-modal/new-assessment-modal.component.ts
@@ -80,7 +80,6 @@ export class NewAssessmentModalComponent implements FormCreation {
         options: this.data.services,
         validators: [Validators.required],
         floatingLabel: 'always',
-        value: this.data.services[0]?.value,
         selectConfig: {
           onCreateRecord: this.data.createService,
         },

--- a/src/app/modules/assessments/models/assessments.interfaces.ts
+++ b/src/app/modules/assessments/models/assessments.interfaces.ts
@@ -3,6 +3,7 @@ import {
   AssessmentStatus,
 } from '@core/models/assessment.model';
 import { Lookup } from '@core/models/lookup';
+import { Observable } from 'rxjs';
 
 export interface AssessmentsLookups {
   profiles: Lookup[];
@@ -10,6 +11,7 @@ export interface AssessmentsLookups {
   professionals: Lookup[];
   students: Lookup[];
   preselectedStudentId?: number;
+  createProfessional?: (name: string) => Observable<Lookup>;
 }
 
 export interface AssessmentModalData extends AssessmentsLookups {

--- a/src/app/modules/assessments/models/assessments.interfaces.ts
+++ b/src/app/modules/assessments/models/assessments.interfaces.ts
@@ -12,6 +12,7 @@ export interface AssessmentsLookups {
   students: Lookup[];
   preselectedStudentId?: number;
   createProfessional?: (name: string) => Observable<Lookup>;
+  createService?: (record: string) => Observable<Lookup>;
 }
 
 export interface AssessmentModalData extends AssessmentsLookups {

--- a/src/app/modules/supports-referrals/models/referrals.interfaces.ts
+++ b/src/app/modules/supports-referrals/models/referrals.interfaces.ts
@@ -44,6 +44,15 @@ export interface JuService {
   id: number;
 }
 
+export interface AddProfessionalResponse {
+  entity: AssignedProfessional;
+  message: string;
+  status: string;
+  success: boolean;
+  successfullImports: number;
+  validationErrors: string[];
+}
+
 export interface AssignedProfessional {
   audit: AuditModel;
   id: number;

--- a/src/app/modules/supports-referrals/services/juServices.service.ts
+++ b/src/app/modules/supports-referrals/services/juServices.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { Observable } from 'rxjs';
+import { Observable, shareReplay, tap } from 'rxjs';
 
 import { JuService } from '../models/referrals.interfaces';
 import { PagedResult } from '@core/services/interfaces/page.type';
@@ -14,21 +14,35 @@ import { HttpParams } from '@angular/common/http';
 })
 export class JuServicesService extends BaseApiService {
   protected resource = 'ju_services';
+  private cache$: Observable<PagedResult<JuService>> | null = null;
 
   getAllJuServices(
     pagination?: Pagination
   ): Observable<PagedResult<JuService>> {
     let params = undefined;
 
+    if (this.cache$) {
+      return this.cache$;
+    }
+
     if (pagination) {
       params = new HttpParams()
         .set('PageSize', pagination.pageSize)
         .set('Page', pagination.page);
     }
-    return this.get<PagedResult<JuService>>('', params);
+    this.cache$ = this.get<PagedResult<JuService>>('', params).pipe(
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+    return this.cache$;
   }
 
   addNewService(service: JuService): Observable<JuService> {
-    return this.post<JuService>('', service);
+    return this.post<JuService>('', service).pipe(
+      tap(() => this.invalidateCache())
+    );
+  }
+
+  invalidateCache(): void {
+    this.cache$ = null;
   }
 }

--- a/src/app/modules/supports-referrals/services/juServices.service.ts
+++ b/src/app/modules/supports-referrals/services/juServices.service.ts
@@ -6,6 +6,8 @@ import { JuService } from '../models/referrals.interfaces';
 import { PagedResult } from '@core/services/interfaces/page.type';
 
 import { BaseApiService } from '@core/services/api/base-api.service';
+import { Pagination } from '@core/services/interfaces/server.type';
+import { HttpParams } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +15,20 @@ import { BaseApiService } from '@core/services/api/base-api.service';
 export class JuServicesService extends BaseApiService {
   protected resource = 'ju_services';
 
-  getAllJuServices(): Observable<PagedResult<JuService>> {
-    return this.get<PagedResult<JuService>>('');
+  getAllJuServices(
+    pagination?: Pagination
+  ): Observable<PagedResult<JuService>> {
+    let params = undefined;
+
+    if (pagination) {
+      params = new HttpParams()
+        .set('PageSize', pagination.pageSize)
+        .set('Page', pagination.page);
+    }
+    return this.get<PagedResult<JuService>>('', params);
+  }
+
+  addNewService(service: JuService): Observable<JuService> {
+    return this.post<JuService>('', service);
   }
 }

--- a/src/app/modules/supports-referrals/services/professionals.service.ts
+++ b/src/app/modules/supports-referrals/services/professionals.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { Observable } from 'rxjs';
+import { Observable, shareReplay, tap } from 'rxjs';
 
 import { AssignedProfessional } from '../models/referrals.interfaces';
 import { PagedResult } from '@core/services/interfaces/page.type';
@@ -15,22 +15,37 @@ import { HttpParams } from '@angular/common/http';
 export class ProfessionalsService extends BaseApiService {
   protected resource = 'professionals';
 
+  private cache$: Observable<PagedResult<AssignedProfessional>> | null = null;
+
   getAllProfessionals(
     pagination?: Pagination
   ): Observable<PagedResult<AssignedProfessional>> {
     let params = undefined;
+
+    if (this.cache$) {
+      return this.cache$;
+    }
 
     if (pagination) {
       params = new HttpParams()
         .set('PageSize', pagination.pageSize)
         .set('Page', pagination.page);
     }
-    return this.get<PagedResult<AssignedProfessional>>('', params);
+    this.cache$ = this.get<PagedResult<AssignedProfessional>>('', params).pipe(
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+    return this.cache$;
   }
 
   addNewProfessional(
     professional: AssignedProfessional
   ): Observable<AssignedProfessional> {
-    return this.post<AssignedProfessional>('', professional);
+    return this.post<AssignedProfessional>('', professional).pipe(
+      tap(() => this.invalidateCache())
+    );
+  }
+
+  invalidateCache(): void {
+    this.cache$ = null;
   }
 }

--- a/src/app/modules/supports-referrals/services/professionals.service.ts
+++ b/src/app/modules/supports-referrals/services/professionals.service.ts
@@ -16,4 +16,10 @@ export class ProfessionalsService extends BaseApiService {
   getAllProfessionals(): Observable<PagedResult<AssignedProfessional>> {
     return this.get<PagedResult<AssignedProfessional>>('');
   }
+
+  addNewProfessional(
+    professional: AssignedProfessional
+  ): Observable<AssignedProfessional> {
+    return this.post<AssignedProfessional>('', professional);
+  }
 }

--- a/src/app/modules/supports-referrals/services/professionals.service.ts
+++ b/src/app/modules/supports-referrals/services/professionals.service.ts
@@ -6,6 +6,8 @@ import { AssignedProfessional } from '../models/referrals.interfaces';
 import { PagedResult } from '@core/services/interfaces/page.type';
 
 import { BaseApiService } from '@core/services/api/base-api.service';
+import { Pagination } from '@core/services/interfaces/server.type';
+import { HttpParams } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root',
@@ -13,8 +15,17 @@ import { BaseApiService } from '@core/services/api/base-api.service';
 export class ProfessionalsService extends BaseApiService {
   protected resource = 'professionals';
 
-  getAllProfessionals(): Observable<PagedResult<AssignedProfessional>> {
-    return this.get<PagedResult<AssignedProfessional>>('');
+  getAllProfessionals(
+    pagination?: Pagination
+  ): Observable<PagedResult<AssignedProfessional>> {
+    let params = undefined;
+
+    if (pagination) {
+      params = new HttpParams()
+        .set('PageSize', pagination.pageSize)
+        .set('Page', pagination.page);
+    }
+    return this.get<PagedResult<AssignedProfessional>>('', params);
   }
 
   addNewProfessional(


### PR DESCRIPTION
## Description

New component created for: services and professionals fields in the modal (New assessment modal) in Edit assessment modal the same component is used but is not possible to create new ones.
Added tests related to the new component.
Increased code coverage

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues

#970 