### PR TITLE
Feature/fe 533/show risk level and include it as a new filter in interventions view

### DIFF
--- a/src/app/core/models/assessment.model.ts
+++ b/src/app/core/models/assessment.model.ts
@@ -48,8 +48,8 @@ export interface InterventionModel {
   remarks?: string | null;
   attachments?: string[] | null;
   uploadInput?: File[] | null;
-  riskLevelName?: string;
-  endRiskLevelName?: InterventionStatus;
+  riskLevelName?: RiskLevels;
+  endRiskLevelName?: RiskLevels;
 }
 
 export interface InterventionAttendanceModel {
@@ -82,4 +82,10 @@ export enum InterventionStatus {
   Remitted = 'Remitted',
   InProgress = 'InProgress',
   Finalized = 'Finalized',
+}
+
+export enum RiskLevels {
+  Low = 'Low',
+  Medium = 'Medium',
+  High = 'High',
 }

--- a/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.html
@@ -46,6 +46,23 @@
     <span class="field-label">Student(s):</span>
     <span class="field-value">{{ displayStudents() }}</span>
   </div>
+  @if (data.riskLevelName) {
+    <div class="field-group">
+      <span class="field-label">Risk Level:</span>
+      <span class="field-value">
+        <app-intervention-pill-badge [value]="data.riskLevelName" />
+      </span>
+    </div>
+  }
+
+  @if (data.endRiskLevelName) {
+    <div class="field-group">
+      <span class="field-label">End Risk Level:</span>
+      <span class="field-value">
+        <app-intervention-pill-badge [value]="data.endRiskLevelName" />
+      </span>
+    </div>
+  }
 
   @if (data.area) {
     <div class="field-group">

--- a/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-detail/intervention-detail.component.spec.ts
@@ -1,0 +1,90 @@
+import { InterventionRowViewModel } from '@core/models/assessment.model';
+import { InterventionDetailComponent } from './intervention-detail.component';
+import { InterventionService } from '@core/services/api/intervention.service';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+describe('InterventionDetailComponent', () => {
+  let component: InterventionDetailComponent;
+  let fixture: ComponentFixture<InterventionDetailComponent>;
+  let mockInterventionService: jasmine.SpyObj<InterventionService>;
+
+  const row: InterventionRowViewModel = {
+    commentPreview: '',
+    studentDisplay: [
+      { id: 1, name: 'John Doe', email: 'a@mail.com' },
+      { id: 2, name: 'Jane Smith', email: 'b@mail.com' },
+    ],
+  } as unknown as InterventionRowViewModel;
+
+  beforeEach(async () => {
+    mockInterventionService = jasmine.createSpyObj('InterventionService', [
+      'downloadAttachment',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [InterventionDetailComponent],
+      providers: [
+        {
+          provide: InterventionService,
+          useValue: mockInterventionService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterventionDetailComponent);
+    component = fixture.componentInstance;
+    component.data = row;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display student names when studentDisplay is an array', () => {
+    expect(component.displayStudents()).toBe('John Doe, Jane Smith');
+  });
+
+  it('should return studentDisplay when it is a string', () => {
+    component.data = {
+      ...row,
+      studentDisplay: 'No student assigned',
+    };
+    expect(component.displayStudents()).toBe('No student assigned');
+  });
+
+  it('should emit close event', () => {
+    spyOn(component.close, 'emit');
+    component.onClose();
+    expect(component.close.emit).toHaveBeenCalled();
+  });
+
+  it('should return file name from path', () => {
+    expect(component.getFileName('uploads/docs/file.pdf')).toBe('file.pdf');
+  });
+
+  it('should return original string when path has no slash', () => {
+    expect(component.getFileName('file.pdf')).toBe('file.pdf');
+  });
+
+  it('should return pdf icon', () => {
+    expect(component.getFileIcon('test.pdf')).toBe('picture_as_pdf');
+  });
+
+  it('should return image icon for jpg', () => {
+    expect(component.getFileIcon('image.jpg')).toBe('image');
+  });
+
+  it('should return image icon for jpeg', () => {
+    expect(component.getFileIcon('image.jpeg')).toBe('image');
+  });
+
+  it('should return image icon for png', () => {
+    expect(component.getFileIcon('image.png')).toBe('image');
+  });
+
+  it('should return default icon for other files', () => {
+    expect(component.getFileIcon('file.docx')).toBe('insert_drive_file');
+  });
+});

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -111,6 +111,13 @@
             </td>
           </ng-container>
 
+          <ng-container matColumnDef="risk">
+            <th mat-header-cell *matHeaderCellDef>Risk Level</th>
+            <td mat-cell *matCellDef="let item">
+              <app-intervention-pill-badge [value]="item.riskLevelName" />
+            </td>
+          </ng-container>
+
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef>Status</th>
             <td mat-cell *matCellDef="let item">

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.html
@@ -112,7 +112,21 @@
           </ng-container>
 
           <ng-container matColumnDef="risk">
-            <th mat-header-cell *matHeaderCellDef>Risk Level</th>
+            <th
+              mat-header-cell
+              *matHeaderCellDef
+              (click)="('risk')"
+              class="sortable-header"
+            >
+              Risk Level
+              <mat-icon class="sort-icon" (click)="onSortClick('risk')">
+                {{
+                  sortDirection() === 'asc'
+                    ? 'arrow_drop_up'
+                    : 'arrow_drop_down'
+                }}
+              </mat-icon>
+            </th>
             <td mat-cell *matCellDef="let item">
               <app-intervention-pill-badge [value]="item.riskLevelName" />
             </td>

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.spec.ts
@@ -1,0 +1,273 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InterventionListComponent } from './intervention-list.component';
+import { AssessmentService } from '@core/services/api/assessement.service';
+import { InterventionService } from '@core/services/api/intervention.service';
+import { InterventionFilterStrategy } from '@shared/components/list-filters/strategies/interventions.strategy';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { StudentProfileData } from '../../assessment-list/assessment-student-data/assessment-student-data.component';
+import {
+  AssessmentModel,
+  AssessmentStatus,
+  InterventionMode,
+  InterventionModel,
+  InterventionType,
+} from '@core/models/assessment.model';
+import { of, throwError } from 'rxjs';
+import { PageEvent } from '@angular/material/paginator';
+
+describe('InterventionListComponent', () => {
+  let component: InterventionListComponent;
+  let fixture: ComponentFixture<InterventionListComponent>;
+  let mockAssessmentService: jasmine.SpyObj<AssessmentService>;
+  let mockInterventionService: jasmine.SpyObj<InterventionService>;
+  let mockFilterStrategy: jasmine.SpyObj<InterventionFilterStrategy>;
+
+  const intervention: InterventionModel = {
+    id: 1,
+    assessmentId: 10,
+    comments: 'Test comment',
+    studentIds: [1],
+    kind: InterventionType.Individual,
+    mode: InterventionMode.InPlace,
+    dateUtc: '2026-02-20',
+  } as InterventionModel;
+
+  const assessment: AssessmentModel = {
+    id: 10,
+    status: AssessmentStatus.Remitted,
+  } as AssessmentModel;
+
+  const studentLookup: Record<string, StudentProfileData> = {
+    '1': {
+      id: 1,
+      name: 'Abby',
+      email: 'aby@mail.com',
+    } as StudentProfileData,
+  };
+
+  beforeEach(async () => {
+    mockAssessmentService = jasmine.createSpyObj('AssessmentService', [
+      'getById',
+    ]);
+    mockInterventionService = jasmine.createSpyObj('InterventionService', [
+      'getByAssessment',
+    ]);
+    mockFilterStrategy = jasmine.createSpyObj('InterventionFilterStrategy', [
+      'apply',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [InterventionListComponent],
+      providers: [
+        { provide: AssessmentService, useValue: mockAssessmentService },
+        { provide: InterventionService, useValue: mockInterventionService },
+        { provide: InterventionFilterStrategy, useValue: mockFilterStrategy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InterventionListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load interventions and assessment when assessmentIdInput is set', () => {
+    mockInterventionService.getByAssessment.and.returnValue(of([]));
+    mockAssessmentService.getById.and.returnValue(of(assessment));
+    mockFilterStrategy.apply.and.returnValue([]);
+
+    spyOn(component, 'loadInterventions');
+    component.assessmentIdInput = 10;
+    expect(component.assessmentId()).toBe(10);
+    expect(component.loadInterventions).toHaveBeenCalledWith(10);
+  });
+
+  it('should clear data when assessmentIdInput is null', () => {
+    component['interventions'].set([
+      {
+        studentDisplay: '',
+        commentPreview: '',
+        assessmentId: 0,
+        kind: InterventionType.Individual,
+        mode: InterventionMode.InPlace,
+        dateUtc: '',
+        studentIds: [],
+      },
+    ]);
+    component['assessment'].set(assessment);
+    component.assessmentIdInput = null;
+
+    expect(component['interventions']()).toEqual([]);
+    expect(component['assessment']()).toBeNull();
+  });
+
+  it('should load interventions', () => {
+    component.studentNamesLookup = studentLookup;
+    mockInterventionService.getByAssessment.and.returnValue(of([intervention]));
+    mockFilterStrategy.apply.and.callFake(items => items);
+    component.loadInterventions(10);
+
+    expect(mockInterventionService.getByAssessment).toHaveBeenCalledWith(10);
+    expect(component['isLoading']()).toBeFalse();
+    expect(component['hasInterventions']()).toBeTrue();
+    expect(component['interventions']().length).toBe(1);
+  });
+
+  it('should handle intervention load error', () => {
+    mockInterventionService.getByAssessment.and.returnValue(
+      throwError(() => new Error('error'))
+    );
+    spyOn(console, 'error');
+    component.loadInterventions(10);
+    expect(console.error).toHaveBeenCalled();
+    expect(component['interventions']()).toEqual([]);
+    expect(component['isLoading']()).toBeFalse();
+  });
+
+  it('should refresh selected intervention after reload', () => {
+    component.studentNamesLookup = studentLookup;
+    const updated = {
+      ...intervention,
+      comments: 'Updated',
+    };
+    mockInterventionService.getByAssessment.and.returnValue(of([updated]));
+    component['selectedIntervention'].set({
+      ...updated,
+      studentDisplay: [],
+      commentPreview: '',
+    });
+    component.loadInterventions(10);
+    expect(component['selectedIntervention']()?.comments).toBe('Updated');
+  });
+
+  it('should load assessment', () => {
+    mockAssessmentService.getById.and.returnValue(of(assessment));
+    component['loadAssessment'](10);
+    expect(mockAssessmentService.getById).toHaveBeenCalledWith('10');
+    expect(component['assessment']()).toEqual(assessment);
+    expect(component['isLoadingAssessment']()).toBeFalse();
+  });
+
+  it('should handle assessment load error', () => {
+    mockAssessmentService.getById.and.returnValue(
+      throwError(() => new Error())
+    );
+    spyOn(console, 'error');
+    component['loadAssessment'](10);
+    expect(console.error).toHaveBeenCalled();
+    expect(component['assessment']()).toBeNull();
+    expect(component['isLoadingAssessment']()).toBeFalse();
+  });
+
+  it('should return true when assessment is finalized', () => {
+    component['assessment'].set({
+      status: 'Finalized',
+    } as AssessmentModel);
+    expect(component.statusFinalizedAssessment).toBeTrue();
+  });
+
+  it('should return false when assessment is not finalized', () => {
+    component['assessment'].set({
+      status: AssessmentStatus.Remitted,
+    } as AssessmentModel);
+    expect(component.statusFinalizedAssessment).toBeFalse();
+  });
+
+  it('should emit create event', () => {
+    spyOn(component.createClicked, 'emit');
+    component['onCreateClick']();
+    expect(component.createClicked.emit).toHaveBeenCalled();
+  });
+
+  it('should emit edit event', () => {
+    spyOn(component.editClicked, 'emit');
+    component['onEditClick'](intervention);
+    expect(component.editClicked.emit).toHaveBeenCalledWith(intervention);
+  });
+
+  it('should emit delete event', () => {
+    spyOn(component.deleteClicked, 'emit');
+    component['onDeleteClick'](intervention);
+    expect(component.deleteClicked.emit).toHaveBeenCalledWith(intervention);
+  });
+
+  it('should select intervention on view click', () => {
+    const row = {
+      ...intervention,
+      studentDisplay: [],
+      commentPreview: '',
+    };
+    component['onViewClick'](row);
+    expect(component['selectedIntervention']()).toEqual(row);
+  });
+
+  it('should close detail panel', () => {
+    component['selectedIntervention'].set({
+      studentDisplay: '',
+      commentPreview: '',
+      assessmentId: 0,
+      kind: InterventionType.Individual,
+      mode: InterventionMode.InPlace,
+      dateUtc: '',
+      studentIds: [],
+    });
+    component['closeDetailPanel']();
+    expect(component['selectedIntervention']()).toBeNull();
+  });
+
+  it('should update page index', () => {
+    component['onPageChange']({
+      pageIndex: 2,
+      pageSize: 10,
+    } as PageEvent);
+    expect(component['pageIndex']()).toBe(2);
+  });
+
+  it('should use filter strategy', () => {
+    component.studentNamesLookup = studentLookup;
+    component['interventions'].set([
+      {
+        ...intervention,
+        studentDisplay: [],
+        commentPreview: '',
+      },
+    ]);
+    mockFilterStrategy.apply.and.returnValue(component['interventions']());
+    component['filteredInterventions']();
+    expect(mockFilterStrategy.apply).toHaveBeenCalledWith(
+      component['interventions'](),
+      component.appliedFilters()
+    );
+  });
+  it('should truncate long comments', () => {
+    const longComment = 'a'.repeat(100);
+    mockInterventionService.getByAssessment.and.returnValue(
+      of([
+        {
+          ...intervention,
+          comments: longComment,
+        },
+      ])
+    );
+    component.loadInterventions(10);
+    expect(
+      component['interventions']()[0].commentPreview.endsWith('...')
+    ).toBeTrue();
+  });
+
+  it('should show dash when comments are empty', () => {
+    mockInterventionService.getByAssessment.and.returnValue(
+      of([
+        {
+          ...intervention,
+          comments: '',
+        },
+      ])
+    );
+    component.loadInterventions(10);
+    expect(component['interventions']()[0].commentPreview).toBe('—');
+  });
+});

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { InterventionListComponent } from './intervention-list.component';
+import {
+  InterventionListComponent,
+  InterventionRowViewModel,
+} from './intervention-list.component';
 import { AssessmentService } from '@core/services/api/assessement.service';
 import { InterventionService } from '@core/services/api/intervention.service';
 import { InterventionFilterStrategy } from '@shared/components/list-filters/strategies/interventions.strategy';
@@ -11,6 +14,7 @@ import {
   InterventionMode,
   InterventionModel,
   InterventionType,
+  RiskLevels,
 } from '@core/models/assessment.model';
 import { of, throwError } from 'rxjs';
 import { PageEvent } from '@angular/material/paginator';
@@ -242,6 +246,7 @@ describe('InterventionListComponent', () => {
       component.appliedFilters()
     );
   });
+
   it('should truncate long comments', () => {
     const longComment = 'a'.repeat(100);
     mockInterventionService.getByAssessment.and.returnValue(
@@ -269,5 +274,157 @@ describe('InterventionListComponent', () => {
     );
     component.loadInterventions(10);
     expect(component['interventions']()[0].commentPreview).toBe('—');
+  });
+
+  describe('sorting behavior', () => {
+    const highRisk = {
+      ...intervention,
+      id: 1,
+      dateUtc: '2026-02-20',
+      riskLevelName: RiskLevels.High,
+      studentDisplay: [],
+      commentPreview: '',
+    } as unknown as InterventionRowViewModel;
+
+    const mediumRisk = {
+      ...intervention,
+      id: 2,
+      dateUtc: '2026-03-01',
+      riskLevelName: RiskLevels.Medium,
+      studentDisplay: [],
+      commentPreview: '',
+    } as unknown as InterventionRowViewModel;
+
+    const lowRisk = {
+      ...intervention,
+      id: 3,
+      dateUtc: '2026-01-10',
+      riskLevelName: RiskLevels.Low,
+      studentDisplay: [],
+      commentPreview: '',
+    } as unknown as InterventionRowViewModel;
+
+    describe('onSortClick', () => {
+      it('should set the new column and reset direction to "asc" when a different column is clicked', () => {
+        component['onSortClick']('risk');
+        expect(component['sortColumn']()).toBe('risk');
+        expect(component['sortDirection']()).toBe('asc');
+      });
+
+      it('should toggle direction when the same column is clicked again', () => {
+        component['onSortClick']('risk');
+        expect(component['sortDirection']()).toBe('asc');
+
+        component['onSortClick']('risk');
+        expect(component['sortDirection']()).toBe('desc');
+
+        component['onSortClick']('risk');
+        expect(component['sortDirection']()).toBe('asc');
+      });
+
+      it('should reset pageIndex to 0 when sorting changes', () => {
+        component['pageIndex'].set(2);
+        component['onSortClick']('risk');
+        expect(component['pageIndex']()).toBe(0);
+      });
+    });
+
+    describe('compareByColumn', () => {
+      it('should rank "high" above "medium" and "low" for the risk column', () => {
+        const result = component['compareByColumn'](
+          highRisk,
+          mediumRisk,
+          'risk'
+        );
+        expect(result).toBeGreaterThan(0);
+      });
+
+      it('should rank "low" below "medium" for the risk column', () => {
+        const result = component['compareByColumn'](
+          lowRisk,
+          mediumRisk,
+          'risk'
+        );
+        expect(result).toBeLessThan(0);
+      });
+
+      it('should return 0 when comparing equal risk levels', () => {
+        const anotherHigh = { ...highRisk, id: 4 };
+        const result = component['compareByColumn'](
+          highRisk,
+          anotherHigh,
+          'risk'
+        );
+        expect(result).toBe(0);
+      });
+
+      it('should fall back to string comparison for unknown columns', () => {
+        const itemA = {
+          ...highRisk,
+          activity: 'Aaa',
+        } as unknown as InterventionRowViewModel;
+        const itemB = {
+          ...mediumRisk,
+          activity: 'Bbb',
+        } as unknown as InterventionRowViewModel;
+        const result = component['compareByColumn'](itemA, itemB, 'activity');
+        expect(result).toBe(0);
+      });
+    });
+
+    describe('sortedInterventions', () => {
+      beforeEach(() => {
+        component.studentNamesLookup = studentLookup;
+        mockFilterStrategy.apply.and.callFake(items => items);
+      });
+
+      it('should sort by risk level when sortColumn is "risk"', () => {
+        mockInterventionService.getByAssessment.and.returnValue(
+          of([
+            { ...intervention, id: 1, riskLevelName: RiskLevels.Low },
+            { ...intervention, id: 2, riskLevelName: RiskLevels.High },
+            { ...intervention, id: 3, riskLevelName: RiskLevels.Medium },
+          ])
+        );
+        component.loadInterventions(10);
+        component['onSortClick']('risk');
+        const result = component['sortedInterventions']();
+        expect(result.map(r => r.id)).toEqual([1, 3, 2]);
+      });
+
+      it('should reverse order when direction toggles to desc', () => {
+        mockInterventionService.getByAssessment.and.returnValue(
+          of([
+            { ...intervention, id: 1, riskLevelName: RiskLevels.Low },
+            { ...intervention, id: 2, riskLevelName: RiskLevels.High },
+            { ...intervention, id: 3, riskLevelName: RiskLevels.Medium },
+          ])
+        );
+        component.loadInterventions(10);
+        component['onSortClick']('risk');
+        component['onSortClick']('risk');
+
+        const result = component['sortedInterventions']();
+        expect(result.map(r => r.id)).toEqual([2, 3, 1]);
+      });
+
+      it('should not mutate the original filteredInterventions array', () => {
+        mockInterventionService.getByAssessment.and.returnValue(
+          of([
+            { ...intervention, id: 1, dateUtc: '2026-01-10' },
+            { ...intervention, id: 2, dateUtc: '2026-03-01' },
+          ])
+        );
+        component.loadInterventions(10);
+
+        const before = component['filteredInterventions']();
+        const beforeOrder = before.map(r => r.id);
+
+        component['sortedInterventions']();
+
+        const after = component['filteredInterventions']();
+        expect(after.map(r => r.id)).toEqual(beforeOrder);
+      });
+    });
   });
 });

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -100,6 +100,7 @@ export class InterventionListComponent {
     'professional',
     'student',
     'area',
+    'risk',
     'status',
     'comment',
     'actions',

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -77,6 +77,7 @@ export class InterventionListComponent {
     if (value != null) {
       this.loadInterventions(value);
       this.loadAssessment(value);
+      this.sortColumn.set(null);
     } else {
       this.interventions.set([]);
       this.assessment.set(null);
@@ -112,11 +113,46 @@ export class InterventionListComponent {
   protected readonly selectedIntervention =
     signal<InterventionRowViewModel | null>(null);
 
+  protected readonly sortColumn = signal<string | null>(null);
+  protected readonly sortDirection = signal<'asc' | 'desc'>('asc');
+
+  private readonly riskRank: Record<string, number> = {
+    high: 3,
+    medium: 2,
+    low: 1,
+  };
+
   protected readonly pagedInterventions = computed(() => {
     const start = this.pageIndex() * this.pageSize;
     const end = start + this.pageSize;
-    return this.filteredInterventions().slice(start, end);
+    return this.sortedInterventions().slice(start, end);
   });
+
+  protected readonly sortedInterventions = computed(() => {
+    const rows = this.filteredInterventions();
+    const column = this.sortColumn();
+    const direction = this.sortDirection();
+    if (!column) return rows;
+
+    const sorted = [...rows].sort((a, b) => {
+      const cmp = this.compareByColumn(a, b, column);
+      return direction === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  });
+
+  private compareByColumn(
+    a: InterventionRowViewModel,
+    b: InterventionRowViewModel,
+    column: string
+  ): number {
+    if (column === 'risk') {
+      const rankA = this.riskRank[a.riskLevelName!.toLowerCase()] ?? 0;
+      const rankB = this.riskRank[b.riskLevelName!.toLowerCase()] ?? 0;
+      return rankA - rankB;
+    }
+    return 0;
+  }
 
   protected readonly filteredInterventions = computed(() => {
     const filters = this.appliedFilters();
@@ -223,5 +259,17 @@ export class InterventionListComponent {
         this.isLoadingAssessment.set(false);
       },
     });
+  }
+
+  protected onSortClick(column: string): void {
+    console.log('hi');
+
+    if (this.sortColumn() === column) {
+      this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
+    } else {
+      this.sortColumn.set(column);
+      this.sortDirection.set('asc');
+    }
+    this.pageIndex.set(0);
   }
 }

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-list.component.ts
@@ -262,8 +262,6 @@ export class InterventionListComponent {
   }
 
   protected onSortClick(column: string): void {
-    console.log('hi');
-
     if (this.sortColumn() === column) {
       this.sortDirection.set(this.sortDirection() === 'asc' ? 'desc' : 'asc');
     } else {

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-status-badge/intervention-pill-badge.component.scss
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-status-badge/intervention-pill-badge.component.scss
@@ -43,3 +43,18 @@
   background-color: #afeae9;
   color: #117473;
 }
+
+.risk-level-low {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.risk-level-medium {
+  background-color: #ffedd5;
+  color: #9a3412;
+}
+
+.risk-level-high {
+  background-color: #fee2e2;
+  color: #991b1b;
+}

--- a/src/app/modules/assessments/components/interventions/interventions-list/intervention-status-badge/intervention-pill-badge.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions-list/intervention-status-badge/intervention-pill-badge.component.ts
@@ -4,9 +4,14 @@ import {
   InterventionType,
   InterventionMode,
   InterventionStatus,
+  RiskLevels,
 } from '@core/models/assessment.model';
 
-type PillValue = InterventionType | InterventionMode | InterventionStatus;
+type PillValue =
+  | InterventionType
+  | InterventionMode
+  | InterventionStatus
+  | RiskLevels;
 
 @Component({
   selector: 'app-intervention-pill-badge',
@@ -34,6 +39,9 @@ export class InterventionPillBadgeComponent {
     [InterventionStatus.Remitted]: 'Remitted',
     [InterventionStatus.InProgress]: 'In Progress',
     [InterventionStatus.Finalized]: 'Finalized',
+    [RiskLevels.Low]: 'Low',
+    [RiskLevels.Medium]: 'Medium',
+    [RiskLevels.High]: 'High',
   };
 
   private readonly classMap: Record<string, string> = {
@@ -44,5 +52,8 @@ export class InterventionPillBadgeComponent {
     [InterventionStatus.Remitted]: 'status-remitted',
     [InterventionStatus.InProgress]: 'status-in-progress',
     [InterventionStatus.Finalized]: 'status-finalized',
+    [RiskLevels.Low]: 'risk-level-low',
+    [RiskLevels.Medium]: 'risk-level-medium',
+    [RiskLevels.High]: 'risk-level-high',
   };
 }

--- a/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
@@ -4,6 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 import {
   AssessmentModel,
   AssessmentStatus,
+  InterventionModel,
 } from '@core/models/assessment.model';
 import { AssessmentService } from '@core/services/api/assessement.service';
 import { of } from 'rxjs';
@@ -11,6 +12,9 @@ import {
   AppliedFilter,
   FilterName,
 } from '@shared/components/list-filters/models/list-filters.interface';
+import { ToastNotificationService } from '@core/services/toast-notification.service';
+import { InterventionService } from '@core/services/api/intervention.service';
+import { MatDialog } from '@angular/material/dialog';
 
 // Helpers
 const assessments: AssessmentModel[] = [
@@ -43,32 +47,67 @@ const assessments: AssessmentModel[] = [
   },
 ];
 
+const intervention: InterventionModel = {
+  id: 15,
+  status: 'Remitted',
+} as InterventionModel;
+
 describe('InterventionsComponent', () => {
   let component: InterventionsComponent;
   let fixture: ComponentFixture<InterventionsComponent>;
 
   let assessmentServiceSpy: jasmine.SpyObj<AssessmentService>;
 
+  let dialog: jasmine.SpyObj<MatDialog>;
+  let interventionServiceSpy: jasmine.SpyObj<InterventionService>;
+  let toastServiceSpy: jasmine.SpyObj<ToastNotificationService>;
+  const dialogRef = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+
   beforeEach(async () => {
     assessmentServiceSpy = jasmine.createSpyObj('AssessmentService', [
       'getAll',
     ]);
+    interventionServiceSpy = jasmine.createSpyObj<InterventionService>(
+      'InterventionService',
+      ['deleteIntervention']
+    );
+    toastServiceSpy = jasmine.createSpyObj<ToastNotificationService>(
+      'ToastNotificationService',
+      ['showToast']
+    );
 
-    // Default AssessmentService.getAll value
+    dialogRef.afterClosed.and.returnValue(of(undefined));
+
+    dialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+
+    dialog.open.and.returnValue(dialogRef);
+
     assessmentServiceSpy.getAll.and.returnValue(of(assessments));
 
     await TestBed.configureTestingModule({
       imports: [InterventionsComponent],
-      providers: [provideHttpClient()],
+      providers: [
+        provideHttpClient(),
+        { provide: AssessmentService, useValue: assessmentServiceSpy },
+        { provide: InterventionService, useValue: interventionServiceSpy },
+        { provide: ToastNotificationService, useValue: toastServiceSpy },
+        { provide: MatDialog, useValue: dialog },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(InterventionsComponent);
     component = fixture.componentInstance;
+
+    component.interventionList = jasmine.createSpyObj(
+      'InterventionListComponent',
+      ['loadInterventions']
+    );
   });
 
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
+    expect(TestBed.inject(MatDialog)).toBe(dialog);
   });
 
   it('should build assessment, type, and status filters once assessments load', () => {
@@ -80,10 +119,12 @@ describe('InterventionsComponent', () => {
     );
     const statusFilter = filters.find(f => f.name === FilterName.Status);
     const typeFilter = filters.find(f => f.name === FilterName.Type);
+    const riskFilter = filters.find(f => f.name === FilterName.Risk);
 
     expect(assessmentFilter).toBeDefined();
     expect(statusFilter).toBeDefined();
     expect(typeFilter).toBeDefined();
+    expect(riskFilter).toBeDefined();
   });
 
   it('should build assessment options with the loaded assessments', () => {
@@ -110,7 +151,6 @@ describe('InterventionsComponent', () => {
 
   it('should set selectedAssessmentId when an Assessment filter with a value is present', () => {
     component.handleFilters([{ name: FilterName.Assessment, value: 2 }]);
-
     expect(component.selectedAssessmentId()).toBe(2);
   });
 
@@ -119,7 +159,6 @@ describe('InterventionsComponent', () => {
     component.handleFilters([
       { name: FilterName.Type, value: 'virtual-select' },
     ]);
-
     expect(component.selectedAssessmentId()).toBe(1);
   });
 
@@ -128,7 +167,28 @@ describe('InterventionsComponent', () => {
       { name: FilterName.Assessment, value: 2 },
     ];
     component.handleFilters(filters);
-
     expect(component.appliedFilters()).toEqual(filters);
+  });
+
+  it('should not open create modal when no assessment is selected', () => {
+    component.openCreateModal();
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open create modal when assessment is not found', () => {
+    component['allAssessments'].set([]);
+    component.onAssessmentChange(1);
+    component.openCreateModal();
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open edit modal when no assessment is selected', () => {
+    component.openEditModal(intervention);
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open confirmation dialog without selected assessment', () => {
+    component.confirmDelete(intervention);
+    expect(dialog.open).not.toHaveBeenCalled();
   });
 });

--- a/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.spec.ts
@@ -4,7 +4,9 @@ import { provideHttpClient } from '@angular/common/http';
 import {
   AssessmentModel,
   AssessmentStatus,
+  InterventionMode,
   InterventionModel,
+  InterventionType,
 } from '@core/models/assessment.model';
 import { AssessmentService } from '@core/services/api/assessement.service';
 import { of } from 'rxjs';
@@ -15,6 +17,8 @@ import {
 import { ToastNotificationService } from '@core/services/toast-notification.service';
 import { InterventionService } from '@core/services/api/intervention.service';
 import { MatDialog } from '@angular/material/dialog';
+import { NewInterventionModalComponent } from './new-intervention-modal/new-intervention-modal.component';
+import { EditInterventionModalComponent } from './edit-intervention-modal/edit-intervention-modal.component';
 
 // Helpers
 const assessments: AssessmentModel[] = [
@@ -62,8 +66,11 @@ describe('InterventionsComponent', () => {
   let interventionServiceSpy: jasmine.SpyObj<InterventionService>;
   let toastServiceSpy: jasmine.SpyObj<ToastNotificationService>;
   const dialogRef = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+  dialogRef.afterClosed.and.returnValue(of(undefined));
 
   beforeEach(async () => {
+    dialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+
     assessmentServiceSpy = jasmine.createSpyObj('AssessmentService', [
       'getAll',
     ]);
@@ -76,13 +83,10 @@ describe('InterventionsComponent', () => {
       ['showToast']
     );
 
-    dialogRef.afterClosed.and.returnValue(of(undefined));
-
-    dialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
-
-    dialog.open.and.returnValue(dialogRef);
+    // dialogRef.afterClosed.and.returnValue(of(undefined));
 
     assessmentServiceSpy.getAll.and.returnValue(of(assessments));
+    dialog.open.and.returnValue(dialogRef);
 
     await TestBed.configureTestingModule({
       imports: [InterventionsComponent],
@@ -93,7 +97,13 @@ describe('InterventionsComponent', () => {
         { provide: ToastNotificationService, useValue: toastServiceSpy },
         { provide: MatDialog, useValue: dialog },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(InterventionsComponent, {
+        set: {
+          providers: [{ provide: MatDialog, useValue: dialog }],
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(InterventionsComponent);
     component = fixture.componentInstance;
@@ -187,8 +197,106 @@ describe('InterventionsComponent', () => {
     expect(dialog.open).not.toHaveBeenCalled();
   });
 
-  it('should not open confirmation dialog without selected assessment', () => {
+  it('should not open edit modal without selecteed assessment', () => {
+    component.onAssessmentChange(1);
+    component['allAssessments'].set([]);
+    component.openEditModal(intervention);
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open confirmation dialog without selected intervention', () => {
     component.confirmDelete(intervention);
     expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('should not open confirmation dialog without selected assessment', () => {
+    component.onAssessmentChange(1);
+    // component['allAssessments'].set([]);
+    component.confirmDelete(intervention);
+    expect(dialog.open).toHaveBeenCalled();
+  });
+
+  it('should open create intervention dialog', () => {
+    component.onAssessmentChange(1);
+    component.handleFilters([
+      { name: FilterName.Type, value: 'virtual-select' },
+    ]);
+    component['allAssessments'].set(assessments);
+
+    component.openCreateModal();
+    expect(dialog.open).toHaveBeenCalledWith(
+      NewInterventionModalComponent,
+      jasmine.objectContaining({
+        data: jasmine.objectContaining({
+          assessmentId: 1,
+          professional: {
+            value: '',
+            label: '',
+          },
+          students: [
+            { value: '103', label: '103', riskLevel: 0 },
+            { value: '215', label: '215', riskLevel: 0 },
+          ],
+        }),
+      })
+    );
+  });
+
+  it('should open edit intervention dialog', () => {
+    const exampleIntervention: InterventionModel = {
+      id: 10,
+      assessmentId: 1,
+      kind: InterventionType.Individual,
+      mode: InterventionMode.InPlace,
+      dateUtc: '',
+      studentIds: [2],
+    };
+
+    const assessment: AssessmentModel = {
+      id: 1,
+      createdAtUtc: '',
+      createdBy: 'me',
+      service: 'Support',
+      studentIds: ['2'],
+      students: [
+        {
+          id: 2,
+          name: 'John Doe',
+          email: '',
+          avgRiskLevel: 3,
+        },
+      ],
+      assignedProfessional: 'Jane Smith',
+      interventions: [exampleIntervention],
+      status: AssessmentStatus.Finalized,
+    };
+
+    component['allAssessments'].set([assessment]);
+    component.onAssessmentChange(1);
+
+    component.openEditModal(intervention);
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      EditInterventionModalComponent,
+      jasmine.objectContaining({
+        width: '520px',
+        disableClose: true,
+        data: {
+          assessmentId: 1,
+          professional: {
+            value: 'Jane Smith',
+            label: 'Jane Smith',
+          },
+          students: [
+            {
+              value: '2',
+              label: 'John Doe',
+              riskLevel: 3,
+            },
+          ],
+          intervention: intervention,
+        },
+      })
+    );
   });
 });

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -24,6 +24,7 @@ import {
   AssessmentStatus,
   InterventionModel,
   InterventionType,
+  RiskLevels,
 } from '@core/models/assessment.model';
 import { InterventionListComponent } from './interventions-list/intervention-list.component';
 import { NewInterventionModalComponent } from './new-intervention-modal/new-intervention-modal.component';
@@ -96,11 +97,13 @@ export class InterventionsComponent implements OnInit {
     );
     const statusOptions = this._mapStatus();
     const typeOptions = this._mapTypes();
+    const riskOptions = this._mapRiskLevels();
 
     return this._buildFilters({
       assessmentOptions,
       statusOptions,
       typeOptions,
+      riskOptions,
     });
   });
 
@@ -183,6 +186,15 @@ export class InterventionsComponent implements OnInit {
         options: filtersOptions['statusOptions'],
         validators: [Validators.required],
       },
+      {
+        name: FilterName.Risk,
+        disabled: false,
+        label: 'Risk Level',
+        type: FilterType.virtualMultiSelect,
+        value: null,
+        options: filtersOptions['riskOptions'],
+        validators: [Validators.required],
+      },
     ];
   }
 
@@ -227,6 +239,23 @@ export class InterventionsComponent implements OnInit {
       {
         label: InterventionType.Individual,
         value: InterventionType.Individual,
+      },
+    ];
+  }
+
+  private _mapRiskLevels(): MultipleSelectItem[] {
+    return [
+      {
+        label: RiskLevels.Low,
+        value: RiskLevels.Low,
+      },
+      {
+        label: RiskLevels.Medium,
+        value: RiskLevels.Medium,
+      },
+      {
+        label: RiskLevels.High,
+        value: RiskLevels.High,
       },
     ];
   }

--- a/src/app/modules/assessments/components/interventions/interventions.component.ts
+++ b/src/app/modules/assessments/components/interventions/interventions.component.ts
@@ -309,7 +309,7 @@ export class InterventionsComponent implements OnInit {
     const students = assessment.studentIds.map((id, index) => ({
       value: id,
       label: assessment.students?.[index]?.name ?? String(id),
-      riskLevel: assessment.students?.[index].avgRiskLevel ?? 0,
+      riskLevel: assessment.students?.[index]?.avgRiskLevel ?? 0,
     }));
 
     this.matDialog

--- a/src/app/shared/components/list-filters/models/list-filters.interface.ts
+++ b/src/app/shared/components/list-filters/models/list-filters.interface.ts
@@ -13,6 +13,7 @@ enum FilterName {
   Assessment = 'assessment',
   Status = 'status',
   Type = 'type',
+  Risk = 'risk',
 }
 
 enum FilterType {

--- a/src/app/shared/components/list-filters/strategies/interventions.strategy.ts
+++ b/src/app/shared/components/list-filters/strategies/interventions.strategy.ts
@@ -25,7 +25,14 @@ export class InterventionFilterStrategy implements FilterStrategy<InterventionMo
         typeFilter &&
         (typeFilter.value as string[]).includes(intervention.kind);
 
-      return statusMatch && typeMatch;
+      const riskFilter = filters.find(
+        filter => filter.name === FilterName.Risk
+      );
+      const riskMatch =
+        riskFilter &&
+        (riskFilter.value as string[]).includes(intervention.riskLevelName!);
+
+      return statusMatch && typeMatch && riskMatch;
     });
   }
 }


### PR DESCRIPTION
## Description

- A filter for risk levels was added to the Interventions section.
- In the interventions table, risk levels are displayed.
- In the intervention details (when the aside panel of a selected intervention is opened), the risk level and the final risk level, if applicable, are displayed
- Tests have been added for each updated component (increasing the code coverage).
- The risk level column can be sorted in ascending or descending order by risk level.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues
