### PR TITLE
Fix/fe 993/data not loading in assessment modals

### DIFF
--- a/src/app/core/services/api/student.service.ts
+++ b/src/app/core/services/api/student.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { StudentResponse } from '../../models/student-request.model';
 import {
   StudentImport,
@@ -13,12 +13,16 @@ import { map, Observable } from 'rxjs';
 import { StudentRiskResponse } from '../../models/cohort.model';
 import { AnswerResponse } from '../../models/answer-request.model';
 import { sortArray } from '../../utils/helpers/sort';
+import { Cacheable } from '@core/utils/decorators/cacheable.decorator';
+import { CacheService } from '../cache.service';
+import { CacheableHost } from '../interfaces/cacheable-host';
 
 @Injectable({
   providedIn: 'root',
 })
-export class StudentService extends BaseApiService {
+export class StudentService extends BaseApiService implements CacheableHost {
   protected resource = 'students';
+  public readonly cacheService: CacheService = inject(CacheService);
 
   getStudentDetailsById(studentId: number, pagination: Pagination) {
     const params = new HttpParams()
@@ -27,6 +31,7 @@ export class StudentService extends BaseApiService {
     return this.get<StudentResponse>(studentId, params);
   }
 
+  @Cacheable()
   getAllStudents() {
     const params = new HttpParams().set('PageSize', 9999).set('Page', 0);
     return this.get<PagedResult<StudentModel>>('', params);

--- a/src/app/core/services/api/student.service.ts
+++ b/src/app/core/services/api/student.service.ts
@@ -31,7 +31,6 @@ export class StudentService extends BaseApiService implements CacheableHost {
     return this.get<StudentResponse>(studentId, params);
   }
 
-  @Cacheable()
   getAllStudents() {
     const params = new HttpParams().set('PageSize', 9999).set('Page', 0);
     return this.get<PagedResult<StudentModel>>('', params);
@@ -184,6 +183,7 @@ export class StudentService extends BaseApiService implements CacheableHost {
     );
   }
 
+  @Cacheable()
   getAllStudentsLight() {
     return this.get<StudentLightModel[]>('light');
   }

--- a/src/app/core/services/cache.service.spec.ts
+++ b/src/app/core/services/cache.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CacheService } from './cache.service';
+
+describe('CacheService', () => {
+  let service: CacheService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CacheService);
+
+    service.clearAllCachedData();
+    service.setCachedData<number>('test', 1);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should get the cached data', () => {
+    const cachedData = service.getCachedData<number>('test');
+
+    expect(cachedData).toBe(1);
+  });
+
+  it('should return null if there is no cached data with the provided key', () => {
+    const cachedData = service.getCachedData<string>('non-existing');
+
+    expect(cachedData).toBeNull();
+  });
+
+  it('should return null if cached data exceeds timeToLive', () => {
+    const time = Date.now() + 6 * 60 * 1000;
+    jasmine.clock().mockDate(new Date(time));
+
+    const cachedData = service.getCachedData<number>('test');
+    expect(cachedData).toBeNull();
+  });
+
+  it('should return null if cached data Map is empty', () => {
+    service.clearAllCachedData();
+
+    const cachedData = service.getCachedData<number>('test');
+
+    expect(cachedData).toBeNull();
+  });
+
+  it('should add new cached data', () => {
+    service.setCachedData<number>('second', 2);
+
+    const cachedData = service.getCachedData<number>('second');
+
+    expect(service['_cachedData'].size).toBe(2);
+    expect(cachedData).not.toBeNull();
+  });
+
+  it('should replace existing cached data', () => {
+    service.setCachedData<number>('test', 3);
+
+    const cachedData = service.getCachedData<number>('test');
+
+    expect(cachedData).toBe(3);
+  });
+
+  it('should remove cached data', () => {
+    service.invalidateCachedData('test');
+
+    const cachedData = service.getCachedData('test');
+
+    expect(cachedData).toBeNull();
+    expect(service['_cachedData'].size).toBe(0);
+  });
+
+  it('should clean all cached data', () => {
+    service.clearAllCachedData();
+
+    const cachedData = service.getCachedData('test');
+
+    expect(cachedData).toBeNull();
+    expect(service['_cachedData'].size).toBe(0);
+  });
+});

--- a/src/app/core/services/cache.service.ts
+++ b/src/app/core/services/cache.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CacheService {
+  private _cachedData = new Map<string, { data: unknown; timestamp: number }>();
+  private _timeToLive = 5 * 60 * 1000; // 5 minutes
+
+  /**
+   * Looks for a cached data using the `key` parameter. If exists and it is
+   * within the `timeToLive` returns the cached value. If not, returns `null`.
+   * @param key the key of the data to be retrieved.
+   * @returns cached data (T) or null.
+   */
+  getCachedData<T>(key: string): T | null {
+    const cachedData = this._cachedData.get(key);
+    if (cachedData && Date.now() - cachedData.timestamp < this._timeToLive) {
+      return cachedData.data as T;
+    }
+
+    return null;
+  }
+
+  /**
+   * Sets or updates cached data.
+   * @param key the key that identifies the cached value.
+   * @param data the data to be cached.
+   */
+  setCachedData<T>(key: string, data: T): void {
+    this._cachedData.set(key, { data, timestamp: Date.now() });
+  }
+
+  /**
+   * Removes the cached value assigned to the `key` parameter.
+   * @param key the key of the cached value to invalidate.
+   */
+  invalidateCachedData(key: string) {
+    this._cachedData.delete(key);
+  }
+
+  /**
+   * Removes all cached data.
+   */
+  clearAllCachedData() {
+    this._cachedData.clear();
+  }
+}

--- a/src/app/core/services/interfaces/cacheable-host.ts
+++ b/src/app/core/services/interfaces/cacheable-host.ts
@@ -1,0 +1,12 @@
+import { CacheService } from '../cache.service';
+
+/**
+ * Interface to ensure a class has a reference
+ * to CacheService.
+ *
+ * Intended to be implemented on classes that use
+ * `@Cacheable` decorator on any of their methods
+ */
+export interface CacheableHost {
+  cacheService: CacheService;
+}

--- a/src/app/core/utils/decorators/cacheable.decorator.ts
+++ b/src/app/core/utils/decorators/cacheable.decorator.ts
@@ -1,0 +1,59 @@
+import { Observable, shareReplay } from 'rxjs';
+import { CacheableHost } from '@core/services/interfaces/cacheable-host';
+
+/**
+ * Custom decorator to make a function cacheable. It stores the
+ * return value of the function as an entry of a `Map` in `CacheService`.
+ * Receives a string for setting a custom key for the cached value.
+ * If not provided, defaults to the function name.
+ *
+ * It requires the class in which is used to implement `CacheableHost` interface
+ * and have a reference to `CacheService`.
+ *
+ * @param customKey custom key to identify cached data.
+ */
+function Cacheable(customKey?: string) {
+  return function (
+    target: object,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const originalFunction = descriptor.value;
+    const cacheKey = customKey ?? propertyKey;
+
+    descriptor.value = function (this: CacheableHost, ...args: unknown[]) {
+      const cacheService = this.cacheService;
+
+      if (!cacheService) {
+        console.warn(
+          `"${propertyKey}" requires a "cacheService" property on the instance. Inject CacheService.`
+        );
+
+        return originalFunction.apply(this, args);
+      }
+      const cachedValue = cacheService.getCachedData(cacheKey);
+
+      if (cachedValue !== null) {
+        return cachedValue;
+      }
+
+      const result = originalFunction.apply(this, args);
+
+      // Use shareReplay to avoid triggering request on new subscriptions.
+      if (result instanceof Observable) {
+        const sharedObservable = result.pipe(
+          shareReplay({ bufferSize: 1, refCount: false })
+        );
+        cacheService.setCachedData(cacheKey, sharedObservable);
+
+        return sharedObservable;
+      }
+
+      // Non-observable cases.
+      cacheService.setCachedData(cacheKey, result);
+      return result;
+    };
+  };
+}
+
+export { Cacheable };

--- a/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
+++ b/src/app/modules/assessments/components/assessment-list/assessment-list.component.html
@@ -10,14 +10,24 @@
       </div>
       <h3>No Assessments yet</h3>
       <p>Get Started by creating your first assessment record</p>
-      <button mat-flat-button type="button" (click)="onCreateClick()">
+      <button
+        mat-flat-button
+        type="button"
+        [disabled]="lookupsLoading()"
+        (click)="onCreateClick()"
+      >
         Create Assessment
       </button>
     </div>
   </div>
 } @else {
   <div class="page-header">
-    <button mat-flat-button type="button" (click)="onCreateClick()">
+    <button
+      mat-flat-button
+      type="button"
+      [disabled]="lookupsLoading()"
+      (click)="onCreateClick()"
+    >
       <mat-icon>add</mat-icon>
       Create Assessment
     </button>
@@ -89,7 +99,7 @@
                     mat-icon-button
                     type="button"
                     matTooltip="Edit"
-                    [disabled]="item.status === 'Finalized'"
+                    [disabled]="lookupsLoading() || item.status === 'Finalized'"
                     (click)="onEditClick(item)"
                   >
                     <mat-icon>edit</mat-icon>


### PR DESCRIPTION
## Description

- Implement CacheService to handle caching in the application
- Create a @Cacheable decorator to make a method cacheable and store its result in CacheService
- Disabled button to create and edit assessments until data is fully loaded

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## Angular Checklist

- [ ] Are components following the single responsibility principle?
- [ ] Is the routing configuration clean and well-organized?
- [ ] Are form validations implemented and working correctly?
- [ ] Are errors gracefully handled and logged?
- [ ] Is there a consistent approach to styling (CSS, SCSS, CSS-in-JS)?
- [ ] Is user input sanitized to prevent XSS attacks?
- [ ] Are all dependencies necessary and up-to-date?

## Design Checklist
- [ ] Most important content is be visible on all screen sizes
- [ ] Space is properly used on all screen sizes
- [ ] Texts are properly displayed on all sizes (lines around 40 em, no overflows)
- [ ] Design follows accesibility guidelines
- [ ] Only relative units are used (vw, vh, ems or %)
- [ ] Only modern layout techniques are used (flexbox and grid)
- [ ] Large touch targets on mobile (minumim tap size: 48px X 48px)

## Related Issues


